### PR TITLE
Add interactive motor ID setup command

### DIFF
--- a/lampgo/cli.py
+++ b/lampgo/cli.py
@@ -119,6 +119,10 @@ def main() -> None:
     ping_p = sub.add_parser("ping", help="Ping all motor IDs and report status")
     ping_p.add_argument("--port", default=None, help="Serial port (default: config, then auto-detect)")
 
+    # --- setup-motors ---
+    setup_p = sub.add_parser("setup-motors", help="Interactively assign Feetech motor IDs")
+    setup_p.add_argument("--port", default=None, help="Serial port (default: config, then auto-detect)")
+
     # --- openclaw integration ---
     oc_p = sub.add_parser(
         "install-openclaw",
@@ -177,6 +181,7 @@ def main() -> None:
         "record": _cmd_record,
         "clear": _cmd_clear,
         "ping": _cmd_ping,
+        "setup-motors": _cmd_setup_motors,
         "install-openclaw": _cmd_install_openclaw,
         "onboard": _cmd_onboard,
         "install": _cmd_onboard,
@@ -274,6 +279,7 @@ def _build_help_text() -> str:
         "  uv run lampgo move base_yaw=0 --velocity 20\n"
         "  uv run lampgo invoke return_safe\n\n"
         "5) 校准\n"
+        "  uv run lampgo setup-motors --port /dev/tty.usbmodemXXXX  # 逐颗设置舵机 ID\n"
         "  uv run lampgo calibrate --port /dev/tty.usbmodemXXXX --id AL02\n\n"
         "6) 表情与文本路由\n"
         "  uv run lampgo invoke set_expression expression=heart\n"
@@ -418,6 +424,62 @@ def _cmd_ping(args: argparse.Namespace) -> None:
 
     bus.port_handler.closePort()
     sys.exit(0 if all_ok else 1)
+
+
+def _cmd_setup_motors(args: argparse.Namespace) -> None:
+    """Interactively assign each configured Feetech motor ID and baud rate."""
+    from lampgo.core.config import load_config
+
+    config = load_config(config_path=getattr(args, "config", None))
+    port = _resolve_calibration_port(args, config)
+    if not port:
+        print(
+            "Error: serial port required. Use --port, set LAMPGO_MOTOR_PORT, or connect hardware for auto-detect.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        from lerobot.motors import Motor, MotorNormMode
+        from lerobot.motors.feetech import FeetechMotorsBus
+    except ImportError:
+        print("Error: lerobot[feetech] not installed.", file=sys.stderr)
+        sys.exit(1)
+
+    motors = {
+        name: Motor(mc.id, mc.model, MotorNormMode.DEGREES)
+        for name, mc in config.device.motors.items()
+    }
+    print(
+        "This will assign Feetech motor IDs one at a time.\n"
+        "Connect exactly one motor when prompted; motors with duplicate IDs must not share the bus.\n"
+        f"Port: {port}\n"
+    )
+
+    ordered_names = list(motors)
+    for index, name in enumerate(ordered_names, start=1):
+        motor = motors[name]
+        input(f"[{index}/{len(ordered_names)}] Connect only '{name}' (target ID {motor.id}) and press ENTER.")
+
+        bus = FeetechMotorsBus(port=port, motors={name: motor})
+        try:
+            bus.connect(handshake=False)
+            bus.setup_motor(name)
+            print(f"  ✓ '{name}' ID set to {motor.id}")
+        except Exception as e:
+            print(f"Setup failed for '{name}' on {port}: {type(e).__name__}: {e}", file=sys.stderr)
+            print(
+                "Hint: connect exactly one STS3215 motor, check power/cable, then rerun this command.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        finally:
+            try:
+                bus.port_handler.closePort()
+            except Exception:
+                pass
+
+    print("All configured motor IDs have been assigned. Run `uv run lampgo ping` to verify the full chain.")
 
 
 def _cmd_install_openclaw(args: argparse.Namespace) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ def test_build_help_text_contains_common_commands():
     assert "http://localhost:8420" in text
     assert "uv run lampgo detect" in text
     assert "uv run lampgo clear" in text
+    assert "uv run lampgo setup-motors" in text
     assert "uv run lampgo calibrate" in text
 
 
@@ -265,3 +266,56 @@ def test_cmd_ping_reports_status_error(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "STATUS ERROR" in out
     assert "OverEle error" in out
+
+
+def test_cmd_setup_motors_assigns_each_configured_motor(monkeypatch, capsys):
+    args = argparse.Namespace(port="/dev/tty.test", config=None)
+    prompts: list[str] = []
+    setup_calls: list[tuple[str, int]] = []
+
+    class FakeBus:
+        def __init__(self, port, motors):
+            self.port = port
+            self.motors = motors
+            self.port_handler = SimpleNamespace(closePort=lambda: None)
+
+        def connect(self, handshake=False):
+            return None
+
+        def setup_motor(self, motor_name):
+            setup_calls.append((motor_name, self.motors[motor_name].id))
+
+    fake_motors_mod = SimpleNamespace(
+        Motor=lambda id_, model, norm_mode: SimpleNamespace(id=id_, model=model),
+        MotorNormMode=SimpleNamespace(DEGREES="degrees"),
+    )
+    fake_feetech_mod = SimpleNamespace(FeetechMotorsBus=FakeBus)
+    monkeypatch.setitem(sys.modules, "lerobot.motors", fake_motors_mod)
+    monkeypatch.setitem(sys.modules, "lerobot.motors.feetech", fake_feetech_mod)
+    monkeypatch.setattr("builtins.input", lambda prompt="": prompts.append(prompt) or "")
+
+    import lampgo.core.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda config_path=None: SimpleNamespace(
+            device=SimpleNamespace(
+                motor_port="/dev/tty.config",
+                motors={
+                    "base_yaw": SimpleNamespace(id=1, model="sts3215"),
+                    "base_pitch": SimpleNamespace(id=2, model="sts3215"),
+                },
+            )
+        ),
+    )
+
+    cli._cmd_setup_motors(args)
+
+    assert setup_calls == [("base_yaw", 1), ("base_pitch", 2)]
+    assert len(prompts) == 2
+    assert "target ID 1" in prompts[0]
+    assert "target ID 2" in prompts[1]
+    out = capsys.readouterr().out
+    assert "Connect exactly one motor" in out
+    assert "All configured motor IDs" in out


### PR DESCRIPTION
﻿## Summary
- Add `lampgo setup-motors` to assign Feetech/ST3215 motor IDs one at a time.
- Add CLI help text for the new setup flow.
- Add tests covering the help entry and interactive motor setup command.

## Testing
- `python -m pytest tests/test_cli.py::test_build_help_text_contains_common_commands tests/test_cli.py::test_cmd_setup_motors_assigns_each_configured_motor -q`
- `python -m ruff check lampgo\cli.py tests\test_cli.py`

## Notes
- Full `uv run pytest` on Windows currently reports an existing IPC failure in `tests/test_cli.py::test_no_hw_server_uses_virtual_motion_for_skills` because `asyncio.start_unix_server` is unavailable on Windows.
- Full `uv run ruff check lampgo tests` still reports pre-existing repository lint issues noted in the contributor guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增命令行交互式子命令 `setup-motors`（支持 `--port`），可按已配置电机顺序逐个引导连接并完成电机 ID 设置。
  * 帮助信息更新，新增 `lampgo setup-motors --port ...` 用法示例。
* **Bug 修复**
  * 当串口解析/连接或电机导入失败时，提供更明确的错误提示并终止流程。
  * 设置完成后给出连通性/校验建议，引导后续执行（如 `lampgo ping`）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->