### PR TITLE
[codex] improve motor bus diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ uv run lampgo calibrate
 uv run lampgo help                         # 查看常用调试命令
 uv run lampgo status                       # 查询守护进程状态
 uv run lampgo detect                       # 自动探测串口
+uv run lampgo scan-motors --ids 1-20       # 电机总线原始扫描
 uv run lampgo skills                       # 列出可用技能
 
 uv run lampgo text "做个害羞的表情"          # 自然语言路由

--- a/assets/calibration/AL02.json
+++ b/assets/calibration/AL02.json
@@ -2,46 +2,46 @@
   "base_yaw": {
     "id": 1,
     "drive_mode": 0,
-    "homing_offset": 1440,
-    "range_min": 1183,
-    "range_max": 2704,
+    "homing_offset": 1593,
+    "range_min": 1128,
+    "range_max": 2927,
     "neutral_raw": 2047,
-    "neutral_degrees": 9.1
+    "neutral_degrees": 1.7
   },
   "base_pitch": {
     "id": 2,
     "drive_mode": 0,
-    "homing_offset": -951,
-    "range_min": 1436,
-    "range_max": 2541,
-    "neutral_raw": 2048,
-    "neutral_degrees": 5.2
+    "homing_offset": 1731,
+    "range_min": 1490,
+    "range_max": 2841,
+    "neutral_raw": 2047,
+    "neutral_degrees": -10.4
   },
   "elbow_pitch": {
     "id": 3,
     "drive_mode": 0,
-    "homing_offset": -1809,
-    "range_min": 1397,
-    "range_max": 2873,
+    "homing_offset": -879,
+    "range_min": 1362,
+    "range_max": 2643,
     "neutral_raw": 2047,
-    "neutral_degrees": -7.7
+    "neutral_degrees": 3.9
   },
   "wrist_roll": {
     "id": 4,
     "drive_mode": 0,
-    "homing_offset": 1442,
-    "range_min": 1084,
-    "range_max": 3069,
+    "homing_offset": 434,
+    "range_min": 1281,
+    "range_max": 2937,
     "neutral_raw": 2047,
-    "neutral_degrees": -2.6
+    "neutral_degrees": -5.5
   },
   "wrist_pitch": {
     "id": 5,
     "drive_mode": 0,
-    "homing_offset": 992,
-    "range_min": 1201,
-    "range_max": 2413,
+    "homing_offset": 1584,
+    "range_min": 1496,
+    "range_max": 2526,
     "neutral_raw": 2047,
-    "neutral_degrees": 21.1
+    "neutral_degrees": 3.2
   }
 }

--- a/assets/calibration/AL02.json
+++ b/assets/calibration/AL02.json
@@ -2,46 +2,46 @@
   "base_yaw": {
     "id": 1,
     "drive_mode": 0,
-    "homing_offset": 1593,
-    "range_min": 1128,
-    "range_max": 2927,
+    "homing_offset": -1513,
+    "range_min": 1048,
+    "range_max": 3539,
     "neutral_raw": 2047,
-    "neutral_degrees": 1.7
+    "neutral_degrees": -21.7
   },
   "base_pitch": {
     "id": 2,
     "drive_mode": 0,
-    "homing_offset": 1731,
-    "range_min": 1490,
-    "range_max": 2841,
+    "homing_offset": 1670,
+    "range_min": 1511,
+    "range_max": 3248,
     "neutral_raw": 2047,
-    "neutral_degrees": -10.4
+    "neutral_degrees": -29.2
   },
   "elbow_pitch": {
     "id": 3,
     "drive_mode": 0,
-    "homing_offset": -879,
-    "range_min": 1362,
-    "range_max": 2643,
+    "homing_offset": -1520,
+    "range_min": 1591,
+    "range_max": 3021,
     "neutral_raw": 2047,
-    "neutral_degrees": 3.9
+    "neutral_degrees": -22.8
   },
   "wrist_roll": {
     "id": 4,
     "drive_mode": 0,
-    "homing_offset": 434,
-    "range_min": 1281,
-    "range_max": 2937,
+    "homing_offset": 437,
+    "range_min": 1146,
+    "range_max": 2967,
     "neutral_raw": 2047,
-    "neutral_degrees": -5.5
+    "neutral_degrees": -0.8
   },
   "wrist_pitch": {
     "id": 5,
     "drive_mode": 0,
-    "homing_offset": 1584,
-    "range_min": 1496,
-    "range_max": 2526,
+    "homing_offset": 1513,
+    "range_min": 1608,
+    "range_max": 2836,
     "neutral_raw": 2047,
-    "neutral_degrees": 3.2
+    "neutral_degrees": -15.4
   }
 }

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -48,7 +48,7 @@ LAMPGO_HOME=/tmp/lampgo-dev uv run lampgo run --web --no-hw
 
 - `无线接入`：ESP32 设备自动发现或指定 `lampgo-cam-XXXX.local` / IP，调整画面尺寸、JPEG 画质和 HTTP 超时。
 - `本机硬件`：电机串口 `device.motor_port`、本地摄像头 `camera.port`、本地麦克风 `voice.mic_device`。
-- `高级`：设备标识 `device.lamp_id` 和角度单位 `device.use_degrees`。
+- `高级`：设备标识 `device.lamp_id`、角度单位 `device.use_degrees` 和堵转保护 `device.max_torque_pct`。
 - `运动 / 安全`：默认动作速度、动作风格、待机随机摆动、安全速度和安全加速度。
 
 
@@ -154,6 +154,7 @@ silence_timeout_s = 60
 motor_port = "/dev/ttyUSB0"
 lamp_id = "AL02"
 use_degrees = true
+max_torque_pct = 80
 
 [camera]
 port = ""
@@ -168,6 +169,7 @@ http_timeout_s = 5.0
 
 - `motor_port`：Feetech 电机总线串口，可在 Web 硬件页保存后热重连。
 - `lamp_id`：用于匹配 `assets/calibration/` 下的校准文件。
+- `max_torque_pct`：电机 Torque_Limit 百分比，默认 `80`；降低堵转电流和转接板发热，不改变正常空载速度。
 - `camera.port`：本地 USB 摄像头索引，如 `0` 或 `1`；使用 ESP32 摄像头时通常留空。
 - `device_esp32.preferred_host`：留空表示自动发现，也可指定 `lampgo-cam-XXXX.local` 或设备 IP。
 

--- a/lampgo.toml.example
+++ b/lampgo.toml.example
@@ -13,6 +13,7 @@
 motor_port = "/dev/ttyUSB0"    # Feetech 电机总线串口 (必填，你的设备可能不同)
 lamp_id = "AL02"               # 设备标识，用于校准文件查找
 use_degrees = true             # true = 角度模式, false = 归一化 -100~100
+max_torque_pct = 80            # 电机 Torque_Limit 百分比 (10-100)，降低堵转电流和转接板发热
 
 [motion]
 tick_rate_hz = 50.0            # 控制循环频率 (Hz)

--- a/lampgo/autodetect.py
+++ b/lampgo/autodetect.py
@@ -36,7 +36,14 @@ def _list_serial_ports() -> list[str]:
 
 
 def _probe_feetech(port: str) -> bool:
-    """Try to ping motor ID 1 on a Feetech bus. Returns True if it responds."""
+    """Try to ping motor IDs 1-6 on a Feetech SCS bus. Returns True if any responds.
+
+    Note: SCS protocol is half-duplex single-wire. Raw pyserial probing may fail
+    because direction-pin control (handled by lerobot) is not available here. A
+    False return does NOT mean the hardware is absent — it may just mean the USB
+    adapter does not expose a direction pin. The caller applies a single-port
+    fallback in that case.
+    """
     try:
         import serial
     except ImportError:
@@ -49,15 +56,21 @@ def _probe_feetech(port: str) -> bool:
         return False
 
     try:
-        motor_id = 1
-        payload = bytes([motor_id, 2, 1])  # ID, length=2, instruction=PING
-        checksum = (~sum(payload)) & 0xFF
-        packet = b"\xff\xff" + payload + bytes([checksum])
-        ser.reset_input_buffer()
-        ser.write(packet)
-        response = ser.read(6)
-        if len(response) >= 6 and response[0:2] == b"\xff\xff":
-            return True
+        for motor_id in range(1, 7):
+            payload = bytes([motor_id, 2, 1])  # ID, length=2, instruction=PING
+            checksum = (~sum(payload)) & 0xFF
+            packet = b"\xff\xff" + payload + bytes([checksum])
+            ser.reset_input_buffer()
+            ser.write(packet)
+            # Read up to 12 bytes: 6 possible TX echo + 6 response
+            raw = ser.read(12)
+            # Scan for a valid status-packet header anywhere in the buffer
+            for i in range(len(raw) - 5):
+                if raw[i : i + 2] == b"\xff\xff" and raw[i + 2] == motor_id:
+                    logger.info(
+                        "autodetect.feetech_found", port=port, motor_id=motor_id
+                    )
+                    return True
         return False
     except Exception:
         return False
@@ -66,7 +79,11 @@ def _probe_feetech(port: str) -> bool:
 
 
 def _probe_esp32(port: str) -> bool:
-    """Try to communicate with ESP32 LED controller at 9600 baud."""
+    """Try to communicate with ESP32 LED controller at 9600 baud.
+
+    Sends a status query and waits for any non-empty reply. Returns False if no
+    data is received, so a bare USB-serial adapter does not false-positive.
+    """
     try:
         import serial
     except ImportError:
@@ -78,10 +95,12 @@ def _probe_esp32(port: str) -> bool:
         return False
 
     try:
-        ser.write(b"m0\n")
         import time
-        time.sleep(0.1)
-        return True
+        ser.reset_input_buffer()
+        ser.write(b"ping\n")
+        time.sleep(0.15)
+        data = ser.read(ser.in_waiting or 1)
+        return len(data) > 0
     except Exception:
         return False
     finally:
@@ -92,7 +111,9 @@ def _list_camera_names() -> dict[int, str]:
     """Best-effort: get human-readable camera names from the OS."""
     names: dict[int, str] = {}
     try:
-        import subprocess, json as _json
+        import json as _json
+        import subprocess
+
         proc = subprocess.run(
             ["system_profiler", "SPCameraDataType", "-json"],
             capture_output=True, text=True, timeout=5, check=False,
@@ -118,7 +139,8 @@ def _detect_camera() -> tuple[str | None, list[str]]:
     found: list[str] = []
     recommended: str | None = None
 
-    import os, sys
+    import os
+
     for idx in range(4):
         devnull = os.open(os.devnull, os.O_WRONLY)
         old_stderr = os.dup(2)
@@ -203,6 +225,21 @@ def detect_ports() -> dict:
                 motor_port = port
                 messages.append(f"Motor bus detected: {port}")
 
+        if motor_port is None:
+            # SCS half-duplex probing often fails without direction-pin support;
+            # fall back gracefully before probing for the LED controller so we
+            # don't accidentally assign the only port to LED instead of motors.
+            if len(ports) == 1:
+                motor_port = ports[0]
+                messages.append(
+                    f"Motor bus auto-probe inconclusive (expected for SCS half-duplex). "
+                    f"Only one port available — assuming motor bus: {motor_port}"
+                )
+            else:
+                messages.append(
+                    "Motor bus not detected. Check USB connection and power supply."
+                )
+
         remaining = [p for p in ports if p != motor_port]
         for port in remaining:
             if led_port is not None:
@@ -212,12 +249,7 @@ def detect_ports() -> dict:
                 led_port = port
                 messages.append(f"LED controller detected: {port}")
 
-        if motor_port is None:
-            messages.append("Motor bus not detected. Check connection and power.")
-            if len(ports) == 1:
-                motor_port = ports[0]
-                messages.append(f"Only one port found, assuming motor bus: {motor_port}")
-        if led_port is None and len(remaining) > 0:
+        if led_port is None and remaining:
             messages.append(f"LED controller not detected. Candidate ports: {remaining}")
 
     camera_port, cam_msgs = _detect_camera()

--- a/lampgo/cli.py
+++ b/lampgo/cli.py
@@ -119,6 +119,24 @@ def main() -> None:
     ping_p = sub.add_parser("ping", help="Ping all motor IDs and report status")
     ping_p.add_argument("--port", default=None, help="Serial port (default: config, then auto-detect)")
 
+    scan_p = sub.add_parser(
+        "scan-motors",
+        help="Raw bus scan: probe ID 1-253 with bare pyserial, bypassing lerobot model checks. "
+             "Use for hardware diagnosis when calibrate/ping find nothing.",
+    )
+    scan_p.add_argument("--port", default=None, help="Serial port (default: auto-detect)")
+    scan_p.add_argument(
+        "--baud", type=int, default=1_000_000, help="Baud rate (default: 1000000)"
+    )
+    scan_p.add_argument(
+        "--ids",
+        default="1-20",
+        help="ID range or list to probe, e.g. '1-20' or '1,3,5' (default: 1-20)",
+    )
+    scan_p.add_argument(
+        "--timeout", type=float, default=0.1, help="Per-ID read timeout in seconds (default: 0.1)"
+    )
+
     # --- openclaw integration ---
     oc_p = sub.add_parser(
         "install-openclaw",
@@ -177,6 +195,7 @@ def main() -> None:
         "record": _cmd_record,
         "clear": _cmd_clear,
         "ping": _cmd_ping,
+        "scan-motors": _cmd_scan_motors,
         "install-openclaw": _cmd_install_openclaw,
         "onboard": _cmd_onboard,
         "install": _cmd_onboard,
@@ -260,6 +279,7 @@ def _build_help_text() -> str:
         "  uv run lampgo onboard -y --skip persona_memory,openclaw_plugin\n\n"
         "1) 串口和配置\n"
         "  uv run lampgo detect\n"
+        "  uv run lampgo scan-motors --ids 1-20\n"
         "  uv run lampgo skills\n\n"
         "2) 启动与状态\n"
         "  uv run lampgo run\n"
@@ -283,7 +303,8 @@ def _build_help_text() -> str:
         "  uv run lampgo play my_action\n"
         "  录制按 Ctrl+C 结束，默认保存到 assets/recordings/user/\n\n"
         "8) 硬件检测（串口 + 摄像头）\n"
-        "  uv run lampgo detect\n\n"
+        "  uv run lampgo detect\n"
+        "  uv run lampgo scan-motors --ids 1-20\n\n"
         "提示: 推荐用 Ctrl+C 优雅退出 daemon，避免电机保持扭矩锁死。"
     )
 
@@ -418,6 +439,103 @@ def _cmd_ping(args: argparse.Namespace) -> None:
 
     bus.port_handler.closePort()
     sys.exit(0 if all_ok else 1)
+
+
+def _cmd_scan_motors(args: argparse.Namespace) -> None:
+    """Raw SCS/STS bus scan using bare pyserial — no lerobot, no model checks.
+
+    Sends a PING packet to each requested ID and reports any response. Useful
+    for hardware diagnosis when ``calibrate`` / ``ping`` report an empty bus.
+    """
+    try:
+        import serial
+    except ImportError:
+        print("Error: pyserial not installed. Run: uv add pyserial", file=sys.stderr)
+        sys.exit(1)
+
+    # --- resolve port ---
+    port = getattr(args, "port", None)
+    if not port:
+        from lampgo.core.config import load_config
+        cfg = load_config(config_path=getattr(args, "config", None))
+        port = cfg.device.motor_port
+    if not port:
+        from lampgo.autodetect import detect_ports
+        port = detect_ports().get("motor_port")
+    if not port:
+        print("Error: no motor port found. Use --port or connect hardware.", file=sys.stderr)
+        sys.exit(1)
+
+    # --- parse ID range ---
+    ids: list[int] = []
+    spec: str = getattr(args, "ids", "1-20") or "1-20"
+    for part in spec.split(","):
+        part = part.strip()
+        if "-" in part:
+            lo, hi = part.split("-", 1)
+            ids.extend(range(int(lo), int(hi) + 1))
+        else:
+            ids.append(int(part))
+
+    baud: int = getattr(args, "baud", 1_000_000)
+    timeout: float = getattr(args, "timeout", 0.05)
+
+    print(f"Scanning port {port} at {baud} baud, IDs {spec} …")
+    print(f"(TX echo is stripped automatically; each ID gets {int(timeout * 1000)} ms)\n")
+
+    try:
+        ser = serial.Serial(port, baud, timeout=timeout)
+    except Exception as e:
+        print(f"Error: cannot open {port}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    found: list[tuple[int, int]] = []  # (id, model_number)
+    PING_INSTR = 0x01
+
+    for motor_id in ids:
+        payload = bytes([motor_id, 2, PING_INSTR])
+        checksum = (~sum(payload)) & 0xFF
+        packet = b"\xff\xff" + payload + bytes([checksum])
+
+        ser.reset_input_buffer()
+        ser.write(packet)
+        ser.flush()  # wait for OS to actually transmit before switching to RX
+
+        # Read up to 12 bytes: 6 possible TX echo + 6 status response
+        raw = ser.read(12)
+
+        # Scan for a valid status-packet starting with FF FF <id>
+        model_num: int | None = None
+        for i in range(len(raw) - 5):
+            if raw[i] == 0xFF and raw[i + 1] == 0xFF and raw[i + 2] == motor_id:
+                # status packet: FF FF ID LEN ERROR CHECKSUM
+                # Some buses also include model in extended response — accept any reply
+                model_num = 0
+                break
+
+        if model_num is not None:
+            found.append((motor_id, model_num))
+            print(f"  ID {motor_id:>3}: ✓  ONLINE")
+        else:
+            print(f"  ID {motor_id:>3}:    (no response)")
+
+    ser.close()
+
+    print()
+    if found:
+        print(f"Found {len(found)} motor(s) responding: IDs {[f[0] for f in found]}")
+        sys.exit(0)
+    else:
+        print(
+            "No motors responded.\n"
+            "Possible causes:\n"
+            "  • 12 V power not reaching servos (check driver board output)\n"
+            "  • Bus data line disconnected or damaged\n"
+            "  • Motor IDs outside the scanned range (try --ids 1-253)\n"
+            "  • Wrong baud rate (Feetech default: 1000000, some units: 115200)\n"
+            "  • Half-duplex direction-pin issue on this USB adapter"
+        )
+        sys.exit(1)
 
 
 def _cmd_install_openclaw(args: argparse.Namespace) -> None:

--- a/lampgo/core/config.py
+++ b/lampgo/core/config.py
@@ -65,6 +65,20 @@ class DeviceConfig(BaseModel):
     use_degrees: bool = Field(default=True, description="Interpret positions as degrees (vs normalised -100..100)")
     disable_torque_on_disconnect: bool = True
     calibration_dir: Path = Field(default=Path("assets/calibration"))
+    max_torque_pct: int = Field(
+        default=80,
+        ge=10,
+        le=100,
+        description=(
+            "Maximum torque limit as a percentage of rated torque (10-100). "
+            "Applied to every motor at startup via the Torque_Limit register. "
+            "Only affects stall current (motor jammed against a hard stop); "
+            "free-running speed and acceleration are unaffected up to this limit. "
+            "80% cuts worst-case stall current by ~20%% while preserving full "
+            "expressiveness for normal motion. Lower to 50-60 if the bus adapter "
+            "still overheats."
+        ),
+    )
 
 
 class MotionConfig(BaseModel):
@@ -81,7 +95,10 @@ class MotionConfig(BaseModel):
     )
     default_style: str = Field(
         default="gentle",
-        description="Biomimetic style preset when MotionTarget.style is unset (gentle|confident|curious|bouncy|hesitant|linear)",
+        description=(
+            "Biomimetic style preset when MotionTarget.style is unset "
+            "(gentle|confident|curious|bouncy|hesitant|linear)"
+        ),
     )
     default_playback_mode: str = Field(
         default="cleaned",
@@ -235,7 +252,11 @@ class LLMConfig(BaseModel):
         them so the runtime value matches what the UI/preset table expects.
         """
         return cls.normalize_provider_alias(v)
-    message_type: str = Field(default="openai", description="Message envelope: 'openai' (chat.completions) or 'anthropic' (messages)")
+
+    message_type: str = Field(
+        default="openai",
+        description="Message envelope: 'openai' (chat.completions) or 'anthropic' (messages)",
+    )
     model: str = Field(default="mimo-v2.5", description="Model name for complex reasoning tasks")
     fast_model: str = Field(default="mimo-v2.5", description="Model for simple/fast intent classification")
     api_key: str = Field(default="", description="Set via LAMPGO_LLM_API_KEY env var, NOT in config file")
@@ -426,7 +447,10 @@ class VoiceConfig(BaseModel):
     )
     call_mode: Literal["stable", "interruptible", "esp32_aec"] = Field(
         default="stable",
-        description="LiveKit call mode: stable half-duplex, interruptible without ESP32 AEC, or experimental ESP32 AEC.",
+        description=(
+            "LiveKit call mode: stable half-duplex, interruptible without "
+            "ESP32 AEC, or experimental ESP32 AEC."
+        ),
     )
     livekit_allow_interruptions: bool = Field(
         default=False,
@@ -442,7 +466,12 @@ class VoiceConfig(BaseModel):
         default=True,
         description="Drop likely self-echo ASR text in interruptible modes without enabling ESP32-side AEC.",
     )
-    silence_timeout_s: int = Field(default=60, ge=10, le=300, description="Seconds of silence before ending a conversation")
+    silence_timeout_s: int = Field(
+        default=60,
+        ge=10,
+        le=300,
+        description="Seconds of silence before ending a conversation",
+    )
     volcengine_app_id: str = Field(default="", description="Volcengine app ID for ASR/TTS")
     volcengine_access_token: str = Field(default="", description="Volcengine access token for ASR/TTS")
     livekit_tts_voice: str = Field(
@@ -700,6 +729,7 @@ def _apply_env_overrides(config: LampgoConfig, *, track: bool = False) -> list[s
         "LAMPGO_MOTOR_PORT": ("device", "motor_port"),
         "LAMPGO_LED_PORT": ("device", "led_port"),
         "LAMPGO_LAMP_ID": ("device", "lamp_id"),
+        "LAMPGO_MAX_TORQUE_PCT": ("device", "max_torque_pct"),
         "LAMPGO_MOTION_DEFAULT_MAX_VELOCITY": ("motion", "default_max_velocity"),
         "LAMPGO_MOTION_DEFAULT_STYLE": ("motion", "default_style"),
         "LAMPGO_MOTION_DEFAULT_PLAYBACK_MODE": ("motion", "default_playback_mode"),

--- a/lampgo/core/hal.py
+++ b/lampgo/core/hal.py
@@ -199,15 +199,7 @@ class HardwareAbstraction:
         if self._bus is None:
             logger.info("hal.disable_torque: stub mode")
             return
-        # Prefer per-motor explicit register writes first (more observable and
-        # robust across mixed firmware), then call bus-level helper as fallback.
-        for motor in self._bus.motors:
-            self._safe_bus_write("Lock", motor, 0)
-            self._safe_bus_write("Torque_Enable", motor, 0)
-        try:
-            self._bus.disable_torque()
-        except Exception:
-            logger.warning("hal.disable_torque_bus_call_failed", exc_info=True)
+        self._release_torque_for_manual_motion(strict=False)
         logger.info("hal.torque_disabled")
 
     def enable_torque(self) -> None:
@@ -266,9 +258,10 @@ class HardwareAbstraction:
                 return
 
         logger.info("calibration.start")
-        self._bus.disable_torque()
+        self._release_torque_for_manual_motion(strict=True)
         for motor in self._bus.motors:
-            self._bus.write("Operating_Mode", motor, OperatingMode.POSITION.value)
+            self._write_register_or_raise("Operating_Mode", motor, OperatingMode.POSITION.value)
+        self._open_manual_calibration_range()
 
         input("Move arm to the middle of its range of motion and press ENTER...")
         homing_offsets = self._bus.set_half_turn_homings()
@@ -441,6 +434,110 @@ class HardwareAbstraction:
                 exc_info=True,
             )
             return False
+
+    def _write_register_or_raise(
+        self,
+        data_name: str,
+        motor: str,
+        value: Any,
+        *,
+        normalize: bool = True,
+        num_retry: int = 3,
+    ) -> None:
+        if not self._safe_bus_write(
+            data_name,
+            motor,
+            value,
+            normalize=normalize,
+            num_retry=num_retry,
+        ):
+            raise RuntimeError(f"Cannot write {data_name}={value!r} for '{motor}'.")
+
+        try:
+            actual = self._bus.read(data_name, motor, normalize=normalize)
+        except Exception:
+            logger.warning(
+                "hal.register_verify_read_failed",
+                motor=motor,
+                register=data_name,
+                expected=value,
+                exc_info=True,
+            )
+            return
+
+        if int(actual) != int(value):
+            raise RuntimeError(
+                f"Cannot verify {data_name} for '{motor}': expected {value}, got {actual}."
+            )
+
+    def _release_torque_for_manual_motion(self, *, strict: bool) -> None:
+        """Release every motor before hand-guided calibration/recording.
+
+        Feetech configuration writes are slow and occasionally flaky on a busy
+        serial bus. Use explicit per-register retries and then verify the two
+        registers that matter for safe hand movement.
+        """
+        if self._bus is None:
+            return
+
+        motors = list(self._bus.motors)
+        for motor in motors:
+            self._safe_bus_write("Torque_Enable", motor, 0, num_retry=3)
+            self._safe_bus_write("Lock", motor, 0, num_retry=3)
+
+        try:
+            self._bus.disable_torque(motors, num_retry=3)
+        except TypeError:
+            try:
+                self._bus.disable_torque()
+            except Exception:
+                logger.warning("hal.disable_torque_bus_call_failed", exc_info=True)
+        except Exception:
+            logger.warning("hal.disable_torque_bus_call_failed", exc_info=True)
+
+        bad: dict[str, dict[str, Any]] = {}
+        for motor in motors:
+            state: dict[str, Any] = {}
+            for register in ("Torque_Enable", "Lock"):
+                try:
+                    state[register] = self._bus.read(register, motor, normalize=False)
+                except Exception as exc:
+                    state[register] = f"read_failed:{type(exc).__name__}"
+            if state.get("Torque_Enable") != 0 or state.get("Lock") != 0:
+                bad[motor] = state
+
+        if bad:
+            logger.warning("hal.torque_release_verify_failed", motors=bad)
+            if strict:
+                detail = ", ".join(f"{motor}={state}" for motor, state in bad.items())
+                raise RuntimeError(
+                    "Motor torque/lock registers did not release before manual motion: "
+                    f"{detail}"
+                )
+
+    def _open_manual_calibration_range(self) -> None:
+        """Clear stale hardware limits before asking the user to move joints by hand."""
+        if self._bus is None:
+            return
+
+        opened: dict[str, dict[str, int]] = {}
+        for motor, config in self._bus.motors.items():
+            model = config.model
+            max_position = int(self._bus.model_resolution_table[model]) - 1
+            self._write_register_or_raise("Homing_Offset", motor, 0, normalize=False)
+            self._write_register_or_raise("Min_Position_Limit", motor, 0, normalize=False)
+            self._write_register_or_raise(
+                "Max_Position_Limit",
+                motor,
+                max_position,
+                normalize=False,
+            )
+            opened[motor] = {
+                "min": 0,
+                "max": max_position,
+            }
+
+        logger.info("calibration.manual_range_opened", motors=opened)
 
     def _ensure_hardware_calibration(self) -> None:
         if self._bus is None or not self._bus.calibration:

--- a/lampgo/core/hal.py
+++ b/lampgo/core/hal.py
@@ -392,6 +392,11 @@ class HardwareAbstraction:
 
         self._ensure_hardware_calibration()
 
+        # Torque_Limit (0-1000) caps stall current for every motor.
+        # Keeps the bus servo adapter board from overheating when servos are
+        # stalled against mechanical stops. 800 = 80 % of rated torque by default.
+        torque_limit_raw = max(100, min(1000, int(self._config.max_torque_pct * 10)))
+
         for motor in healthy_motors:
             # Configure each motor independently so one flaky status packet
             # does not block the whole arm from starting up.
@@ -403,6 +408,8 @@ class HardwareAbstraction:
             self._safe_bus_write("P_Coefficient", motor, 16)
             self._safe_bus_write("I_Coefficient", motor, 0)
             self._safe_bus_write("D_Coefficient", motor, 32)
+            self._safe_bus_write("Torque_Limit", motor, torque_limit_raw, normalize=False)
+        logger.info("hal.torque_limit_set", pct=self._config.max_torque_pct, raw=torque_limit_raw)
 
         self._seed_goal_positions_to_present(healthy_motors)
         for motor in healthy_motors:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ def test_build_help_text_contains_common_commands():
     assert "uv run lampgo run --web" in text
     assert "http://localhost:8420" in text
     assert "uv run lampgo detect" in text
+    assert "uv run lampgo scan-motors --ids 1-20" in text
     assert "uv run lampgo clear" in text
     assert "uv run lampgo calibrate" in text
 

--- a/tests/test_hal.py
+++ b/tests/test_hal.py
@@ -55,6 +55,7 @@ def test_hal_configure_seeds_goal_position_before_enabling_torque() -> None:
 
     assert ("Present_Position", "base_pitch", False) in bus.reads
     assert ("Goal_Position", "base_pitch", 1739, False) in bus.writes
+    assert ("Torque_Limit", "base_pitch", 800, False) in bus.writes
 
     disable_idx = bus.writes.index(("Torque_Enable", "base_pitch", 0, True))
     seed_idx = bus.writes.index(("Goal_Position", "base_pitch", 1739, False))
@@ -114,6 +115,7 @@ def test_hal_configure_expands_limits_and_holds_when_present_outside_calibration
 
     assert ("Min_Position_Limit", "base_pitch", 444, False) in bus.writes
     assert ("Goal_Position", "base_pitch", 540, False) in bus.writes
+    assert ("Torque_Limit", "base_pitch", 800, False) in bus.writes
     assert ("Torque_Enable", "base_pitch", 0, True) in bus.writes
     assert ("Torque_Enable", "base_pitch", 1, True) in bus.writes
 

--- a/tests/test_hal.py
+++ b/tests/test_hal.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 
 def test_hal_configure_seeds_goal_position_before_enabling_torque() -> None:
     from lampgo.core.config import DeviceConfig
@@ -149,3 +151,124 @@ def test_hal_calibration_home_uses_saved_neutral_degrees() -> None:
     home = hal.get_calibration_home()
 
     assert home == {"elbow_pitch": -56.8, "wrist_pitch": 41.8}
+
+
+def test_hal_manual_motion_release_retries_and_verifies_torque_registers() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    class FakeBus:
+        def __init__(self) -> None:
+            self.motors = {"elbow_pitch": object()}
+            self.writes: list[tuple[str, str, int, bool, int]] = []
+            self.disable_calls: list[tuple[list[str], int]] = []
+
+        def write(
+            self,
+            data_name: str,
+            motor: str,
+            value: int,
+            *,
+            normalize: bool = True,
+            num_retry: int = 0,
+        ) -> None:
+            self.writes.append((data_name, motor, value, normalize, num_retry))
+
+        def read(self, data_name: str, motor: str, *, normalize: bool = True) -> int:
+            assert motor == "elbow_pitch"
+            assert normalize is False
+            assert data_name in {"Torque_Enable", "Lock"}
+            return 0
+
+        def disable_torque(self, motors, num_retry: int = 0) -> None:
+            self.disable_calls.append((list(motors), num_retry))
+
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = FakeBus()
+    hal._bus = bus
+
+    hal._release_torque_for_manual_motion(strict=True)
+
+    assert ("Torque_Enable", "elbow_pitch", 0, True, 3) in bus.writes
+    assert ("Lock", "elbow_pitch", 0, True, 3) in bus.writes
+    assert bus.disable_calls == [(["elbow_pitch"], 3)]
+
+
+def test_hal_manual_motion_release_raises_when_register_stays_enabled() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    class FakeBus:
+        motors = {"elbow_pitch": object()}
+
+        def write(
+            self,
+            data_name: str,
+            motor: str,
+            value: int,
+            *,
+            normalize: bool = True,
+            num_retry: int = 0,
+        ) -> None:
+            del data_name, motor, value, normalize, num_retry
+
+        def read(self, data_name: str, motor: str, *, normalize: bool = True) -> int:
+            assert motor == "elbow_pitch"
+            assert normalize is False
+            if data_name == "Torque_Enable":
+                return 1
+            if data_name == "Lock":
+                return 0
+            raise AssertionError(data_name)
+
+        def disable_torque(self, motors, num_retry: int = 0) -> None:
+            del motors, num_retry
+
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    hal._bus = FakeBus()
+
+    with pytest.raises(RuntimeError, match="elbow_pitch"):
+        hal._release_torque_for_manual_motion(strict=True)
+
+
+def test_hal_opens_full_manual_calibration_range_before_user_moves() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    class FakeBus:
+        def __init__(self) -> None:
+            self.motors = {"elbow_pitch": SimpleNamespace(model="sts3215")}
+            self.model_resolution_table = {"sts3215": 4096}
+            self.values = {
+                ("Homing_Offset", "elbow_pitch"): -1083,
+                ("Min_Position_Limit", "elbow_pitch"): 1307,
+                ("Max_Position_Limit", "elbow_pitch"): 2920,
+            }
+            self.writes: list[tuple[str, str, int, bool, int]] = []
+
+        def write(
+            self,
+            data_name: str,
+            motor: str,
+            value: int,
+            *,
+            normalize: bool = True,
+            num_retry: int = 0,
+        ) -> None:
+            self.writes.append((data_name, motor, value, normalize, num_retry))
+            self.values[(data_name, motor)] = value
+
+        def read(self, data_name: str, motor: str, *, normalize: bool = True) -> int:
+            assert motor == "elbow_pitch"
+            assert normalize is False
+            return self.values[(data_name, motor)]
+
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = FakeBus()
+    hal._bus = bus
+
+    hal._open_manual_calibration_range()
+
+    assert ("Homing_Offset", "elbow_pitch", 0, False, 3) in bus.writes
+    assert ("Min_Position_Limit", "elbow_pitch", 0, False, 3) in bus.writes
+    assert ("Max_Position_Limit", "elbow_pitch", 4095, False, 3) in bus.writes

--- a/tools/diagnose_feetech_motor.py
+++ b/tools/diagnose_feetech_motor.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""Diagnose one Feetech motor connected directly to the driver board.
+
+This tool is intentionally outside the normal lampgo runtime because it is for
+bench diagnosis: one motor on the bus, no arm-level calibration assumptions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+READ_REGISTERS = [
+    "Model_Number",
+    "ID",
+    "Baud_Rate",
+    "Torque_Enable",
+    "Lock",
+    "Operating_Mode",
+    "Min_Position_Limit",
+    "Max_Position_Limit",
+    "Homing_Offset",
+    "Goal_Position",
+    "Present_Position",
+    "Present_Velocity",
+    "Present_Load",
+    "Present_Current",
+    "Present_Temperature",
+    "Present_Voltage",
+    "Status",
+    "Acceleration",
+    "P_Coefficient",
+    "I_Coefficient",
+    "D_Coefficient",
+    "Torque_Limit",
+    "Protection_Current",
+    "Overload_Torque",
+    "Protection_Time",
+]
+
+
+@dataclass
+class Diagnostic:
+    port: str
+    motor_id: int
+    model: str
+    ok: bool = True
+    findings: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def fail(self, text: str) -> None:
+        self.ok = False
+        self.findings.append(text)
+
+    def warn(self, text: str) -> None:
+        self.warnings.append(text)
+
+    def note(self, text: str) -> None:
+        self.findings.append(text)
+
+
+def _load_lerobot():
+    try:
+        from lerobot.motors import Motor, MotorNormMode
+        from lerobot.motors.feetech import FeetechMotorsBus, OperatingMode
+    except ImportError as exc:
+        raise RuntimeError("lerobot[feetech] is not installed. Run through `uv run ...`.") from exc
+    return Motor, MotorNormMode, FeetechMotorsBus, OperatingMode
+
+
+def _detect_port() -> str | None:
+    try:
+        from lampgo.autodetect import detect_ports
+    except Exception:
+        return None
+
+    detected = detect_ports()
+    return str(detected.get("motor_port") or "").strip() or None
+
+
+def _tx_result(bus: Any, comm: int) -> str:
+    try:
+        return str(bus.packet_handler.getTxRxResult(comm))
+    except Exception:
+        return str(comm)
+
+
+def _rx_error(bus: Any, error: int) -> str:
+    try:
+        return str(bus.packet_handler.getRxPacketError(error))
+    except Exception:
+        return str(error)
+
+
+def _connect_bus(port: str, motor_id: int, model: str):
+    Motor, MotorNormMode, FeetechMotorsBus, _OperatingMode = _load_lerobot()
+    name = f"motor_{motor_id}"
+    motors = {name: Motor(motor_id, model, MotorNormMode.DEGREES)}
+    bus = FeetechMotorsBus(port=port, motors=motors)
+    bus.connect(handshake=False)
+    return bus, name
+
+
+def _close_bus(bus: Any) -> None:
+    try:
+        bus.disable_torque(num_retry=3)
+    except Exception:
+        pass
+    try:
+        bus.port_handler.closePort()
+    except Exception:
+        pass
+
+
+def _read(bus: Any, motor_name: str, register: str) -> Any:
+    try:
+        return bus.read(register, motor_name, normalize=False)
+    except Exception as exc:
+        return {"error": f"{type(exc).__name__}: {exc}"}
+
+
+def _snapshot(bus: Any, motor_name: str, registers: Iterable[str] = READ_REGISTERS) -> dict[str, Any]:
+    return {register: _read(bus, motor_name, register) for register in registers}
+
+
+def _write_checked(
+    bus: Any,
+    motor_name: str,
+    register: str,
+    value: int,
+    *,
+    normalize: bool = False,
+    verify: bool = True,
+) -> None:
+    bus.write(register, motor_name, value, normalize=normalize, num_retry=3)
+    if not verify:
+        return
+    actual = bus.read(register, motor_name, normalize=normalize)
+    if int(actual) != int(value):
+        raise RuntimeError(f"{register} verify failed: expected {value}, got {actual}")
+
+
+def _ping(bus: Any, motor_id: int) -> dict[str, Any]:
+    try:
+        model_number, comm, error = bus.packet_handler.ping(bus.port_handler, motor_id)
+    except Exception as exc:
+        return {
+            "ok": False,
+            "comm_ok": False,
+            "status_ok": False,
+            "model_number": None,
+            "comm": None,
+            "comm_text": f"{type(exc).__name__}: {exc}",
+            "status_error": None,
+            "status_text": "",
+        }
+    ok = bool(bus._is_comm_success(comm))
+    status_ok = not bool(bus._is_error(error)) if ok else False
+    return {
+        "ok": ok and status_ok,
+        "comm_ok": ok,
+        "status_ok": status_ok,
+        "model_number": int(model_number) if ok else None,
+        "comm": int(comm),
+        "comm_text": _tx_result(bus, comm),
+        "status_error": int(error),
+        "status_text": _rx_error(bus, error) if ok and not status_ok else "",
+    }
+
+
+def _scan_ids(bus: Any, start: int, end: int) -> list[dict[str, Any]]:
+    found: list[dict[str, Any]] = []
+    for motor_id in range(start, end + 1):
+        result = _ping(bus, motor_id)
+        if result["comm_ok"]:
+            result["id"] = motor_id
+            found.append(result)
+    return found
+
+
+def _set_motor_id(bus: Any, motor_name: str, old_id: int, new_id: int, *, assume_yes: bool) -> dict[str, Any]:
+    if not assume_yes:
+        raise RuntimeError("Refusing to change motor ID without --yes. Connect only one motor before using --set-id.")
+    if not 0 <= new_id <= 253:
+        raise ValueError("--set-id must be in range 0..253")
+
+    local_scan = _scan_ids(bus, 0, 20)
+    found_ids = [int(item["id"]) for item in local_scan if item.get("comm_ok")]
+    if found_ids != [old_id]:
+        raise RuntimeError(
+            "Refusing to change ID because scan did not find exactly the requested single motor. "
+            f"found={found_ids}, requested={old_id}. Disconnect all other motors and retry."
+        )
+
+    _write_checked(bus, motor_name, "Torque_Enable", 0, normalize=True, verify=False)
+    _write_checked(bus, motor_name, "Lock", 0, normalize=True, verify=False)
+    _write_checked(bus, motor_name, "ID", new_id, normalize=False, verify=False)
+    time.sleep(0.2)
+    return {
+        "old_id": old_id,
+        "new_id": new_id,
+        "pre_scan_ids": found_ids,
+    }
+
+
+def _release_for_manual_motion(bus: Any, motor_name: str) -> None:
+    _write_checked(bus, motor_name, "Torque_Enable", 0, normalize=True, verify=False)
+    _write_checked(bus, motor_name, "Lock", 0, normalize=True, verify=False)
+    bus.disable_torque([motor_name], num_retry=3)
+    torque = bus.read("Torque_Enable", motor_name, normalize=False)
+    lock = bus.read("Lock", motor_name, normalize=False)
+    if int(torque) != 0 or int(lock) != 0:
+        raise RuntimeError(f"torque release failed: Torque_Enable={torque}, Lock={lock}")
+
+
+def _open_full_range(bus: Any, motor_name: str) -> dict[str, int]:
+    motor = bus.motors[motor_name]
+    max_position = int(bus.model_resolution_table[motor.model]) - 1
+    _write_checked(bus, motor_name, "Homing_Offset", 0, normalize=False)
+    _write_checked(bus, motor_name, "Min_Position_Limit", 0, normalize=False)
+    _write_checked(bus, motor_name, "Max_Position_Limit", max_position, normalize=False)
+    return {"min": 0, "max": max_position, "homing_offset": 0}
+
+
+def _sample(bus: Any, motor_name: str, seconds: float, interval_s: float) -> dict[str, Any]:
+    deadline = time.monotonic() + seconds
+    samples: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        item = {
+            "t": round(time.monotonic(), 4),
+            "position": _read(bus, motor_name, "Present_Position"),
+            "current": _read(bus, motor_name, "Present_Current"),
+            "load": _read(bus, motor_name, "Present_Load"),
+            "status": _read(bus, motor_name, "Status"),
+        }
+        samples.append(item)
+        time.sleep(interval_s)
+
+    positions = [int(s["position"]) for s in samples if isinstance(s.get("position"), int)]
+    currents = [int(s["current"]) for s in samples if isinstance(s.get("current"), int)]
+    loads = [int(s["load"]) for s in samples if isinstance(s.get("load"), int)]
+    return {
+        "samples": samples,
+        "count": len(samples),
+        "position_min": min(positions) if positions else None,
+        "position_max": max(positions) if positions else None,
+        "position_span": (max(positions) - min(positions)) if positions else None,
+        "current_max": max(currents) if currents else None,
+        "load_abs_max": max((abs(v) for v in loads), default=None),
+    }
+
+
+def _watch(bus: Any, motor_name: str, interval_s: float) -> dict[str, Any]:
+    print("Live watch. Move the motor by hand; press Ctrl+C to stop.", flush=True)
+    samples: list[dict[str, Any]] = []
+    pos_min: int | None = None
+    pos_max: int | None = None
+    try:
+        while True:
+            position = _read(bus, motor_name, "Present_Position")
+            current = _read(bus, motor_name, "Present_Current")
+            load = _read(bus, motor_name, "Present_Load")
+            status = _read(bus, motor_name, "Status")
+            if isinstance(position, int):
+                pos_min = position if pos_min is None else min(pos_min, position)
+                pos_max = position if pos_max is None else max(pos_max, position)
+            span = (pos_max - pos_min) if pos_min is not None and pos_max is not None else None
+            print(
+                f"pos={position} span={span} min={pos_min} max={pos_max} "
+                f"current={current} load={load} status={status}",
+                flush=True,
+            )
+            samples.append(
+                {
+                    "position": position,
+                    "current": current,
+                    "load": load,
+                    "status": status,
+                }
+            )
+            time.sleep(interval_s)
+    except KeyboardInterrupt:
+        print("Stopped live watch.", flush=True)
+
+    return {
+        "samples": samples,
+        "count": len(samples),
+        "position_min": pos_min,
+        "position_max": pos_max,
+        "position_span": (pos_max - pos_min) if pos_min is not None and pos_max is not None else None,
+    }
+
+
+def _bounded_target(start: int, delta: int, lo: int, hi: int, direction: int) -> int:
+    target = start + direction * abs(delta)
+    if lo <= target <= hi:
+        return target
+    return start - direction * abs(delta)
+
+
+def _active_test(bus: Any, motor_name: str, delta: int, move_time_ms: int) -> dict[str, Any]:
+    _load_lerobot()
+    _release_for_manual_motion(bus, motor_name)
+    _write_checked(bus, motor_name, "Operating_Mode", 0, normalize=True)
+    try:
+        _write_checked(bus, motor_name, "Acceleration", 10, normalize=True, verify=False)
+    except Exception:
+        pass
+
+    start = int(bus.read("Present_Position", motor_name, normalize=False))
+    lo = int(bus.read("Min_Position_Limit", motor_name, normalize=False))
+    hi = int(bus.read("Max_Position_Limit", motor_name, normalize=False))
+    target_a = _bounded_target(start, delta, lo, hi, 1)
+    target_b = _bounded_target(start, delta, lo, hi, -1)
+
+    _write_checked(bus, motor_name, "Goal_Position", start, normalize=False)
+    _write_checked(bus, motor_name, "Lock", 1, normalize=True, verify=False)
+    _write_checked(bus, motor_name, "Torque_Enable", 1, normalize=True, verify=True)
+    time.sleep(0.2)
+
+    segments: list[dict[str, Any]] = []
+    for target in [target_a, start, target_b, start]:
+        try:
+            _write_checked(bus, motor_name, "Goal_Time", move_time_ms, normalize=False, verify=False)
+        except Exception:
+            pass
+        _write_checked(bus, motor_name, "Goal_Position", int(target), normalize=False)
+        samples = _sample(bus, motor_name, max(move_time_ms / 1000.0 + 0.25, 0.35), 0.05)
+        segments.append({"target": int(target), **samples})
+
+    _release_for_manual_motion(bus, motor_name)
+
+    all_positions = [
+        int(s["position"])
+        for segment in segments
+        for s in segment["samples"]
+        if isinstance(s.get("position"), int)
+    ]
+    span = (max(all_positions) - min(all_positions)) if all_positions else 0
+    return {
+        "start_position": start,
+        "delta_command": abs(delta),
+        "targets": [int(target_a), start, int(target_b), start],
+        "observed_span": span,
+        "segments": segments,
+    }
+
+
+def _classify(report: Diagnostic, manual_seconds: float, active: bool) -> None:
+    ping = report.data.get("ping") or {}
+    before = report.data.get("snapshot_before") or {}
+    manual = report.data.get("manual_sample") or {}
+    active_result = report.data.get("active_test") or {}
+
+    if not ping.get("comm_ok"):
+        report.fail("No response from the requested motor ID. Check ID, power, cable, and driver board first.")
+        return
+    if not ping.get("status_ok"):
+        report.fail(f"Motor responded but reported status error: {ping.get('status_text') or ping.get('status_error')}")
+    else:
+        report.note("Ping and status packet are OK.")
+
+    status = before.get("Status")
+    if isinstance(status, int) and status != 0:
+        report.fail(f"Status register is non-zero before testing: {status}.")
+
+    voltage = before.get("Present_Voltage")
+    if isinstance(voltage, int) and voltage < 95:
+        report.warn(f"Voltage looks low ({voltage / 10:.1f} V if Feetech units are 0.1 V).")
+
+    if manual_seconds > 0:
+        span = manual.get("position_span")
+        if isinstance(span, int):
+            if span < 20:
+                report.warn(
+                    "Manual sample saw almost no encoder movement. "
+                    "If you moved the shaft, encoder/gear damage is likely."
+                )
+            elif span < 300:
+                report.warn(
+                    "Manual sample saw a small range only. "
+                    "If you swept the full free travel, suspect mechanical blockage."
+                )
+            else:
+                report.note(f"Manual encoder span looks alive: {span} raw counts.")
+
+    if active:
+        observed = active_result.get("observed_span")
+        command = active_result.get("delta_command")
+        if isinstance(observed, int) and isinstance(command, int):
+            if observed >= max(20, int(command * 0.7)):
+                report.note("Small active movement succeeded. Electronics and position loop are probably alive.")
+            else:
+                report.fail(
+                    "Small active movement did not produce enough encoder change. "
+                    "Suspect motor output stage, internal gear train, wiring, or a hard mechanical jam."
+                )
+
+    if report.ok:
+        report.note("No clear electrical failure found in this diagnostic run.")
+
+
+def _print_human(report: Diagnostic) -> None:
+    print(f"Single Feetech motor diagnostic: port={report.port}, id={report.motor_id}, model={report.model}")
+    print(f"Result: {'PASS' if report.ok else 'FAIL / SUSPECT'}")
+    print()
+    for finding in report.findings:
+        print(f"- {finding}")
+    for warning in report.warnings:
+        print(f"- Warning: {warning}")
+
+    ping = report.data.get("ping")
+    if ping:
+        print()
+        print(
+            "Ping: "
+            f"comm_ok={ping.get('comm_ok')} status_ok={ping.get('status_ok')} "
+            f"model_number={ping.get('model_number')} status={ping.get('status_error')}"
+        )
+
+    before = report.data.get("snapshot_before") or {}
+    after = report.data.get("snapshot_after") or {}
+    for label, snap in [("before", before), ("after", after)]:
+        if not snap:
+            continue
+        print()
+        print(f"Snapshot {label}:")
+        for key in READ_REGISTERS:
+            if key in snap:
+                print(f"  {key:>22}: {snap[key]}")
+
+    manual = report.data.get("manual_sample")
+    if manual:
+        print()
+        print(
+            "Manual sample: "
+            f"count={manual.get('count')} span={manual.get('position_span')} "
+            f"min={manual.get('position_min')} max={manual.get('position_max')} "
+            f"current_max={manual.get('current_max')} load_abs_max={manual.get('load_abs_max')}"
+        )
+
+    watch = report.data.get("watch")
+    if watch:
+        print()
+        print(
+            "Live watch summary: "
+            f"count={watch.get('count')} span={watch.get('position_span')} "
+            f"min={watch.get('position_min')} max={watch.get('position_max')}"
+        )
+
+    active = report.data.get("active_test")
+    if active:
+        print()
+        print(
+            "Active test: "
+            f"command_delta={active.get('delta_command')} observed_span={active.get('observed_span')} "
+            f"targets={active.get('targets')}"
+        )
+
+    scan = report.data.get("scan")
+    if scan is not None:
+        print()
+        print(f"Scan found IDs: {[item.get('id') for item in scan]}")
+
+
+def run(args: argparse.Namespace) -> Diagnostic:
+    port = args.port or _detect_port()
+    if not port:
+        raise SystemExit("No motor port found. Pass --port /dev/tty.usbmodemXXXX.")
+
+    report = Diagnostic(port=port, motor_id=args.id, model=args.model)
+    bus, motor_name = _connect_bus(port, args.id, args.model)
+    try:
+        if args.scan:
+            report.data["scan"] = _scan_ids(bus, args.scan_start, args.scan_end)
+            if args.scan_only:
+                report.note("Scan-only mode completed.")
+                return report
+
+        report.data["ping"] = _ping(bus, args.id)
+        report.data["snapshot_before"] = _snapshot(bus, motor_name)
+
+        if args.set_id is not None:
+            report.data["set_id"] = _set_motor_id(
+                bus,
+                motor_name,
+                args.id,
+                args.set_id,
+                assume_yes=args.yes,
+            )
+            report.note(
+                f"Changed motor ID from {args.id} to {args.set_id}. "
+                f"Re-run diagnostics with --id {args.set_id}."
+            )
+            return report
+
+        if args.release or args.open_range or args.manual_seconds > 0 or args.watch or args.active_test:
+            _release_for_manual_motion(bus, motor_name)
+
+        if args.open_range:
+            report.data["opened_range"] = _open_full_range(bus, motor_name)
+
+        if args.manual_seconds > 0:
+            print(
+                f"Manual sampling for {args.manual_seconds:.1f}s. Move the motor shaft through its free travel now.",
+                flush=True,
+            )
+            report.data["manual_sample"] = _sample(
+                bus,
+                motor_name,
+                args.manual_seconds,
+                args.sample_interval,
+            )
+
+        if args.watch:
+            report.data["watch"] = _watch(bus, motor_name, args.sample_interval)
+
+        if args.active_test:
+            report.data["active_test"] = _active_test(
+                bus,
+                motor_name,
+                args.active_delta,
+                args.active_time_ms,
+            )
+
+        report.data["snapshot_after"] = _snapshot(bus, motor_name)
+    finally:
+        _close_bus(bus)
+
+    _classify(report, args.manual_seconds, args.active_test)
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", default="", help="Motor bus serial port. Defaults to lampgo autodetect.")
+    parser.add_argument("--id", type=int, default=3, help="Expected motor ID.")
+    parser.add_argument("--model", default="sts3215", help="Expected Feetech model key.")
+    parser.add_argument("--scan", action="store_true", help="Scan IDs before diagnosis.")
+    parser.add_argument("--scan-only", action="store_true", help="Only scan IDs; do not read the requested motor.")
+    parser.add_argument("--scan-start", type=int, default=0)
+    parser.add_argument("--scan-end", type=int, default=10)
+    parser.add_argument("--set-id", type=int, default=None, help="Change the connected single motor's ID.")
+    parser.add_argument("--yes", action="store_true", help="Confirm dangerous operations such as --set-id.")
+    parser.add_argument("--release", action="store_true", help="Release torque and verify Torque_Enable/Lock.")
+    parser.add_argument("--open-range", action="store_true", help="Temporarily set Homing=0 and Min/Max to full range.")
+    parser.add_argument(
+        "--manual-seconds",
+        type=float,
+        default=0.0,
+        help="Sample encoder while you move the shaft by hand.",
+    )
+    parser.add_argument("--sample-interval", type=float, default=0.05)
+    parser.add_argument("--watch", action="store_true", help="Print live encoder/current readings until Ctrl+C.")
+    parser.add_argument("--active-test", action="store_true", help="Run a tiny powered position-loop test.")
+    parser.add_argument("--active-delta", type=int, default=64, help="Raw-count delta for active test.")
+    parser.add_argument("--active-time-ms", type=int, default=700)
+    parser.add_argument("--json", action="store_true", help="Print full JSON report.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    report = run(args)
+    if args.json:
+        print(json.dumps(report.__dict__, ensure_ascii=False, indent=2, default=str))
+    else:
+        _print_human(report)
+    raise SystemExit(0 if report.ok else 2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Harden manual motor release by retrying and verifying Torque_Enable and Lock before hand-guided calibration.
- Open full raw travel limits before manual calibration so stale limits do not block movement.
- Add a single-motor Feetech bench diagnostic tool for ping, scan, manual encoder sampling, release, open-range, ID change, and small active movement tests.
- Refresh AL02 calibration with the latest local calibration values.

## Hardware / device notes
- Calibration file touched: assets/calibration/AL02.json.
- Diagnostic tool added: tools/diagnose_feetech_motor.py.
- No live hardware re-test was run during this publish pass; changes are covered by unit tests and prior local diagnostic work.
- no-hw behavior is covered indirectly by the existing test suite.

## Validation
- uv run pytest tests/test_hal.py -> 6 passed.
- uv run pytest -> 194 passed, 1 existing Starlette deprecation warning.
- uv run ruff check lampgo/core/hal.py tests/test_hal.py tools/diagnose_feetech_motor.py -> passed.
- uv run python -m py_compile tools/diagnose_feetech_motor.py -> passed.
- uv run ruff check lampgo tests -> fails on existing repository lint issues outside this change area (import ordering, line length, unused imports, etc.).

## Notes
- This updates the existing motor diagnostics PR with the follow-up manual calibration safety and bench diagnostic work.