### PR TITLE
[codex] add local vision cat teaser debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ uv run lampgo skills                       # 列出可用技能
 
 uv run lampgo text "做个害羞的表情"          # 自然语言路由
 uv run lampgo invoke dance                 # 调用内置技能
-uv run lampgo invoke cat_teaser marker_color=magenta duration=60  # 逗猫棒互动
+uv run lampgo invoke cat_teaser marker_color=red duration=60      # 逗猫棒互动
 uv run lampgo move base_yaw=30             # 直接移动指定关节
 uv run lampgo play shy                     # 回放录制动作
 uv run lampgo record my_action --fps 30    # 手动录制新动作

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ uv run lampgo skills                       # 列出可用技能
 
 uv run lampgo text "做个害羞的表情"          # 自然语言路由
 uv run lampgo invoke dance                 # 调用内置技能
+uv run lampgo invoke cat_teaser marker_color=magenta duration=60  # 逗猫棒互动
 uv run lampgo move base_yaw=30             # 直接移动指定关节
 uv run lampgo play shy                     # 回放录制动作
 uv run lampgo record my_action --fps 30    # 手动录制新动作

--- a/docs/guides/motion-and-expression.md
+++ b/docs/guides/motion-and-expression.md
@@ -37,7 +37,7 @@ uv run lampgo move elbow_pitch=-40 wrist_pitch=20 --velocity 90
 
 ## 逗猫棒互动
 
-`cat_teaser` 是本地视觉实时技能。请在逗猫棒末端贴一个明显的红色标记，并让灯头摄像头能看到标记。
+`cat_teaser` 是本地视觉实时技能。请在逗猫棒末端贴一个与 `marker_color` 一致的明显标记（默认 red），并让灯头摄像头能看到标记。
 
 ```bash
 uv run lampgo invoke cat_teaser marker_color=red duration=60
@@ -46,11 +46,11 @@ uv run lampgo invoke cat_teaser marker_color=magenta duration=60
 
 它会用 OpenCV 在本机识别标记位置，并根据标记附近的运动能量估计 `searching`、`teasing`、`engaged`、`pounce`、`caught`、`rest`、`unsafe_close` 等状态。运行时默认弹出 `LampGo Cat Teaser Vision` 调试窗口，窗口里会显示摄像头画面、标记圈、运动质心、状态、motion/engagement 分数；按 `q` 或 `esc` 可停止本次逗猫。终端会打印类似 `[cat_teaser] 12.4秒有触碰动作 ...` 的事件日志，便于判断是摄像头没看到标记、颜色参数不匹配，还是状态机阈值需要调。
 
-默认还会把本次摄像头画面保存为 MP4：`recording_dir=""` 时写到 `~/.lampgo/cat_teaser_recordings/<时间>-<颜色>/cat_teaser.mp4`，同目录的 `frames.jsonl` 会记录每帧状态和触碰事件，方便回看排查。
+默认还会把硬件摄像头画面保存为 MP4：`recording_dir=""` 时写到 `~/.lampgo/cat_teaser_recordings/<时间>-<颜色>/cat_teaser.mp4`，同目录的 `frames.jsonl` 会记录每帧状态和触碰事件，方便回看排查。`--no-hw` 模式下不会保存电脑摄像头视频。
 
 检测到扑击、遮挡或距离过近时会短暂停顿或撤离；摄像头不可用或未安装 perception extra 时会返回明确错误。如果只想后台运行，可以加 `debug_view=false`，如果只想关闭中文事件日志，可以加 `log_events=false`。
 
-在 `--no-hw` 无硬件模式下，如果没有配置 LampGo/ESP32 灯头摄像头，`cat_teaser` 会尝试用电脑本机摄像头 `local://0` 作为 fallback，只运行视觉算法和虚拟动作；Web 弹窗会明确标注当前没有 LampGo 本体硬件。
+在 `--no-hw` 无硬件模式下，如果没有配置 LampGo/ESP32 灯头摄像头，`cat_teaser` 会尝试用电脑本机摄像头 `local://0` 作为 fallback，只运行视觉算法和虚拟动作；Web 弹窗会明确标注当前没有 LampGo 本体硬件，并禁用本次视频保存。
 
 ## LED 表情
 

--- a/docs/guides/motion-and-expression.md
+++ b/docs/guides/motion-and-expression.md
@@ -41,9 +41,12 @@ uv run lampgo move elbow_pitch=-40 wrist_pitch=20 --velocity 90
 
 ```bash
 uv run lampgo invoke cat_teaser marker_color=magenta duration=60
+uv run lampgo invoke cat_teaser marker_color=red duration=60
 ```
 
-它会用 OpenCV 在本机识别标记位置，并根据标记附近的运动能量估计 `searching`、`teasing`、`engaged`、`pounce`、`caught`、`rest`、`unsafe_close` 等状态。检测到扑击、遮挡或距离过近时会短暂停顿或撤离；摄像头不可用或未安装 perception extra 时会返回明确错误。
+它会用 OpenCV 在本机识别标记位置，并根据标记附近的运动能量估计 `searching`、`teasing`、`engaged`、`pounce`、`caught`、`rest`、`unsafe_close` 等状态。运行时默认弹出 `LampGo Cat Teaser Vision` 调试窗口，窗口里会显示摄像头画面、标记圈、运动质心、状态、motion/engagement 分数；按 `q` 或 `esc` 可停止本次逗猫。终端会打印类似 `[cat_teaser] 12.4秒有触碰动作 ...` 的事件日志，便于判断是摄像头没看到标记、颜色参数不匹配，还是状态机阈值需要调。
+
+检测到扑击、遮挡或距离过近时会短暂停顿或撤离；摄像头不可用或未安装 perception extra 时会返回明确错误。如果只想后台运行，可以加 `debug_view=false`，如果只想关闭中文事件日志，可以加 `log_events=false`。
 
 ## LED 表情
 

--- a/docs/guides/motion-and-expression.md
+++ b/docs/guides/motion-and-expression.md
@@ -13,7 +13,7 @@ uv run lampgo invoke headshake
 uv run lampgo invoke look_at yaw=20 pitch=-10
 uv run lampgo invoke idle_sway
 uv run lampgo invoke dance
-uv run lampgo invoke cat_teaser marker_color=magenta duration=60
+uv run lampgo invoke cat_teaser marker_color=red duration=60
 ```
 
 自然语言入口：
@@ -37,16 +37,20 @@ uv run lampgo move elbow_pitch=-40 wrist_pitch=20 --velocity 90
 
 ## 逗猫棒互动
 
-`cat_teaser` 是本地视觉实时技能。请在逗猫棒末端贴一个明显的彩色标记，默认推荐亮品红色，并让灯头摄像头能看到标记。
+`cat_teaser` 是本地视觉实时技能。请在逗猫棒末端贴一个明显的红色标记，并让灯头摄像头能看到标记。
 
 ```bash
-uv run lampgo invoke cat_teaser marker_color=magenta duration=60
 uv run lampgo invoke cat_teaser marker_color=red duration=60
+uv run lampgo invoke cat_teaser marker_color=magenta duration=60
 ```
 
 它会用 OpenCV 在本机识别标记位置，并根据标记附近的运动能量估计 `searching`、`teasing`、`engaged`、`pounce`、`caught`、`rest`、`unsafe_close` 等状态。运行时默认弹出 `LampGo Cat Teaser Vision` 调试窗口，窗口里会显示摄像头画面、标记圈、运动质心、状态、motion/engagement 分数；按 `q` 或 `esc` 可停止本次逗猫。终端会打印类似 `[cat_teaser] 12.4秒有触碰动作 ...` 的事件日志，便于判断是摄像头没看到标记、颜色参数不匹配，还是状态机阈值需要调。
 
+默认还会把本次摄像头画面保存为 MP4：`recording_dir=""` 时写到 `~/.lampgo/cat_teaser_recordings/<时间>-<颜色>/cat_teaser.mp4`，同目录的 `frames.jsonl` 会记录每帧状态和触碰事件，方便回看排查。
+
 检测到扑击、遮挡或距离过近时会短暂停顿或撤离；摄像头不可用或未安装 perception extra 时会返回明确错误。如果只想后台运行，可以加 `debug_view=false`，如果只想关闭中文事件日志，可以加 `log_events=false`。
+
+在 `--no-hw` 无硬件模式下，如果没有配置 LampGo/ESP32 灯头摄像头，`cat_teaser` 会尝试用电脑本机摄像头 `local://0` 作为 fallback，只运行视觉算法和虚拟动作；Web 弹窗会明确标注当前没有 LampGo 本体硬件。
 
 ## LED 表情
 

--- a/docs/guides/motion-and-expression.md
+++ b/docs/guides/motion-and-expression.md
@@ -13,6 +13,7 @@ uv run lampgo invoke headshake
 uv run lampgo invoke look_at yaw=20 pitch=-10
 uv run lampgo invoke idle_sway
 uv run lampgo invoke dance
+uv run lampgo invoke cat_teaser marker_color=magenta duration=60
 ```
 
 自然语言入口：
@@ -33,6 +34,16 @@ uv run lampgo move elbow_pitch=-40 wrist_pitch=20 --velocity 90
 ```
 
 关节命令仍会经过 `MotionRuntime` 和 `SafetyKernel`，包括关节限位、速度上限、加速度上限和急停状态检查。
+
+## 逗猫棒互动
+
+`cat_teaser` 是本地视觉实时技能。请在逗猫棒末端贴一个明显的彩色标记，默认推荐亮品红色，并让灯头摄像头能看到标记。
+
+```bash
+uv run lampgo invoke cat_teaser marker_color=magenta duration=60
+```
+
+它会用 OpenCV 在本机识别标记位置，并根据标记附近的运动能量估计 `searching`、`teasing`、`engaged`、`pounce`、`caught`、`rest`、`unsafe_close` 等状态。检测到扑击、遮挡或距离过近时会短暂停顿或撤离；摄像头不可用或未安装 perception extra 时会返回明确错误。
 
 ## LED 表情
 

--- a/lampgo/perception/cat_teaser.py
+++ b/lampgo/perception/cat_teaser.py
@@ -1,0 +1,400 @@
+"""Local visual state estimation for the cat teaser skill.
+
+The v1 algorithm intentionally stays fast and local: it tracks a bright marker
+on the teaser wand, then estimates cat engagement from motion around that
+marker. It does not try to classify cats with a neural model.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import structlog
+
+from lampgo.core.config import CameraConfig, DeviceEsp32Config
+
+if TYPE_CHECKING:
+    from lampgo.device import Esp32DeviceManager
+
+logger = structlog.get_logger(__name__)
+
+CatPlayState = Literal[
+    "searching",
+    "teasing",
+    "engaged",
+    "pounce",
+    "caught",
+    "rest",
+    "unsafe_close",
+]
+
+_SUPPORTED_MARKER_COLORS = {"magenta", "green", "blue", "red", "yellow"}
+
+
+class CatTeaserError(RuntimeError):
+    """Base class for local cat teaser perception failures."""
+
+
+class CatTeaserDependencyError(CatTeaserError):
+    """Raised when optional perception dependencies are not installed."""
+
+
+class CatTeaserCameraError(CatTeaserError):
+    """Raised when no camera source is configured or readable."""
+
+
+@dataclass(frozen=True)
+class MarkerDetection:
+    """Detected colored marker on the teaser wand."""
+
+    x: float
+    y: float
+    radius: float
+    area: float
+    confidence: float
+    frame_width: int
+    frame_height: int
+
+    @property
+    def normalized_x(self) -> float:
+        return self.x / max(float(self.frame_width), 1.0)
+
+    @property
+    def normalized_y(self) -> float:
+        return self.y / max(float(self.frame_height), 1.0)
+
+
+@dataclass(frozen=True)
+class CatPlayObservation:
+    """One perception tick consumed by the cat teaser motion policy."""
+
+    state: CatPlayState
+    marker: MarkerDetection | None
+    motion_energy: float
+    engagement_score: float
+    motion_centroid: tuple[float, float] | None
+    timestamp: float
+
+
+def _import_cv2():
+    try:
+        import cv2
+    except ImportError as exc:
+        raise CatTeaserDependencyError(
+            "OpenCV is required for cat_teaser. Install the perception extra, "
+            "for example: uv sync --extra perception"
+        ) from exc
+    return cv2
+
+
+class CatTeaserFrameSource:
+    """Read BGR frames from the lamp-head camera.
+
+    ESP32 camera is preferred when enabled and online. If a local camera port is
+    configured, it is used as a fallback or as the primary source.
+    """
+
+    WIDTH = 640
+    HEIGHT = 480
+    ESP32_HTTP_TIMEOUT_S = 1.2
+
+    def __init__(
+        self,
+        camera_config: CameraConfig | None,
+        *,
+        device_esp32_config: DeviceEsp32Config | None = None,
+        esp32_manager: Esp32DeviceManager | None = None,
+    ) -> None:
+        self._config = camera_config or CameraConfig()
+        self._device_cfg = device_esp32_config
+        self._esp32 = esp32_manager
+        self._cv2 = None
+        self._cap = None
+
+    @property
+    def enabled(self) -> bool:
+        if self._config.port.strip():
+            return True
+        return bool(self._device_cfg and self._device_cfg.enabled)
+
+    @property
+    def device_label(self) -> str:
+        if self._device_cfg is not None and self._device_cfg.enabled and self._esp32 is not None:
+            host = self._esp32.get_active_host()
+            if host:
+                return f"esp32://{host}"
+            if self._device_cfg.preferred_host:
+                return f"esp32://{self._device_cfg.preferred_host} (offline)"
+            return "esp32://(discovering)"
+        return self._config.port
+
+    def start(self) -> None:
+        if not self.enabled:
+            raise CatTeaserCameraError("cat_teaser needs a configured lamp-head camera")
+        self._cv2 = _import_cv2()
+        if self._config.port.strip():
+            self._open_local_camera()
+
+    def read(self):
+        if self._cv2 is None:
+            self.start()
+
+        if self._device_cfg is not None and self._device_cfg.enabled and self._esp32 is not None:
+            if self._esp32.is_online():
+                frame = self._read_esp32_frame()
+                if frame is not None:
+                    self._esp32.mark_session_used()
+                    return frame
+
+        if self._cap is not None:
+            ok, frame = self._cap.read()
+            if ok and frame is not None:
+                return frame
+        return None
+
+    def close(self) -> None:
+        if self._cap is not None:
+            self._cap.release()
+            self._cap = None
+
+    def _open_local_camera(self) -> None:
+        cv2 = self._cv2
+        if cv2 is None:
+            return
+        device = self._parse_device(self._config.port)
+        if device is None:
+            return
+        for backend in self._candidate_backends(cv2, device):
+            cap = cv2.VideoCapture(device, backend) if backend is not None else cv2.VideoCapture(device)
+            if cap.isOpened():
+                cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.WIDTH)
+                cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.HEIGHT)
+                self._cap = cap
+                return
+            cap.release()
+        logger.warning("cat_teaser.local_camera_unavailable", port=self._config.port)
+
+    def _read_esp32_frame(self):
+        cv2 = self._cv2
+        if cv2 is None or self._esp32 is None:
+            return None
+        base_url = self._esp32.get_active_base_url()
+        if not base_url:
+            return None
+        try:
+            import httpx
+        except ImportError:
+            logger.warning("cat_teaser.httpx_missing")
+            return None
+        try:
+            with httpx.Client(timeout=self.ESP32_HTTP_TIMEOUT_S, trust_env=False) as client:
+                resp = client.get(f"{base_url}/capture")
+            if resp.status_code != 200:
+                logger.warning("cat_teaser.esp32_http_error", status=resp.status_code)
+                return None
+            data = np.frombuffer(resp.content, dtype=np.uint8)
+            return cv2.imdecode(data, cv2.IMREAD_COLOR)
+        except Exception:
+            logger.debug("cat_teaser.esp32_capture_failed", exc_info=True)
+            return None
+
+    @staticmethod
+    def _parse_device(raw: str) -> int | str | None:
+        value = raw.strip()
+        if not value:
+            return None
+        if value.isdigit():
+            return int(value)
+        return value
+
+    @staticmethod
+    def _candidate_backends(cv2, device: int | str) -> list[int | None]:
+        import sys
+
+        backends: list[int | None] = [None]
+        if isinstance(device, int) and sys.platform == "darwin" and hasattr(cv2, "CAP_AVFOUNDATION"):
+            backends.insert(0, cv2.CAP_AVFOUNDATION)
+        elif isinstance(device, (int, str)) and sys.platform.startswith("linux") and hasattr(cv2, "CAP_V4L2"):
+            backends.insert(0, cv2.CAP_V4L2)
+        return backends
+
+
+class CatToyTracker:
+    """HSV marker tracker for the teaser wand tip."""
+
+    def __init__(self, *, marker_color: str = "magenta", min_area: float = 40.0) -> None:
+        color = marker_color.strip().lower()
+        if color not in _SUPPORTED_MARKER_COLORS:
+            supported = ", ".join(sorted(_SUPPORTED_MARKER_COLORS))
+            raise ValueError(f"Unsupported marker_color={marker_color!r}; expected one of: {supported}")
+        self.marker_color = color
+        self.min_area = float(min_area)
+
+    def track(self, frame) -> MarkerDetection | None:
+        cv2 = _import_cv2()
+        height, width = frame.shape[:2]
+        hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+        mask = self._mask_for_color(cv2, hsv)
+        kernel = np.ones((5, 5), dtype=np.uint8)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+        contours, _hierarchy = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if not contours:
+            return None
+        contour = max(contours, key=cv2.contourArea)
+        area = float(cv2.contourArea(contour))
+        if area < self.min_area:
+            return None
+        (x, y), radius = cv2.minEnclosingCircle(contour)
+        confidence_denominator = max(self.min_area * 8.0, float(width * height) * 0.002)
+        confidence = min(1.0, area / confidence_denominator)
+        return MarkerDetection(
+            x=float(x),
+            y=float(y),
+            radius=float(radius),
+            area=area,
+            confidence=confidence,
+            frame_width=int(width),
+            frame_height=int(height),
+        )
+
+    def _mask_for_color(self, cv2, hsv):
+        ranges = {
+            "magenta": [((140, 70, 70), (175, 255, 255))],
+            "green": [((40, 55, 55), (85, 255, 255))],
+            "blue": [((95, 65, 55), (130, 255, 255))],
+            "yellow": [((20, 70, 80), (38, 255, 255))],
+            "red": [((0, 70, 70), (10, 255, 255)), ((170, 70, 70), (179, 255, 255))],
+        }[self.marker_color]
+        mask = None
+        for lower, upper in ranges:
+            part = cv2.inRange(hsv, np.array(lower, dtype=np.uint8), np.array(upper, dtype=np.uint8))
+            mask = part if mask is None else cv2.bitwise_or(mask, part)
+        return mask
+
+
+@dataclass
+class CatPlayStateEstimator:
+    """Estimate play state from marker tracking and local motion energy."""
+
+    motion_threshold: int = 18
+    marker_timeout_s: float = 0.8
+    rest_after_s: float = 2.0
+    unsafe_radius_ratio: float = 0.22
+    unsafe_area_ratio: float = 0.055
+    _previous_gray: object | None = field(default=None, init=False, repr=False)
+    _last_marker: MarkerDetection | None = field(default=None, init=False)
+    _last_seen_at: float | None = field(default=None, init=False)
+    _engagement_score: float = field(default=0.0, init=False)
+
+    def update(
+        self,
+        frame,
+        marker: MarkerDetection | None,
+        *,
+        timestamp: float | None = None,
+    ) -> CatPlayObservation:
+        cv2 = _import_cv2()
+        now = time.monotonic() if timestamp is None else float(timestamp)
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        gray = cv2.GaussianBlur(gray, (5, 5), 0)
+        motion_mask = self._motion_mask(cv2, gray)
+
+        anchor = marker or self._last_marker
+        motion_energy, centroid = self._local_motion(motion_mask, anchor)
+        state = self._classify(marker, motion_energy, now)
+        self._update_engagement(marker, motion_energy, state)
+
+        if marker is not None:
+            self._last_marker = marker
+            self._last_seen_at = now
+        self._previous_gray = gray
+
+        return CatPlayObservation(
+            state=state,
+            marker=marker,
+            motion_energy=motion_energy,
+            engagement_score=self._engagement_score,
+            motion_centroid=centroid,
+            timestamp=now,
+        )
+
+    def _motion_mask(self, cv2, gray):
+        if self._previous_gray is None:
+            return np.zeros_like(gray, dtype=np.uint8)
+        delta = cv2.absdiff(self._previous_gray, gray)
+        _ret, mask = cv2.threshold(delta, self.motion_threshold, 255, cv2.THRESH_BINARY)
+        return mask
+
+    def _local_motion(
+        self,
+        motion_mask,
+        anchor: MarkerDetection | None,
+    ) -> tuple[float, tuple[float, float] | None]:
+        height, width = motion_mask.shape[:2]
+        if anchor is None:
+            nonzero = int(np.count_nonzero(motion_mask))
+            return nonzero / max(float(width * height), 1.0), None
+
+        radius = max(42, int(anchor.radius * 4.0))
+        x0 = max(0, int(anchor.x) - radius)
+        x1 = min(width, int(anchor.x) + radius)
+        y0 = max(0, int(anchor.y) - radius)
+        y1 = min(height, int(anchor.y) + radius)
+        if x1 <= x0 or y1 <= y0:
+            return 0.0, None
+
+        roi = motion_mask[y0:y1, x0:x1]
+        energy = float(np.count_nonzero(roi)) / max(float(roi.size), 1.0)
+        ys, xs = np.nonzero(roi)
+        if len(xs) == 0:
+            return energy, None
+        cx = (x0 + float(np.mean(xs))) / max(float(width), 1.0)
+        cy = (y0 + float(np.mean(ys))) / max(float(height), 1.0)
+        return energy, (cx, cy)
+
+    def _classify(
+        self,
+        marker: MarkerDetection | None,
+        motion_energy: float,
+        now: float,
+    ) -> CatPlayState:
+        if marker is not None and self._is_unsafe_close(marker):
+            return "unsafe_close"
+
+        if marker is None:
+            recent_marker = self._last_seen_at is not None and now - self._last_seen_at <= self.marker_timeout_s
+            if recent_marker and motion_energy > 0.035:
+                return "caught"
+            if self._last_seen_at is not None and now - self._last_seen_at > self.rest_after_s:
+                if self._engagement_score < 0.12 and motion_energy < 0.02:
+                    return "rest"
+            return "searching"
+
+        if motion_energy > 0.16:
+            return "pounce"
+        if motion_energy > 0.045 or self._engagement_score > 0.35:
+            return "engaged"
+        return "teasing"
+
+    def _is_unsafe_close(self, marker: MarkerDetection) -> bool:
+        min_dim = max(float(min(marker.frame_width, marker.frame_height)), 1.0)
+        frame_area = max(float(marker.frame_width * marker.frame_height), 1.0)
+        return marker.radius / min_dim > self.unsafe_radius_ratio or marker.area / frame_area > self.unsafe_area_ratio
+
+    def _update_engagement(
+        self,
+        marker: MarkerDetection | None,
+        motion_energy: float,
+        state: CatPlayState,
+    ) -> None:
+        marker_score = marker.confidence * 0.25 if marker is not None else 0.0
+        burst_bonus = 0.25 if state in {"pounce", "caught"} else 0.0
+        if state in {"searching", "rest", "unsafe_close"}:
+            raw = 0.0
+        else:
+            raw = min(1.0, marker_score + motion_energy * 6.0 + burst_bonus)
+        self._engagement_score = self._engagement_score * 0.78 + raw * 0.22

--- a/lampgo/perception/cat_teaser.py
+++ b/lampgo/perception/cat_teaser.py
@@ -222,6 +222,153 @@ class CatTeaserFrameSource:
         return backends
 
 
+class CatTeaserDebugView:
+    """OpenCV debug window for cat teaser perception."""
+
+    def __init__(self, *, enabled: bool = True, window_name: str = "LampGo Cat Teaser Vision") -> None:
+        self.enabled = enabled
+        self.window_name = window_name
+        self._cv2 = None
+        self._window_open = False
+        self._warned = False
+
+    def render(
+        self,
+        frame,
+        observation: CatPlayObservation,
+        *,
+        elapsed_s: float,
+        marker_color: str,
+        event_text: str | None = None,
+    ) -> bool:
+        """Show an annotated frame.
+
+        Returns True when the user asks to stop the skill by pressing q/esc or
+        closing the preview window.
+        """
+        if not self.enabled:
+            return False
+        try:
+            cv2 = self._ensure_cv2()
+            self._ensure_window(cv2, frame)
+            display = self._annotate_frame(cv2, frame, observation, elapsed_s, marker_color, event_text)
+            cv2.imshow(self.window_name, display)
+            key = cv2.waitKey(1) & 0xFF
+            if key in {27, ord("q")}:
+                return True
+            return self._window_was_closed(cv2)
+        except Exception as exc:
+            self._disable_after_error(exc)
+            return False
+
+    def close(self) -> None:
+        if self._cv2 is None or not self._window_open:
+            return
+        try:
+            self._cv2.destroyWindow(self.window_name)
+            self._cv2.waitKey(1)
+        except Exception:
+            logger.debug("cat_teaser.debug_view_close_failed", exc_info=True)
+        finally:
+            self._window_open = False
+
+    def _ensure_cv2(self):
+        if self._cv2 is None:
+            self._cv2 = _import_cv2()
+        return self._cv2
+
+    def _ensure_window(self, cv2, frame) -> None:
+        if self._window_open:
+            return
+        cv2.namedWindow(self.window_name, cv2.WINDOW_NORMAL)
+        height, width = frame.shape[:2]
+        cv2.resizeWindow(self.window_name, min(width, 960), min(height, 720))
+        self._window_open = True
+
+    def _annotate_frame(
+        self,
+        cv2,
+        frame,
+        observation: CatPlayObservation,
+        elapsed_s: float,
+        marker_color: str,
+        event_text: str | None,
+    ):
+        display = frame.copy()
+        marker = observation.marker
+        if marker is not None:
+            color = self._bgr_for_marker(marker_color)
+            center = (int(marker.x), int(marker.y))
+            radius = max(3, int(marker.radius))
+            cv2.circle(display, center, radius, color, 2)
+            cv2.circle(display, center, 3, color, -1)
+            self._put_text(cv2, display, f"{marker_color} marker {marker.confidence:.2f}", center[0] + 8, center[1] - 8)
+        else:
+            self._put_text(cv2, display, f"{marker_color} marker lost", 14, 76, color=(0, 0, 255))
+
+        if observation.motion_centroid is not None:
+            height, width = display.shape[:2]
+            cx = int(observation.motion_centroid[0] * width)
+            cy = int(observation.motion_centroid[1] * height)
+            cv2.drawMarker(display, (cx, cy), (0, 255, 255), cv2.MARKER_CROSS, 18, 2)
+
+        lines = [
+            f"t={elapsed_s:.1f}s state={observation.state}",
+            f"motion={observation.motion_energy:.3f} engagement={observation.engagement_score:.2f}",
+            "q/esc: stop cat_teaser",
+        ]
+        if event_text:
+            lines.insert(2, f"event: {event_text}")
+        self._draw_panel(cv2, display, lines)
+        return display
+
+    @staticmethod
+    def _draw_panel(cv2, display, lines: list[str]) -> None:
+        x, y = 12, 18
+        line_h = 24
+        width = max(300, max(len(line) for line in lines) * 10)
+        height = line_h * len(lines) + 14
+        overlay = display.copy()
+        cv2.rectangle(overlay, (8, 8), (8 + width, 8 + height), (0, 0, 0), -1)
+        cv2.addWeighted(overlay, 0.48, display, 0.52, 0, display)
+        for idx, line in enumerate(lines):
+            CatTeaserDebugView._put_text(cv2, display, line, x, y + idx * line_h)
+
+    @staticmethod
+    def _put_text(cv2, display, text: str, x: int, y: int, *, color: tuple[int, int, int] = (255, 255, 255)) -> None:
+        cv2.putText(display, text, (x, y), cv2.FONT_HERSHEY_SIMPLEX, 0.58, (0, 0, 0), 3, cv2.LINE_AA)
+        cv2.putText(display, text, (x, y), cv2.FONT_HERSHEY_SIMPLEX, 0.58, color, 1, cv2.LINE_AA)
+
+    @staticmethod
+    def _bgr_for_marker(marker_color: str) -> tuple[int, int, int]:
+        return {
+            "magenta": (255, 0, 255),
+            "green": (0, 255, 0),
+            "blue": (255, 0, 0),
+            "red": (0, 0, 255),
+            "yellow": (0, 255, 255),
+        }.get(marker_color, (255, 255, 255))
+
+    def _window_was_closed(self, cv2) -> bool:
+        if not self._window_open:
+            return False
+        try:
+            return cv2.getWindowProperty(self.window_name, cv2.WND_PROP_VISIBLE) < 1
+        except Exception:
+            return False
+
+    def _disable_after_error(self, exc: Exception) -> None:
+        self.enabled = False
+        if self._warned:
+            return
+        self._warned = True
+        logger.warning(
+            "cat_teaser.debug_view_unavailable",
+            error=str(exc),
+            hint="OpenCV GUI preview is unavailable; cat_teaser continues without the popup window.",
+        )
+
+
 class CatToyTracker:
     """HSV marker tracker for the teaser wand tip."""
 

--- a/lampgo/perception/cat_teaser.py
+++ b/lampgo/perception/cat_teaser.py
@@ -77,6 +77,8 @@ class CatPlayObservation:
     engagement_score: float
     motion_centroid: tuple[float, float] | None
     timestamp: float
+    contact_motion_energy: float = 0.0
+    marker_disturbance: float = 0.0
 
 
 def _import_cv2():
@@ -94,7 +96,9 @@ class CatTeaserFrameSource:
     """Read BGR frames from the lamp-head camera.
 
     ESP32 camera is preferred when enabled and online. If a local camera port is
-    configured, it is used as a fallback or as the primary source.
+    configured, it is used as a fallback or as the primary source. In no-hardware
+    mode callers may allow an implicit local camera fallback, which tries device
+    index 0 without persisting it to config.
     """
 
     WIDTH = 640
@@ -107,21 +111,28 @@ class CatTeaserFrameSource:
         *,
         device_esp32_config: DeviceEsp32Config | None = None,
         esp32_manager: Esp32DeviceManager | None = None,
+        allow_local_camera_fallback: bool = False,
+        fallback_local_port: str = "0",
     ) -> None:
         self._config = camera_config or CameraConfig()
         self._device_cfg = device_esp32_config
         self._esp32 = esp32_manager
+        self._allow_local_camera_fallback = allow_local_camera_fallback
+        self._fallback_local_port = str(fallback_local_port or "0")
         self._cv2 = None
         self._cap = None
+        self._local_label = ""
 
     @property
     def enabled(self) -> bool:
-        if self._config.port.strip():
+        if self._local_camera_port():
             return True
         return bool(self._device_cfg and self._device_cfg.enabled)
 
     @property
     def device_label(self) -> str:
+        if self._cap is not None and self._local_label:
+            return self._local_label
         if self._device_cfg is not None and self._device_cfg.enabled and self._esp32 is not None:
             host = self._esp32.get_active_host()
             if host:
@@ -129,13 +140,17 @@ class CatTeaserFrameSource:
             if self._device_cfg.preferred_host:
                 return f"esp32://{self._device_cfg.preferred_host} (offline)"
             return "esp32://(discovering)"
-        return self._config.port
+        port = self._local_camera_port()
+        if port:
+            suffix = " (fallback)" if self._using_implicit_local_fallback() else ""
+            return f"local://{port}{suffix}"
+        return ""
 
     def start(self) -> None:
         if not self.enabled:
             raise CatTeaserCameraError("cat_teaser needs a configured lamp-head camera")
         self._cv2 = _import_cv2()
-        if self._config.port.strip():
+        if self._local_camera_port():
             self._open_local_camera()
 
     def read(self):
@@ -164,7 +179,8 @@ class CatTeaserFrameSource:
         cv2 = self._cv2
         if cv2 is None:
             return
-        device = self._parse_device(self._config.port)
+        port = self._local_camera_port()
+        device = self._parse_device(port)
         if device is None:
             return
         for backend in self._candidate_backends(cv2, device):
@@ -173,9 +189,15 @@ class CatTeaserFrameSource:
                 cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.WIDTH)
                 cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.HEIGHT)
                 self._cap = cap
+                suffix = " (fallback)" if self._using_implicit_local_fallback() else ""
+                self._local_label = f"local://{port}{suffix}"
                 return
             cap.release()
-        logger.warning("cat_teaser.local_camera_unavailable", port=self._config.port)
+        logger.warning(
+            "cat_teaser.local_camera_unavailable",
+            port=port,
+            fallback=self._using_implicit_local_fallback(),
+        )
 
     def _read_esp32_frame(self):
         cv2 = self._cv2
@@ -209,6 +231,17 @@ class CatTeaserFrameSource:
         if value.isdigit():
             return int(value)
         return value
+
+    def _local_camera_port(self) -> str:
+        configured = self._config.port.strip()
+        if configured:
+            return configured
+        if self._allow_local_camera_fallback:
+            return self._fallback_local_port.strip() or "0"
+        return ""
+
+    def _using_implicit_local_fallback(self) -> bool:
+        return not self._config.port.strip() and bool(self._allow_local_camera_fallback)
 
     @staticmethod
     def _candidate_backends(cv2, device: int | str) -> list[int | None]:
@@ -315,6 +348,7 @@ class CatTeaserDebugView:
         lines = [
             f"t={elapsed_s:.1f}s state={observation.state}",
             f"motion={observation.motion_energy:.3f} engagement={observation.engagement_score:.2f}",
+            f"contact={observation.contact_motion_energy:.3f} disturb={observation.marker_disturbance:.3f}",
             "q/esc: stop cat_teaser",
         ]
         if event_text:
@@ -429,12 +463,28 @@ class CatPlayStateEstimator:
 
     motion_threshold: int = 18
     marker_timeout_s: float = 0.8
+    min_caught_lost_s: float = 0.28
+    min_caught_lost_frames: int = 3
+    stable_marker_frames: int = 3
+    caught_motion_threshold: float = 0.22
+    pounce_motion_threshold: float = 0.19
+    visible_caught_motion_threshold: float = 0.18
+    visible_caught_contact_threshold: float = 0.27
+    visible_caught_disturbed_contact_threshold: float = 0.18
+    visible_caught_marker_disturbance: float = 0.055
+    visible_caught_strong_marker_disturbance: float = 0.09
     rest_after_s: float = 2.0
     unsafe_radius_ratio: float = 0.22
     unsafe_area_ratio: float = 0.055
     _previous_gray: object | None = field(default=None, init=False, repr=False)
     _last_marker: MarkerDetection | None = field(default=None, init=False)
     _last_seen_at: float | None = field(default=None, init=False)
+    _lost_started_at: float | None = field(default=None, init=False)
+    _marker_seen_frames: int = field(default=0, init=False)
+    _marker_lost_frames: int = field(default=0, init=False)
+    _seen_frames_before_loss: int = field(default=0, init=False)
+    _pounce_motion_frames: int = field(default=0, init=False)
+    _last_pounce_at: float | None = field(default=None, init=False)
     _engagement_score: float = field(default=0.0, init=False)
 
     def update(
@@ -449,15 +499,19 @@ class CatPlayStateEstimator:
         gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
         gray = cv2.GaussianBlur(gray, (5, 5), 0)
         motion_mask = self._motion_mask(cv2, gray)
+        motion_mask = self._without_marker_self_motion(cv2, motion_mask, marker)
 
         anchor = marker or self._last_marker
         motion_energy, centroid = self._local_motion(motion_mask, anchor)
-        state = self._classify(marker, motion_energy, now)
+        contact_motion_energy = self._contact_motion(motion_mask, marker)
+        marker_disturbance = self._marker_disturbance(marker) if marker is not None else 0.0
+        self._update_marker_history(marker, now)
+        state = self._classify(marker, motion_energy, contact_motion_energy, marker_disturbance, now)
+        self._update_pounce_history(state, now)
         self._update_engagement(marker, motion_energy, state)
 
         if marker is not None:
             self._last_marker = marker
-            self._last_seen_at = now
         self._previous_gray = gray
 
         return CatPlayObservation(
@@ -467,6 +521,8 @@ class CatPlayStateEstimator:
             engagement_score=self._engagement_score,
             motion_centroid=centroid,
             timestamp=now,
+            contact_motion_energy=contact_motion_energy,
+            marker_disturbance=marker_disturbance,
         )
 
     def _motion_mask(self, cv2, gray):
@@ -474,6 +530,23 @@ class CatPlayStateEstimator:
             return np.zeros_like(gray, dtype=np.uint8)
         delta = cv2.absdiff(self._previous_gray, gray)
         _ret, mask = cv2.threshold(delta, self.motion_threshold, 255, cv2.THRESH_BINARY)
+        return mask
+
+    def _without_marker_self_motion(
+        self,
+        cv2,
+        motion_mask,
+        marker: MarkerDetection | None,
+    ):
+        if marker is None and self._last_marker is None:
+            return motion_mask
+        mask = motion_mask.copy()
+        for detection in (marker, self._last_marker):
+            if detection is None:
+                continue
+            center = (int(detection.x), int(detection.y))
+            radius = max(20, int(detection.radius * 1.8))
+            cv2.circle(mask, center, radius, 0, -1)
         return mask
 
     def _local_motion(
@@ -503,10 +576,40 @@ class CatPlayStateEstimator:
         cy = (y0 + float(np.mean(ys))) / max(float(height), 1.0)
         return energy, (cx, cy)
 
+    def _contact_motion(
+        self,
+        motion_mask,
+        marker: MarkerDetection | None,
+    ) -> float:
+        if marker is None:
+            return 0.0
+        height, width = motion_mask.shape[:2]
+        cx = int(marker.x)
+        cy = int(marker.y)
+        inner = max(20, int(marker.radius * 1.7))
+        outer = max(inner + 12, int(marker.radius * 3.3))
+        x0 = max(0, cx - outer)
+        x1 = min(width, cx + outer)
+        y0 = max(0, cy - outer)
+        y1 = min(height, cy + outer)
+        if x1 <= x0 or y1 <= y0:
+            return 0.0
+
+        roi = motion_mask[y0:y1, x0:x1]
+        yy, xx = np.ogrid[y0:y1, x0:x1]
+        distance_sq = (xx - marker.x) ** 2 + (yy - marker.y) ** 2
+        ring = (distance_sq >= inner**2) & (distance_sq <= outer**2)
+        ring_area = int(np.count_nonzero(ring))
+        if ring_area <= 0:
+            return 0.0
+        return float(np.count_nonzero(roi[ring])) / float(ring_area)
+
     def _classify(
         self,
         marker: MarkerDetection | None,
         motion_energy: float,
+        contact_motion_energy: float,
+        marker_disturbance: float,
         now: float,
     ) -> CatPlayState:
         if marker is not None and self._is_unsafe_close(marker):
@@ -514,18 +617,100 @@ class CatPlayStateEstimator:
 
         if marker is None:
             recent_marker = self._last_seen_at is not None and now - self._last_seen_at <= self.marker_timeout_s
-            if recent_marker and motion_energy > 0.035:
+            lost_duration = now - self._lost_started_at if self._lost_started_at is not None else 0.0
+            sustained_loss = (
+                self._marker_lost_frames >= self.min_caught_lost_frames
+                and lost_duration >= self.min_caught_lost_s
+            )
+            stable_before_loss = self._seen_frames_before_loss >= self.stable_marker_frames
+            was_pouncing = self._last_pounce_at is not None and now - self._last_pounce_at <= self.marker_timeout_s
+            if (
+                recent_marker
+                and sustained_loss
+                and stable_before_loss
+                and was_pouncing
+                and motion_energy > self.caught_motion_threshold
+            ):
                 return "caught"
             if self._last_seen_at is not None and now - self._last_seen_at > self.rest_after_s:
                 if self._engagement_score < 0.12 and motion_energy < 0.02:
                     return "rest"
             return "searching"
 
-        if motion_energy > 0.16:
+        if self._is_visible_contact(marker, motion_energy, contact_motion_energy, marker_disturbance):
+            return "caught"
+
+        if motion_energy > self.pounce_motion_threshold:
+            self._pounce_motion_frames += 1
+        else:
+            self._pounce_motion_frames = 0
+        if self._pounce_motion_frames >= 2 or motion_energy > self.pounce_motion_threshold * 2.2:
             return "pounce"
         if motion_energy > 0.045 or self._engagement_score > 0.35:
             return "engaged"
         return "teasing"
+
+    def _is_visible_contact(
+        self,
+        marker: MarkerDetection,
+        motion_energy: float,
+        contact_motion_energy: float,
+        marker_disturbance: float,
+    ) -> bool:
+        del marker
+        if contact_motion_energy < self.visible_caught_disturbed_contact_threshold:
+            return False
+
+        strong_contact = (
+            motion_energy >= self.visible_caught_motion_threshold * 1.8
+            and contact_motion_energy >= self.visible_caught_contact_threshold
+            and marker_disturbance >= self.visible_caught_marker_disturbance
+        )
+        disturbed_contact = (
+            motion_energy >= self.visible_caught_motion_threshold
+            and contact_motion_energy >= self.visible_caught_contact_threshold
+            and marker_disturbance >= self.visible_caught_strong_marker_disturbance
+        )
+        near_tip_nudge = (
+            motion_energy >= self.visible_caught_motion_threshold
+            and contact_motion_energy >= self.visible_caught_contact_threshold * 1.1
+            and marker_disturbance >= self.visible_caught_marker_disturbance
+        )
+        if not (strong_contact or disturbed_contact or near_tip_nudge):
+            return False
+        return True
+
+    def _marker_disturbance(self, marker: MarkerDetection) -> float:
+        previous = self._last_marker
+        if previous is None:
+            return 0.0
+        dx = marker.normalized_x - previous.normalized_x
+        dy = marker.normalized_y - previous.normalized_y
+        shift = (dx * dx + dy * dy) ** 0.5 * 4.0
+        area_change = abs(marker.area - previous.area) / max(marker.area, previous.area, 1.0)
+        radius_change = abs(marker.radius - previous.radius) / max(marker.radius, previous.radius, 1.0)
+        confidence_drop = max(0.0, previous.confidence - marker.confidence)
+        return max(shift, area_change, radius_change * 1.4, confidence_drop)
+
+    def _update_marker_history(self, marker: MarkerDetection | None, now: float) -> None:
+        if marker is not None:
+            self._marker_seen_frames += 1
+            self._marker_lost_frames = 0
+            self._lost_started_at = None
+            self._seen_frames_before_loss = 0
+            self._last_seen_at = now
+            return
+
+        if self._marker_lost_frames == 0:
+            self._lost_started_at = now
+            self._seen_frames_before_loss = self._marker_seen_frames
+        self._marker_lost_frames += 1
+        self._marker_seen_frames = 0
+        self._pounce_motion_frames = 0
+
+    def _update_pounce_history(self, state: CatPlayState, now: float) -> None:
+        if state == "pounce":
+            self._last_pounce_at = now
 
     def _is_unsafe_close(self, marker: MarkerDetection) -> bool:
         min_dim = max(float(min(marker.frame_width, marker.frame_height)), 1.0)

--- a/lampgo/perception/cat_teaser.py
+++ b/lampgo/perception/cat_teaser.py
@@ -32,6 +32,7 @@ CatPlayState = Literal[
 ]
 
 _SUPPORTED_MARKER_COLORS = {"magenta", "green", "blue", "red", "yellow"}
+_LOCAL_VIDEO_DEVICE_PREFIX = "/dev/video"
 
 
 class CatTeaserError(RuntimeError):
@@ -44,6 +45,19 @@ class CatTeaserDependencyError(CatTeaserError):
 
 class CatTeaserCameraError(CatTeaserError):
     """Raised when no camera source is configured or readable."""
+
+
+def is_supported_local_camera_port(raw: str) -> bool:
+    """Return True for local camera selectors that cannot become URL/file reads."""
+    value = raw.strip()
+    if not value:
+        return True
+    if value.isdigit():
+        return True
+    if value.startswith(_LOCAL_VIDEO_DEVICE_PREFIX):
+        suffix = value.removeprefix(_LOCAL_VIDEO_DEVICE_PREFIX)
+        return bool(suffix) and suffix.isdigit()
+    return False
 
 
 @dataclass(frozen=True)
@@ -230,12 +244,17 @@ class CatTeaserFrameSource:
             return None
         if value.isdigit():
             return int(value)
-        return value
+        if value.startswith(_LOCAL_VIDEO_DEVICE_PREFIX):
+            suffix = value.removeprefix(_LOCAL_VIDEO_DEVICE_PREFIX)
+            if suffix.isdigit():
+                return value
+        logger.warning("cat_teaser.local_camera_port_rejected", port=value)
+        return None
 
     def _local_camera_port(self) -> str:
         configured = self._config.port.strip()
         if configured:
-            return configured
+            return configured if is_supported_local_camera_port(configured) else ""
         if self._allow_local_camera_fallback:
             return self._fallback_local_port.strip() or "0"
         return ""

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -44,9 +44,11 @@ from lampgo.core.safety import SafetyKernel
 from lampgo.core.virtual_motion import VirtualMotionRuntime
 from lampgo.device import Esp32DeviceManager
 from lampgo.ipc import IPCServer
+from lampgo.perception.cat_teaser import CatTeaserFrameSource
 from lampgo.perception.router import IntentRouter, IntentType
 from lampgo.recordings import build_recording_actions_prompt, write_recording_description
 from lampgo.skills.base import SkillContext
+from lampgo.skills.builtin.cat_teaser import CatTeaserSkill
 from lampgo.skills.builtin.expression_skills import SetExpressionSkill
 from lampgo.skills.builtin.motion_skills import EStopSkill, MoveToSkill, ReturnSafeSkill
 from lampgo.skills.builtin.music_skills import DanceToMusicSkill
@@ -161,6 +163,17 @@ class LampgoServer:
         self.registry.register(LookAtSkill())
         self.registry.register(IdleSwaySkill())
         self.registry.register(DanceToMusicSkill())
+        self.registry.register(CatTeaserSkill(self._make_cat_teaser_frame_source))
+
+    def _make_cat_teaser_frame_source(self) -> CatTeaserFrameSource:
+        return CatTeaserFrameSource(
+            self.config.camera,
+            device_esp32_config=self.config.device_esp32,
+            esp32_manager=self.esp32,
+        )
+
+    def _recording_actions_prompt(self) -> str:
+        return build_recording_actions_prompt(Path(self.config.recordings_dir))
 
     # ---- user / composed skills (JSON-defined, created by OpenClaw & UI) ----
 
@@ -412,7 +425,14 @@ class LampgoServer:
             self._openclaw_asks[ask_id] = fut
 
         opts = list(options or [])
-        await self.events.publish(OpenClawAskRequested(ask_id=ask_id, question=question, options=opts, request_id=request_id))
+        await self.events.publish(
+            OpenClawAskRequested(
+                ask_id=ask_id,
+                question=question,
+                options=opts,
+                request_id=request_id,
+            )
+        )
         await self.events.publish(ChatMessage(role="assistant", content=question, request_id=request_id))
 
         try:
@@ -880,7 +900,11 @@ class LampgoServer:
             return result
 
         if intent.intent_type == IntentType.COMPLEX:
-            await _publish_intent_progress("openclaw_handoff", "关键词未命中且未能本地完成，转交 OpenClaw...", "openclaw")
+            await _publish_intent_progress(
+                "openclaw_handoff",
+                "关键词未命中且未能本地完成，转交 OpenClaw...",
+                "openclaw",
+            )
             return await self._handoff_to_openclaw(
                 request_id=request_id,
                 text=text,
@@ -962,7 +986,12 @@ class LampgoServer:
         request_id = data.get("request_id", "")
 
         audio_rms = self._measure_audio_rms(audio_data)
-        logger.info("server.audio_transcribing", request_id=request_id, audio_b64_len=len(audio_data), rms=f"{audio_rms:.1f}")
+        logger.info(
+            "server.audio_transcribing",
+            request_id=request_id,
+            audio_b64_len=len(audio_data),
+            rms=f"{audio_rms:.1f}",
+        )
         await self.events.publish(IntentRouting(text="[语音输入]", request_id=request_id))
         await self.events.publish(
             IntentProgress(stage="audio_transcribe", message="正在识别语音...", source="stt", request_id=request_id)
@@ -1034,7 +1063,11 @@ class LampgoServer:
             try:
                 data = json.loads(path.read_text(encoding="utf-8"))
                 if isinstance(data, dict):
-                    cached = {str(k).strip(): str(v).strip() for k, v in data.items() if str(k).strip() and str(v).strip()}
+                    cached = {
+                        str(k).strip(): str(v).strip()
+                        for k, v in data.items()
+                        if str(k).strip() and str(v).strip()
+                    }
                 else:
                     cached = {}
             except Exception:
@@ -1501,9 +1534,17 @@ class LampgoServer:
             status = self.esp32.get_status() if self.esp32 else {}
             device = status.get("device") if isinstance(status, dict) else None
             if device and device.get("needs_firmware_update"):
-                return {"ok": False, "error": "esp32_firmware_update_required", "result": {"esp32": self._esp32_camera_info()}}
+                return {
+                    "ok": False,
+                    "error": "esp32_firmware_update_required",
+                    "result": {"esp32": self._esp32_camera_info()},
+                }
             if device and device.get("is_paired_to_other"):
-                return {"ok": False, "error": "esp32_paired_to_other", "result": {"esp32": self._esp32_camera_info()}}
+                return {
+                    "ok": False,
+                    "error": "esp32_paired_to_other",
+                    "result": {"esp32": self._esp32_camera_info()},
+                }
             self.config.device_esp32.enabled = True
             self.config.camera.port = ""
             logger.info("camera.switched_to_esp32")
@@ -1761,7 +1802,7 @@ class LampgoServer:
                 camera_config=self.config.camera,
                 device_esp32_config=self.config.device_esp32,
                 esp32_manager=self.esp32,
-                recording_actions_prompt_provider=lambda: build_recording_actions_prompt(Path(self.config.recordings_dir)),
+                recording_actions_prompt_provider=self._recording_actions_prompt,
             )
             self.router.set_llm_client(client)
             logger.info(
@@ -1954,7 +1995,7 @@ class LampgoServer:
                 camera_config=self.config.camera,
                 device_esp32_config=self.config.device_esp32,
                 esp32_manager=self.esp32,
-                recording_actions_prompt_provider=lambda: build_recording_actions_prompt(Path(self.config.recordings_dir)),
+                recording_actions_prompt_provider=self._recording_actions_prompt,
             )
             self.router.set_llm_client(client)
             logger.info(
@@ -1987,7 +2028,7 @@ class LampgoServer:
                 camera_config=self.config.camera,
                 device_esp32_config=self.config.device_esp32,
                 esp32_manager=self.esp32,
-                recording_actions_prompt_provider=lambda: build_recording_actions_prompt(Path(self.config.recordings_dir)),
+                recording_actions_prompt_provider=self._recording_actions_prompt,
             )
             self.router.set_llm_client(client)
             logger.info(
@@ -2101,11 +2142,14 @@ class LampgoServer:
 
             status = detect_openclaw_integration()
             overall = status.overall
+            plugin_detail = "已安装" if status.plugin.ok else "未安装（运行 `lampgo install-openclaw --yes` 一键安装）"
+            skill_detail = "已注册" if status.skill.ok else "未注册（关键词触发不可用）"
+            trusted_detail = "已启用" if status.trusted.ok else "未启用（OpenClaw 会拒绝加载）"
             integration_lines = [
                 f"openclaw CLI     : {_mark(status.binary.ok)} {status.binary.detail}",
-                f"lampgo plugin    : {_mark(status.plugin.ok)} {'已安装' if status.plugin.ok else '未安装（运行 `lampgo install-openclaw --yes` 一键安装）'}",
-                f"lampgo skill     : {_mark(status.skill.ok)} {'已注册' if status.skill.ok else '未注册（关键词触发不可用）'}",
-                f"plugin 启用      : {_mark(status.trusted.ok)} {'已启用' if status.trusted.ok else '未启用（OpenClaw 会拒绝加载）'}",
+                f"lampgo plugin    : {_mark(status.plugin.ok)} {plugin_detail}",
+                f"lampgo skill     : {_mark(status.skill.ok)} {skill_detail}",
+                f"plugin 启用      : {_mark(status.trusted.ok)} {trusted_detail}",
                 f"gateway 在线     : {_mark(status.gateway.ok)} {status.gateway.detail}",
             ]
             overall_line = f"集成状态         : {overall}"
@@ -2130,14 +2174,16 @@ class LampgoServer:
         )
         esp32_seen = bool(esp32_device or esp32_status.get("preferred_host"))
         voice_ready = livekit_configured and wake_configured and agent_ready and wake_loop_running
+        worker_detail = "registered worker" if agent_ready else ("启动中/未就绪" if agent_running else "未启动")
         livekit_lines = [
             f"LiveKit 配置      : {_mark(livekit_configured)} {vc.livekit_url or '未配置'}",
-            f"LiveKit worker    : {_mark(agent_ready)} {'registered worker' if agent_ready else ('启动中/未就绪' if agent_running else '未启动')}",
+            f"LiveKit worker    : {_mark(agent_ready)} {worker_detail}",
             f"唤醒监听          : {_mark(wake_loop_running and wake_configured)} {vc.wake_word or '未启用'}",
         ]
         if self.config.device_esp32.enabled:
+            esp32_wait = "" if esp32_online else "（等待健康检查）"
             livekit_lines.append(
-                f"ESP32 设备        : {_mark(esp32_online or esp32_seen)} {esp32_label}{'' if esp32_online else '（等待健康检查）'}"
+                f"ESP32 设备        : {_mark(esp32_online or esp32_seen)} {esp32_label}{esp32_wait}"
             )
         livekit_lines.append(f"通话状态          : {_mark(voice_ready)} {'ready' if voice_ready else 'not ready'}")
 

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -170,6 +170,7 @@ class LampgoServer:
             self.config.camera,
             device_esp32_config=self.config.device_esp32,
             esp32_manager=self.esp32,
+            allow_local_camera_fallback=bool(self.config.no_hw),
         )
 
     def _recording_actions_prompt(self) -> str:
@@ -1421,6 +1422,12 @@ class LampgoServer:
         virtual = bool(getattr(self.motion, "is_virtual", False))
         if not self.hal.is_connected and not virtual:
             health = "disconnected"
+        cat_teaser_camera = self._cat_teaser_camera_status()
+        camera_ready = (
+            bool(self.config.camera.port.strip())
+            or bool(self.config.device_esp32.enabled)
+            or bool(cat_teaser_camera.get("fallback"))
+        )
         return {
             "ok": True,
             "result": {
@@ -1435,9 +1442,41 @@ class LampgoServer:
                 "recording": self._record_status(),
                 "hal_connected": bool(self.hal.is_connected),
                 "led_ready": bool(self.led.is_connected),
-                "camera_ready": bool(self.config.camera.port.strip()) or bool(self.config.device_esp32.enabled),
+                "camera_ready": camera_ready,
+                "cat_teaser_camera": cat_teaser_camera,
                 "conversation_state": self._wake_loop.conversation_state.value if self._wake_loop else None,
             },
+        }
+
+    def _cat_teaser_camera_status(self) -> dict[str, Any]:
+        if self.config.device_esp32.enabled:
+            host = self.esp32.get_active_host() if self.esp32 else ""
+            return {
+                "mode": "esp32",
+                "label": f"esp32://{host}" if host else "esp32://(discovering)",
+                "fallback": False,
+                "hardware_present": bool(self.hal.is_connected) and not self.config.no_hw,
+            }
+        port = self.config.camera.port.strip()
+        if port:
+            return {
+                "mode": "local_configured",
+                "label": f"local://{port}",
+                "fallback": False,
+                "hardware_present": bool(self.hal.is_connected) and not self.config.no_hw,
+            }
+        if self.config.no_hw:
+            return {
+                "mode": "local_no_hw_fallback",
+                "label": "local://0 (fallback)",
+                "fallback": True,
+                "hardware_present": False,
+            }
+        return {
+            "mode": "none",
+            "label": "",
+            "fallback": False,
+            "hardware_present": bool(self.hal.is_connected),
         }
 
     def _handle_list_cameras(self) -> dict:

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -44,7 +44,7 @@ from lampgo.core.safety import SafetyKernel
 from lampgo.core.virtual_motion import VirtualMotionRuntime
 from lampgo.device import Esp32DeviceManager
 from lampgo.ipc import IPCServer
-from lampgo.perception.cat_teaser import CatTeaserFrameSource
+from lampgo.perception.cat_teaser import CatTeaserFrameSource, is_supported_local_camera_port
 from lampgo.perception.router import IntentRouter, IntentType
 from lampgo.recordings import build_recording_actions_prompt, write_recording_description
 from lampgo.skills.base import SkillContext
@@ -1428,11 +1428,7 @@ class LampgoServer:
         if not self.hal.is_connected and not virtual:
             health = "disconnected"
         cat_teaser_camera = self._cat_teaser_camera_status()
-        camera_ready = (
-            bool(self.config.camera.port.strip())
-            or bool(self.config.device_esp32.enabled)
-            or bool(cat_teaser_camera.get("fallback"))
-        )
+        camera_ready = self._cat_teaser_camera_ready(cat_teaser_camera)
         return {
             "ok": True,
             "result": {
@@ -1483,6 +1479,21 @@ class LampgoServer:
             "fallback": False,
             "hardware_present": bool(self.hal.is_connected),
         }
+
+    def _cat_teaser_camera_ready(self, camera_status: dict[str, Any] | None = None) -> bool:
+        camera_status = camera_status or self._cat_teaser_camera_status()
+        if bool(camera_status.get("fallback")):
+            return True
+        if bool(self.config.camera.port.strip()):
+            return True
+        if self.config.device_esp32.enabled:
+            esp32 = self._esp32_camera_info()
+            return (
+                bool(esp32.get("online"))
+                and not bool(esp32.get("hidden"))
+                and not bool(esp32.get("needs_firmware_update"))
+            )
+        return False
 
     def _handle_list_cameras(self) -> dict:
         """Probe camera indices 0..3 and return availability + names.
@@ -1593,6 +1604,17 @@ class LampgoServer:
             self.config.camera.port = ""
             logger.info("camera.switched_to_esp32")
         else:
+            if not is_supported_local_camera_port(value):
+                return {
+                    "ok": False,
+                    "error": "unsupported_camera_port",
+                    "result": {
+                        "active": "esp32" if self.config.device_esp32.enabled else self.config.camera.port,
+                        "camera_ready": self._cat_teaser_camera_ready(),
+                        "cat_teaser_camera": self._cat_teaser_camera_status(),
+                        "esp32": self._esp32_camera_info(),
+                    },
+                }
             self.config.device_esp32.enabled = False
             self.config.camera.port = value
             logger.info("camera.port_updated", port=value or "<disabled>")
@@ -1600,7 +1622,8 @@ class LampgoServer:
             "ok": True,
             "result": {
                 "active": "esp32" if self.config.device_esp32.enabled else self.config.camera.port,
-                "camera_ready": bool(value) or self.config.device_esp32.enabled,
+                "camera_ready": self._cat_teaser_camera_ready(),
+                "cat_teaser_camera": self._cat_teaser_camera_status(),
                 "esp32": self._esp32_camera_info(),
             },
         }

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -163,7 +163,12 @@ class LampgoServer:
         self.registry.register(LookAtSkill())
         self.registry.register(IdleSwaySkill())
         self.registry.register(DanceToMusicSkill())
-        self.registry.register(CatTeaserSkill(self._make_cat_teaser_frame_source))
+        self.registry.register(
+            CatTeaserSkill(
+                self._make_cat_teaser_frame_source,
+                allow_recording=not bool(self.config.no_hw),
+            )
+        )
 
     def _make_cat_teaser_frame_source(self) -> CatTeaserFrameSource:
         return CatTeaserFrameSource(

--- a/lampgo/skills/builtin/cat_teaser.py
+++ b/lampgo/skills/builtin/cat_teaser.py
@@ -147,8 +147,9 @@ class CatTeaserSkill(Skill):
             log_events = _bool_param(params.get("log_events"), default=True)
             save_recording_requested = _bool_param(params.get("save_recording"), default=True)
             recording_dir = str(params.get("recording_dir") or "").strip()
+            recording_base_dir = _recording_base_dir(recording_dir)
             tracker = CatToyTracker(marker_color=marker_color)
-        except ValueError as exc:
+        except (TypeError, ValueError) as exc:
             return SkillResult(status="error", message=str(exc))
 
         energy_scale = {"gentle": 0.72, "normal": 1.0, "active": 1.22}.get(energy, 1.0)
@@ -159,7 +160,7 @@ class CatTeaserSkill(Skill):
         save_recording = save_recording_requested and self._allow_recording
         recorder = _CatTeaserFrameRecorder(
             enabled=save_recording,
-            base_dir=_recording_base_dir(recording_dir),
+            base_dir=recording_base_dir,
             marker_color=marker_color,
             camera_fps=camera_fps,
         )
@@ -875,9 +876,13 @@ class _CatTeaserFrameRecorder:
 
 
 def _recording_base_dir(value: str) -> Path:
+    root = lampgo_home() / "cat_teaser_recordings"
     if value:
-        return Path(value).expanduser()
-    return lampgo_home() / "cat_teaser_recordings"
+        name = Path(value).name
+        if name != value or name in {"", ".", ".."}:
+            raise ValueError("recording_dir must be a simple subdirectory name")
+        return root / name
+    return root
 
 
 def _bool_param(value: Any, *, default: bool) -> bool:

--- a/lampgo/skills/builtin/cat_teaser.py
+++ b/lampgo/skills/builtin/cat_teaser.py
@@ -18,6 +18,7 @@ from lampgo.perception.cat_teaser import (
     CatPlayState,
     CatPlayStateEstimator,
     CatTeaserCameraError,
+    CatTeaserDebugView,
     CatTeaserDependencyError,
     CatTeaserFrameSource,
     CatToyTracker,
@@ -88,6 +89,20 @@ class CatTeaserSkill(Skill):
             default=8.0,
             description="Maximum wrist-pitch offset around the starting pose.",
         ),
+        "debug_view": ParameterSpec(
+            name="debug_view",
+            type="bool",
+            required=False,
+            default=True,
+            description="Show an OpenCV preview window with marker and state overlays.",
+        ),
+        "log_events": ParameterSpec(
+            name="log_events",
+            type="bool",
+            required=False,
+            default=True,
+            description="Print Chinese interaction events such as touch and pounce detections.",
+        ),
     }
 
     def __init__(self, frame_source_factory: FrameSourceFactory) -> None:
@@ -105,6 +120,8 @@ class CatTeaserSkill(Skill):
             max_yaw = max(1.0, min(45.0, abs(float(params.get("max_yaw", 25.0)))))
             max_pitch = max(1.0, min(28.0, abs(float(params.get("max_pitch", 14.0)))))
             max_wrist = max(0.0, min(18.0, abs(float(params.get("max_wrist_pitch", 8.0)))))
+            debug_view_enabled = _bool_param(params.get("debug_view"), default=True)
+            log_events = _bool_param(params.get("log_events"), default=True)
             tracker = CatToyTracker(marker_color=marker_color)
         except ValueError as exc:
             return SkillResult(status="error", message=str(exc))
@@ -112,6 +129,8 @@ class CatTeaserSkill(Skill):
         energy_scale = {"gentle": 0.72, "normal": 1.0, "active": 1.22}.get(energy, 1.0)
         frame_interval = 1.0 / camera_fps
         estimator = CatPlayStateEstimator()
+        debug_view = CatTeaserDebugView(enabled=debug_view_enabled)
+        event_tracker = _CatTeaserEventTracker(marker_color=marker_color, enabled=log_events)
         source = self._frame_source_factory()
         cancel_event = asyncio.Event()
         self._cancel_event = cancel_event
@@ -137,6 +156,12 @@ class CatTeaserSkill(Skill):
             await asyncio.to_thread(source.start)
             started_at = time.monotonic()
             end_at = started_at + duration
+            if log_events:
+                print(
+                    f"[cat_teaser] 0.0秒开始逗猫 marker_color={marker_color} "
+                    f"camera={source.device_label} debug_view={debug_view_enabled}",
+                    flush=True,
+                )
             while not cancel_event.is_set() and time.monotonic() < end_at:
                 tick_started = time.monotonic()
                 frame = await asyncio.to_thread(source.read)
@@ -160,6 +185,18 @@ class CatTeaserSkill(Skill):
 
                 if observation.state in {"caught", "unsafe_close", "pounce"}:
                     pause_until = max(pause_until, tick_started + self._pause_duration(observation.state))
+                elapsed_s = tick_started - started_at
+                event_text = event_tracker.update(observation, elapsed_s=elapsed_s)
+                debug_stop = debug_view.render(
+                    frame,
+                    observation,
+                    elapsed_s=elapsed_s,
+                    marker_color=marker_color,
+                    event_text=event_text,
+                )
+                if debug_stop:
+                    stop_reason = "debug_view_closed"
+                    break
                 target = self._target_for_observation(
                     observation,
                     anchor=anchor,
@@ -197,10 +234,14 @@ class CatTeaserSkill(Skill):
                     "engagement_peak": round(engagement_peak, 3),
                     "pounces": pounces,
                     "caught": catches,
+                    "event_counts": event_tracker.counts(),
+                    "events": event_tracker.events[-40:],
                     "stop_reason": stop_reason,
                     "camera": source.device_label,
                     "marker_color": marker_color,
                     "energy": energy,
+                    "debug_view": debug_view_enabled,
+                    "log_events": log_events,
                 },
             )
         except ValueError as exc:
@@ -216,6 +257,7 @@ class CatTeaserSkill(Skill):
             try:
                 ctx.motion.stop_smooth()
             finally:
+                debug_view.close()
                 await asyncio.to_thread(source.close)
                 self._cancel_event = None
                 self._source = None
@@ -324,3 +366,95 @@ class CatTeaserSkill(Skill):
         if state == "caught":
             return 0.65
         return 0.35
+
+
+class _CatTeaserEventTracker:
+    def __init__(self, *, marker_color: str, enabled: bool) -> None:
+        self.marker_color = marker_color
+        self.enabled = enabled
+        self.events: list[dict[str, Any]] = []
+        self._last_state: CatPlayState | None = None
+        self._last_marker_seen = False
+        self._last_emitted_at: dict[str, float] = {}
+
+    def update(self, observation: CatPlayObservation, *, elapsed_s: float) -> str | None:
+        marker_seen = observation.marker is not None
+        event_type, description = self._event_for_observation(observation, marker_seen)
+        self._last_state = observation.state
+        self._last_marker_seen = marker_seen
+        if event_type is None or description is None:
+            return None
+        if not self.enabled or not self._should_emit(event_type, elapsed_s):
+            return description
+
+        message = f"{elapsed_s:.1f}秒{description}"
+        record = {
+            "time_s": round(elapsed_s, 2),
+            "type": event_type,
+            "message": message,
+            "state": observation.state,
+            "motion_energy": round(observation.motion_energy, 4),
+            "engagement_score": round(observation.engagement_score, 4),
+            "marker_seen": marker_seen,
+        }
+        self.events.append(record)
+        self._last_emitted_at[event_type] = elapsed_s
+        print(
+            "[cat_teaser] "
+            f"{message} state={observation.state} motion={observation.motion_energy:.3f} "
+            f"engagement={observation.engagement_score:.2f} marker={'seen' if marker_seen else 'lost'}",
+            flush=True,
+        )
+        logger.info("cat_teaser.event", **record)
+        return description
+
+    def counts(self) -> dict[str, int]:
+        return dict(Counter(str(event["type"]) for event in self.events))
+
+    def _event_for_observation(
+        self,
+        observation: CatPlayObservation,
+        marker_seen: bool,
+    ) -> tuple[str | None, str | None]:
+        if observation.state == "caught":
+            return "touch", "有触碰动作"
+        if observation.state == "pounce":
+            return "pounce", "有扑击动作"
+        if observation.state == "unsafe_close":
+            return "unsafe_close", "距离过近，暂停撤离"
+        if marker_seen and not self._last_marker_seen:
+            return "marker_seen", f"识别到{self.marker_color}标记"
+        if not marker_seen and self._last_marker_seen:
+            return "marker_lost", f"{self.marker_color}标记丢失"
+        if observation.state == "engaged" and self._last_state not in {"engaged", "pounce", "caught"}:
+            return "engaged", "进入互动状态"
+        return None, None
+
+    def _should_emit(self, event_type: str, elapsed_s: float) -> bool:
+        last = self._last_emitted_at.get(event_type)
+        if last is None:
+            return True
+        gap = {
+            "touch": 0.65,
+            "pounce": 0.65,
+            "unsafe_close": 1.0,
+            "engaged": 1.2,
+            "marker_seen": 1.0,
+            "marker_lost": 1.0,
+        }.get(event_type, 1.0)
+        return elapsed_s - last >= gap
+
+
+def _bool_param(value: Any, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on", "enable", "enabled"}:
+        return True
+    if text in {"0", "false", "no", "n", "off", "disable", "disabled"}:
+        return False
+    return default

--- a/lampgo/skills/builtin/cat_teaser.py
+++ b/lampgo/skills/builtin/cat_teaser.py
@@ -127,8 +127,9 @@ class CatTeaserSkill(Skill):
         ),
     }
 
-    def __init__(self, frame_source_factory: FrameSourceFactory) -> None:
+    def __init__(self, frame_source_factory: FrameSourceFactory, *, allow_recording: bool = True) -> None:
         self._frame_source_factory = frame_source_factory
+        self._allow_recording = allow_recording
         self._cancel_event: asyncio.Event | None = None
         self._motion = None
         self._source: CatTeaserFrameSource | None = None
@@ -144,7 +145,7 @@ class CatTeaserSkill(Skill):
             max_wrist = max(0.0, min(18.0, abs(float(params.get("max_wrist_pitch", 8.0)))))
             debug_view_enabled = _bool_param(params.get("debug_view"), default=True)
             log_events = _bool_param(params.get("log_events"), default=True)
-            save_recording = _bool_param(params.get("save_recording"), default=True)
+            save_recording_requested = _bool_param(params.get("save_recording"), default=True)
             recording_dir = str(params.get("recording_dir") or "").strip()
             tracker = CatToyTracker(marker_color=marker_color)
         except ValueError as exc:
@@ -155,6 +156,7 @@ class CatTeaserSkill(Skill):
         estimator = CatPlayStateEstimator()
         debug_view = CatTeaserDebugView(enabled=debug_view_enabled)
         event_tracker = _CatTeaserEventTracker(marker_color=marker_color, enabled=log_events)
+        save_recording = save_recording_requested and self._allow_recording
         recorder = _CatTeaserFrameRecorder(
             enabled=save_recording,
             base_dir=_recording_base_dir(recording_dir),
@@ -196,9 +198,12 @@ class CatTeaserSkill(Skill):
             end_at = started_at + duration
             recorder.set_camera(source.device_label)
             if log_events:
+                if save_recording_requested and not self._allow_recording:
+                    print("[cat_teaser] --no-hw模式下不保存摄像头视频", flush=True)
                 print(
                     f"[cat_teaser] 0.0秒开始逗猫 marker_color={marker_color} "
-                    f"camera={source.device_label} debug_view={debug_view_enabled}",
+                    f"camera={source.device_label} debug_view={debug_view_enabled} "
+                    f"save_recording={save_recording}",
                     flush=True,
                 )
             while not cancel_event.is_set() and time.monotonic() < end_at:
@@ -369,8 +374,6 @@ class CatTeaserSkill(Skill):
             self._cancel_event.set()
         if self._motion is not None:
             self._motion.stop_smooth()
-        if self._source is not None:
-            await asyncio.to_thread(self._source.close)
 
     def _target_for_observation(
         self,

--- a/lampgo/skills/builtin/cat_teaser.py
+++ b/lampgo/skills/builtin/cat_teaser.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import math
 import time
 from collections import Counter
 from collections.abc import Callable
+from dataclasses import replace
+from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import structlog
@@ -23,6 +27,7 @@ from lampgo.perception.cat_teaser import (
     CatTeaserFrameSource,
     CatToyTracker,
 )
+from lampgo.personastore import lampgo_home
 from lampgo.skills.base import ParameterSpec, Skill, SkillContext
 
 logger = structlog.get_logger(__name__)
@@ -51,7 +56,7 @@ class CatTeaserSkill(Skill):
             name="marker_color",
             type="str",
             required=False,
-            default="magenta",
+            default="red",
             description="Colored marker on wand tip: magenta, green, blue, red, or yellow.",
         ),
         "energy": ParameterSpec(
@@ -103,6 +108,23 @@ class CatTeaserSkill(Skill):
             default=True,
             description="Print Chinese interaction events such as touch and pounce detections.",
         ),
+        "save_recording": ParameterSpec(
+            name="save_recording",
+            type="bool",
+            required=False,
+            default=True,
+            description="Save camera video from this cat_teaser run as a local MP4 session recording.",
+        ),
+        "recording_dir": ParameterSpec(
+            name="recording_dir",
+            type="str",
+            required=False,
+            default="",
+            description=(
+                "Base directory for saved cat_teaser camera sessions; "
+                "empty uses ~/.lampgo/cat_teaser_recordings."
+            ),
+        ),
     }
 
     def __init__(self, frame_source_factory: FrameSourceFactory) -> None:
@@ -114,7 +136,7 @@ class CatTeaserSkill(Skill):
     async def execute(self, ctx: SkillContext, **params: Any) -> SkillResult:
         try:
             duration = max(1.0, min(300.0, float(params.get("duration", 60.0))))
-            marker_color = str(params.get("marker_color") or "magenta").strip().lower()
+            marker_color = str(params.get("marker_color") or "red").strip().lower()
             energy = str(params.get("energy") or "normal").strip().lower()
             camera_fps = max(2.0, min(12.0, float(params.get("camera_fps", 8.0))))
             max_yaw = max(1.0, min(45.0, abs(float(params.get("max_yaw", 25.0)))))
@@ -122,6 +144,8 @@ class CatTeaserSkill(Skill):
             max_wrist = max(0.0, min(18.0, abs(float(params.get("max_wrist_pitch", 8.0)))))
             debug_view_enabled = _bool_param(params.get("debug_view"), default=True)
             log_events = _bool_param(params.get("log_events"), default=True)
+            save_recording = _bool_param(params.get("save_recording"), default=True)
+            recording_dir = str(params.get("recording_dir") or "").strip()
             tracker = CatToyTracker(marker_color=marker_color)
         except ValueError as exc:
             return SkillResult(status="error", message=str(exc))
@@ -131,6 +155,12 @@ class CatTeaserSkill(Skill):
         estimator = CatPlayStateEstimator()
         debug_view = CatTeaserDebugView(enabled=debug_view_enabled)
         event_tracker = _CatTeaserEventTracker(marker_color=marker_color, enabled=log_events)
+        recorder = _CatTeaserFrameRecorder(
+            enabled=save_recording,
+            base_dir=_recording_base_dir(recording_dir),
+            marker_color=marker_color,
+            camera_fps=camera_fps,
+        )
         source = self._frame_source_factory()
         cancel_event = asyncio.Event()
         self._cancel_event = cancel_event
@@ -151,11 +181,20 @@ class CatTeaserSkill(Skill):
         missing_frames = 0
         stop_reason = "duration"
         pause_until = 0.0
+        self_motion_suppression_until = 0.0
+        self_motion_suppressed = 0
+        previous_motion_target: dict[str, float] | None = dict(anchor)
+        escape_target: dict[str, float] | None = None
+        escape_until = 0.0
+        last_escape_at = 0.0
+        escape_direction = -1.0
+        escape_dashes = 0
 
         try:
             await asyncio.to_thread(source.start)
             started_at = time.monotonic()
             end_at = started_at + duration
+            recorder.set_camera(source.device_label)
             if log_events:
                 print(
                     f"[cat_teaser] 0.0秒开始逗猫 marker_color={marker_color} "
@@ -176,17 +215,61 @@ class CatTeaserSkill(Skill):
                 frames += 1
 
                 marker = tracker.track(frame)
-                observation = estimator.update(frame, marker, timestamp=tick_started)
+                raw_observation = estimator.update(frame, marker, timestamp=tick_started)
+                observation = self._suppress_self_motion_observation(
+                    raw_observation,
+                    now=tick_started,
+                    suppression_until=self_motion_suppression_until,
+                )
+                if observation.state != raw_observation.state:
+                    self_motion_suppressed += 1
                 state_counts[observation.state] += 1
                 marker_seen += 1 if marker is not None else 0
                 pounces += 1 if observation.state == "pounce" else 0
                 catches += 1 if observation.state == "caught" else 0
                 engagement_peak = max(engagement_peak, observation.engagement_score)
 
+                if observation.state == "unsafe_close":
+                    escape_target = None
+                    escape_until = 0.0
                 if observation.state in {"caught", "unsafe_close", "pounce"}:
                     pause_until = max(pause_until, tick_started + self._pause_duration(observation.state))
                 elapsed_s = tick_started - started_at
+                if observation.state == "caught" and tick_started - last_escape_at >= self._escape_cooldown():
+                    escape_direction = self._escape_direction(observation, previous_direction=escape_direction)
+                    escape_target = self._escape_target(
+                        anchor=anchor,
+                        direction=escape_direction,
+                        max_yaw=max_yaw,
+                        max_pitch=max_pitch,
+                        max_wrist=max_wrist,
+                    )
+                    escape_until = tick_started + self._escape_duration(energy_scale)
+                    last_escape_at = tick_started
+                    escape_dashes += 1
+                    pause_until = max(pause_until, escape_until + 0.12)
+                    direction_label = "right" if escape_direction > 0 else "left"
+                    if log_events:
+                        print(
+                            "[cat_teaser] "
+                            f"{elapsed_s:.1f}秒触碰后快速横向逃逸 direction={direction_label}",
+                            flush=True,
+                        )
+                    logger.info(
+                        "cat_teaser.escape_dash",
+                        time_s=round(elapsed_s, 2),
+                        direction=direction_label,
+                        escape_dashes=escape_dashes,
+                    )
                 event_text = event_tracker.update(observation, elapsed_s=elapsed_s)
+                recording_notice = recorder.write_frame(
+                    frame,
+                    observation=observation,
+                    elapsed_s=elapsed_s,
+                    event_text=event_text,
+                )
+                if log_events and recording_notice is not None:
+                    print(recording_notice, flush=True)
                 debug_stop = debug_view.render(
                     frame,
                     observation,
@@ -197,24 +280,36 @@ class CatTeaserSkill(Skill):
                 if debug_stop:
                     stop_reason = "debug_view_closed"
                     break
-                target = self._target_for_observation(
-                    observation,
-                    anchor=anchor,
-                    now=tick_started,
-                    started_at=started_at,
-                    pause_until=pause_until,
-                    energy_scale=energy_scale,
-                    max_yaw=max_yaw,
-                    max_pitch=max_pitch,
-                    max_wrist=max_wrist,
-                )
+                if tick_started < escape_until and escape_target is not None:
+                    target = escape_target
+                    max_velocity = self._escape_velocity(energy_scale)
+                else:
+                    target = self._target_for_observation(
+                        observation,
+                        anchor=anchor,
+                        now=tick_started,
+                        started_at=started_at,
+                        pause_until=pause_until,
+                        energy_scale=energy_scale,
+                        max_yaw=max_yaw,
+                        max_pitch=max_pitch,
+                        max_wrist=max_wrist,
+                    )
+                    max_velocity = self._velocity_for_state(observation.state, energy_scale)
                 ctx.motion.update_target(
                     MotionTarget(
                         joints=target,
-                        max_velocity=self._velocity_for_state(observation.state, energy_scale),
+                        max_velocity=max_velocity,
                         style="linear",
                     )
                 )
+                self_motion_suppression_until = self._updated_self_motion_suppression_until(
+                    previous_target=previous_motion_target,
+                    current_target=target,
+                    now=tick_started,
+                    current_until=self_motion_suppression_until,
+                )
+                previous_motion_target = target
 
                 elapsed = time.monotonic() - tick_started
                 if elapsed < frame_interval:
@@ -224,6 +319,8 @@ class CatTeaserSkill(Skill):
                 stop_reason = "cancelled"
             if frames == 0:
                 return SkillResult(status="error", message="cat_teaser camera did not provide frames")
+            recorder.close(stop_reason=stop_reason)
+            recording_summary = recorder.summary()
             return SkillResult(
                 status="cancelled" if stop_reason == "cancelled" else "ok",
                 data={
@@ -234,6 +331,8 @@ class CatTeaserSkill(Skill):
                     "engagement_peak": round(engagement_peak, 3),
                     "pounces": pounces,
                     "caught": catches,
+                    "escape_dashes": escape_dashes,
+                    "self_motion_suppressed": self_motion_suppressed,
                     "event_counts": event_tracker.counts(),
                     "events": event_tracker.events[-40:],
                     "stop_reason": stop_reason,
@@ -242,6 +341,7 @@ class CatTeaserSkill(Skill):
                     "energy": energy,
                     "debug_view": debug_view_enabled,
                     "log_events": log_events,
+                    "recording": recording_summary,
                 },
             )
         except ValueError as exc:
@@ -258,6 +358,7 @@ class CatTeaserSkill(Skill):
                 ctx.motion.stop_smooth()
             finally:
                 debug_view.close()
+                recorder.close(stop_reason=stop_reason)
                 await asyncio.to_thread(source.close)
                 self._cancel_event = None
                 self._source = None
@@ -347,6 +448,95 @@ class CatTeaserSkill(Skill):
         return target
 
     @staticmethod
+    def _suppress_self_motion_observation(
+        observation: CatPlayObservation,
+        *,
+        now: float,
+        suppression_until: float,
+    ) -> CatPlayObservation:
+        if now >= suppression_until or observation.state == "unsafe_close":
+            return observation
+        if observation.state == "caught":
+            state: CatPlayState = "engaged" if observation.marker is not None else "searching"
+            return replace(
+                observation,
+                state=state,
+                motion_energy=observation.motion_energy * 0.45,
+            )
+        if observation.state == "pounce" and observation.motion_energy < 0.45:
+            return replace(
+                observation,
+                state="engaged",
+                motion_energy=observation.motion_energy * 0.55,
+            )
+        return observation
+
+    @staticmethod
+    def _updated_self_motion_suppression_until(
+        *,
+        previous_target: dict[str, float] | None,
+        current_target: dict[str, float],
+        now: float,
+        current_until: float,
+    ) -> float:
+        if previous_target is None:
+            return current_until
+        delta = CatTeaserSkill._target_motion_delta(previous_target, current_target)
+        if delta < 6.5:
+            return current_until
+        window_s = min(0.38, max(0.18, 0.12 + delta * 0.012))
+        return max(current_until, now + window_s)
+
+    @staticmethod
+    def _target_motion_delta(previous_target: dict[str, float], current_target: dict[str, float]) -> float:
+        return (
+            abs(current_target.get("base_yaw", 0.0) - previous_target.get("base_yaw", 0.0))
+            + abs(current_target.get("base_pitch", 0.0) - previous_target.get("base_pitch", 0.0)) * 0.65
+            + abs(current_target.get("wrist_pitch", 0.0) - previous_target.get("wrist_pitch", 0.0)) * 0.45
+        )
+
+    @staticmethod
+    def _escape_direction(observation: CatPlayObservation, *, previous_direction: float) -> float:
+        x: float | None = None
+        if observation.motion_centroid is not None:
+            x = observation.motion_centroid[0]
+        elif observation.marker is not None:
+            x = observation.marker.normalized_x
+        if x is None or 0.45 <= x <= 0.55:
+            return -previous_direction if previous_direction else 1.0
+        return 1.0 if x < 0.5 else -1.0
+
+    @staticmethod
+    def _escape_duration(energy_scale: float) -> float:
+        return max(0.26, min(0.48, 0.36 * energy_scale))
+
+    @staticmethod
+    def _escape_cooldown() -> float:
+        return 1.15
+
+    def _escape_target(
+        self,
+        *,
+        anchor: dict[str, float],
+        direction: float,
+        max_yaw: float,
+        max_pitch: float,
+        max_wrist: float,
+    ) -> dict[str, float]:
+        yaw_span = min(max_yaw * 0.92, 28.0)
+        yaw_offset = math.copysign(max(12.0, yaw_span), direction)
+        offsets = {
+            "base_yaw": yaw_offset,
+            "base_pitch": -max_pitch * 0.28,
+            "wrist_pitch": -max_wrist * 0.32,
+        }
+        return self._bounded_target(anchor, offsets)
+
+    @staticmethod
+    def _escape_velocity(energy_scale: float) -> float:
+        return max(54.0, min(86.0, 78.0 * energy_scale))
+
+    @staticmethod
     def _velocity_for_state(state: CatPlayState, energy_scale: float) -> float:
         base = {
             "searching": 34.0,
@@ -394,6 +584,8 @@ class _CatTeaserEventTracker:
             "message": message,
             "state": observation.state,
             "motion_energy": round(observation.motion_energy, 4),
+            "contact_motion_energy": round(observation.contact_motion_energy, 4),
+            "marker_disturbance": round(observation.marker_disturbance, 4),
             "engagement_score": round(observation.engagement_score, 4),
             "marker_seen": marker_seen,
         }
@@ -402,6 +594,7 @@ class _CatTeaserEventTracker:
         print(
             "[cat_teaser] "
             f"{message} state={observation.state} motion={observation.motion_energy:.3f} "
+            f"contact={observation.contact_motion_energy:.3f} disturb={observation.marker_disturbance:.3f} "
             f"engagement={observation.engagement_score:.2f} marker={'seen' if marker_seen else 'lost'}",
             flush=True,
         )
@@ -443,6 +636,245 @@ class _CatTeaserEventTracker:
             "marker_lost": 1.0,
         }.get(event_type, 1.0)
         return elapsed_s - last >= gap
+
+
+class _CatTeaserFrameRecorder:
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        base_dir: Path,
+        marker_color: str,
+        camera_fps: float,
+    ) -> None:
+        self.enabled = enabled
+        self.base_dir = base_dir
+        self.marker_color = marker_color
+        self.camera_fps = camera_fps
+        self.camera = ""
+        self.session_dir: Path | None = None
+        self.video_path: Path | None = None
+        self.frames_written = 0
+        self.error: str | None = None
+        self._cv2 = None
+        self._writer = None
+        self._video_size: tuple[int, int] | None = None
+        self._metadata: dict[str, Any] = {}
+        self._invalid_frame_warned = False
+        self._closed = False
+
+    def set_camera(self, camera: str) -> None:
+        self.camera = camera
+
+    def write_frame(
+        self,
+        frame,
+        *,
+        observation: CatPlayObservation,
+        elapsed_s: float,
+        event_text: str | None,
+    ) -> str | None:
+        if not self.enabled or self._closed:
+            return None
+        if not self._is_image_frame(frame):
+            if not self._invalid_frame_warned:
+                self._invalid_frame_warned = True
+                self.error = "camera frame is not an image; recording skipped"
+            return None
+
+        try:
+            video_frame = self._prepare_video_frame(frame)
+            if video_frame is None:
+                return None
+            notice = self._ensure_session(video_frame)
+            if self.session_dir is None or self.video_path is None or video_frame is None:
+                return notice
+
+            writer = self._ensure_video_writer(video_frame)
+            if writer is None:
+                return notice
+
+            frame_index = self.frames_written + 1
+            writer.write(video_frame)
+            self.frames_written = frame_index
+            self._append_frame_record(frame_index, observation, elapsed_s, event_text)
+            return notice
+        except Exception as exc:
+            self.error = f"recording failed: {exc}"
+            self.enabled = False
+            logger.warning("cat_teaser.recording_failed", error=str(exc), base_dir=str(self.base_dir))
+            return None
+
+    def close(self, *, stop_reason: str) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._writer is not None:
+            try:
+                self._writer.release()
+            except Exception:
+                logger.debug("cat_teaser.video_release_failed", exc_info=True)
+            finally:
+                self._writer = None
+        if self.session_dir is None:
+            return
+        self._metadata.update(
+            {
+                "finished_at": datetime.now().isoformat(timespec="seconds"),
+                "frames_written": self.frames_written,
+                "stop_reason": stop_reason,
+                "error": self.error,
+            }
+        )
+        try:
+            self._write_json(self.session_dir / "metadata.json", self._metadata)
+        except Exception as exc:
+            self.error = f"failed to finalize recording metadata: {exc}"
+            logger.warning("cat_teaser.recording_finalize_failed", error=str(exc), path=str(self.session_dir))
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "path": str(self.session_dir) if self.session_dir is not None else None,
+            "video_path": str(self.video_path) if self.video_path is not None else None,
+            "frames_written": self.frames_written,
+            "events_path": str(self.session_dir / "frames.jsonl") if self.session_dir is not None else None,
+            "metadata_path": str(self.session_dir / "metadata.json") if self.session_dir is not None else None,
+            "error": self.error,
+        }
+
+    @staticmethod
+    def _is_image_frame(frame) -> bool:
+        shape = getattr(frame, "shape", None)
+        if shape is None or len(shape) < 2:
+            return False
+        return len(shape) == 2 or (len(shape) == 3 and shape[2] in {1, 3, 4})
+
+    def _ensure_session(self, frame) -> str | None:
+        if self.session_dir is not None:
+            return None
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        session_dir = (self.base_dir / f"{timestamp}-{self.marker_color}").expanduser()
+        session_dir.mkdir(parents=True, exist_ok=True)
+        self.session_dir = session_dir
+        self.video_path = session_dir / "cat_teaser.mp4"
+
+        height, width = frame.shape[:2]
+        self._metadata = {
+            "started_at": datetime.now().isoformat(timespec="seconds"),
+            "marker_color": self.marker_color,
+            "camera": self.camera,
+            "camera_fps": self.camera_fps,
+            "frame_width": int(width),
+            "frame_height": int(height),
+            "video": "cat_teaser.mp4",
+            "video_codec": "mp4v",
+            "frames_jsonl": "frames.jsonl",
+            "frames_written": 0,
+            "stop_reason": None,
+            "error": None,
+        }
+        self._write_json(self.session_dir / "metadata.json", self._metadata)
+        return f"[cat_teaser] 摄像头视频保存到 {self.video_path}"
+
+    def _ensure_cv2(self):
+        if self._cv2 is not None:
+            return self._cv2
+        try:
+            import cv2
+        except ImportError:
+            self.error = "OpenCV is not available; recording skipped"
+            return None
+        self._cv2 = cv2
+        return cv2
+
+    def _prepare_video_frame(self, frame):
+        cv2 = self._ensure_cv2()
+        if cv2 is None:
+            return None
+        shape = getattr(frame, "shape", None)
+        if shape is None or len(shape) < 2:
+            return None
+        if len(shape) == 2:
+            out = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
+        elif len(shape) == 3 and shape[2] == 4:
+            out = cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
+        elif len(shape) == 3 and shape[2] == 1:
+            out = cv2.cvtColor(frame[:, :, 0], cv2.COLOR_GRAY2BGR)
+        else:
+            out = frame
+        if getattr(out, "dtype", None) != "uint8" and hasattr(out, "astype"):
+            out = out.astype("uint8")
+        height, width = out.shape[:2]
+        even_width = width - (width % 2)
+        even_height = height - (height % 2)
+        if even_width <= 0 or even_height <= 0:
+            return None
+        if even_width != width or even_height != height:
+            out = out[:even_height, :even_width]
+        if self._video_size is not None and (out.shape[1], out.shape[0]) != self._video_size:
+            out = cv2.resize(out, self._video_size)
+        return out
+
+    def _ensure_video_writer(self, frame):
+        if self._writer is not None:
+            return self._writer
+        cv2 = self._ensure_cv2()
+        if cv2 is None or self.video_path is None:
+            return None
+        height, width = frame.shape[:2]
+        self._video_size = (int(width), int(height))
+        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+        writer = cv2.VideoWriter(str(self.video_path), fourcc, float(self.camera_fps), self._video_size)
+        if not writer.isOpened():
+            self.error = f"failed to open mp4 writer: {self.video_path}"
+            self.enabled = False
+            return None
+        self._writer = writer
+        return writer
+
+    def _append_frame_record(
+        self,
+        frame_index: int,
+        observation: CatPlayObservation,
+        elapsed_s: float,
+        event_text: str | None,
+    ) -> None:
+        if self.session_dir is None:
+            return
+        marker = observation.marker
+        record = {
+            "frame": frame_index,
+            "elapsed_s": round(elapsed_s, 3),
+            "state": observation.state,
+            "motion_energy": round(observation.motion_energy, 4),
+            "contact_motion_energy": round(observation.contact_motion_energy, 4),
+            "marker_disturbance": round(observation.marker_disturbance, 4),
+            "engagement_score": round(observation.engagement_score, 4),
+            "motion_centroid": observation.motion_centroid,
+            "event": event_text,
+            "marker": None
+            if marker is None
+            else {
+                "x": round(marker.x, 2),
+                "y": round(marker.y, 2),
+                "radius": round(marker.radius, 2),
+                "area": round(marker.area, 2),
+                "confidence": round(marker.confidence, 4),
+            },
+        }
+        with (self.session_dir / "frames.jsonl").open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    @staticmethod
+    def _write_json(path: Path, data: dict[str, Any]) -> None:
+        path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _recording_base_dir(value: str) -> Path:
+    if value:
+        return Path(value).expanduser()
+    return lampgo_home() / "cat_teaser_recordings"
 
 
 def _bool_param(value: Any, *, default: bool) -> bool:

--- a/lampgo/skills/builtin/cat_teaser.py
+++ b/lampgo/skills/builtin/cat_teaser.py
@@ -1,0 +1,326 @@
+"""Local vision cat teaser skill."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from collections import Counter
+from collections.abc import Callable
+from typing import Any
+
+import structlog
+
+from lampgo.core.config import DEFAULT_JOINT_LIMITS
+from lampgo.core.types import MotionTarget, SkillResult
+from lampgo.perception.cat_teaser import (
+    CatPlayObservation,
+    CatPlayState,
+    CatPlayStateEstimator,
+    CatTeaserCameraError,
+    CatTeaserDependencyError,
+    CatTeaserFrameSource,
+    CatToyTracker,
+)
+from lampgo.skills.base import ParameterSpec, Skill, SkillContext
+
+logger = structlog.get_logger(__name__)
+
+FrameSourceFactory = Callable[[], CatTeaserFrameSource]
+
+
+class CatTeaserSkill(Skill):
+    """Play with a cat using a colored-marker teaser wand and local vision."""
+
+    skill_id = "cat_teaser"
+    label = "逗猫棒互动"
+    description = (
+        "Track a colored marker on a cat teaser wand, estimate cat engagement "
+        "from local motion, and drive playful bounded lamp-head motion."
+    )
+    parameters = {
+        "duration": ParameterSpec(
+            name="duration",
+            type="float",
+            required=False,
+            default=60.0,
+            description="Seconds to play; default 60.",
+        ),
+        "marker_color": ParameterSpec(
+            name="marker_color",
+            type="str",
+            required=False,
+            default="magenta",
+            description="Colored marker on wand tip: magenta, green, blue, red, or yellow.",
+        ),
+        "energy": ParameterSpec(
+            name="energy",
+            type="str",
+            required=False,
+            default="normal",
+            description="Motion intensity: gentle, normal, or active.",
+        ),
+        "camera_fps": ParameterSpec(
+            name="camera_fps",
+            type="float",
+            required=False,
+            default=8.0,
+            description="Camera processing FPS, clamped to 2-12.",
+        ),
+        "max_yaw": ParameterSpec(
+            name="max_yaw",
+            type="float",
+            required=False,
+            default=25.0,
+            description="Maximum yaw offset around the starting pose.",
+        ),
+        "max_pitch": ParameterSpec(
+            name="max_pitch",
+            type="float",
+            required=False,
+            default=14.0,
+            description="Maximum base-pitch offset around the starting pose.",
+        ),
+        "max_wrist_pitch": ParameterSpec(
+            name="max_wrist_pitch",
+            type="float",
+            required=False,
+            default=8.0,
+            description="Maximum wrist-pitch offset around the starting pose.",
+        ),
+    }
+
+    def __init__(self, frame_source_factory: FrameSourceFactory) -> None:
+        self._frame_source_factory = frame_source_factory
+        self._cancel_event: asyncio.Event | None = None
+        self._motion = None
+        self._source: CatTeaserFrameSource | None = None
+
+    async def execute(self, ctx: SkillContext, **params: Any) -> SkillResult:
+        try:
+            duration = max(1.0, min(300.0, float(params.get("duration", 60.0))))
+            marker_color = str(params.get("marker_color") or "magenta").strip().lower()
+            energy = str(params.get("energy") or "normal").strip().lower()
+            camera_fps = max(2.0, min(12.0, float(params.get("camera_fps", 8.0))))
+            max_yaw = max(1.0, min(45.0, abs(float(params.get("max_yaw", 25.0)))))
+            max_pitch = max(1.0, min(28.0, abs(float(params.get("max_pitch", 14.0)))))
+            max_wrist = max(0.0, min(18.0, abs(float(params.get("max_wrist_pitch", 8.0)))))
+            tracker = CatToyTracker(marker_color=marker_color)
+        except ValueError as exc:
+            return SkillResult(status="error", message=str(exc))
+
+        energy_scale = {"gentle": 0.72, "normal": 1.0, "active": 1.22}.get(energy, 1.0)
+        frame_interval = 1.0 / camera_fps
+        estimator = CatPlayStateEstimator()
+        source = self._frame_source_factory()
+        cancel_event = asyncio.Event()
+        self._cancel_event = cancel_event
+        self._source = source
+        self._motion = ctx.motion
+
+        anchor = {
+            "base_yaw": ctx.state.get("base_yaw", 0.0),
+            "base_pitch": ctx.state.get("base_pitch", 0.0),
+            "wrist_pitch": ctx.state.get("wrist_pitch", 0.0),
+        }
+        state_counts: Counter[str] = Counter()
+        frames = 0
+        marker_seen = 0
+        pounces = 0
+        catches = 0
+        engagement_peak = 0.0
+        missing_frames = 0
+        stop_reason = "duration"
+        pause_until = 0.0
+
+        try:
+            await asyncio.to_thread(source.start)
+            started_at = time.monotonic()
+            end_at = started_at + duration
+            while not cancel_event.is_set() and time.monotonic() < end_at:
+                tick_started = time.monotonic()
+                frame = await asyncio.to_thread(source.read)
+                if frame is None:
+                    missing_frames += 1
+                    if missing_frames >= max(2, int(camera_fps * 2)):
+                        stop_reason = "camera_lost"
+                        break
+                    await asyncio.sleep(frame_interval)
+                    continue
+                missing_frames = 0
+                frames += 1
+
+                marker = tracker.track(frame)
+                observation = estimator.update(frame, marker, timestamp=tick_started)
+                state_counts[observation.state] += 1
+                marker_seen += 1 if marker is not None else 0
+                pounces += 1 if observation.state == "pounce" else 0
+                catches += 1 if observation.state == "caught" else 0
+                engagement_peak = max(engagement_peak, observation.engagement_score)
+
+                if observation.state in {"caught", "unsafe_close", "pounce"}:
+                    pause_until = max(pause_until, tick_started + self._pause_duration(observation.state))
+                target = self._target_for_observation(
+                    observation,
+                    anchor=anchor,
+                    now=tick_started,
+                    started_at=started_at,
+                    pause_until=pause_until,
+                    energy_scale=energy_scale,
+                    max_yaw=max_yaw,
+                    max_pitch=max_pitch,
+                    max_wrist=max_wrist,
+                )
+                ctx.motion.update_target(
+                    MotionTarget(
+                        joints=target,
+                        max_velocity=self._velocity_for_state(observation.state, energy_scale),
+                        style="linear",
+                    )
+                )
+
+                elapsed = time.monotonic() - tick_started
+                if elapsed < frame_interval:
+                    await asyncio.sleep(frame_interval - elapsed)
+
+            if cancel_event.is_set():
+                stop_reason = "cancelled"
+            if frames == 0:
+                return SkillResult(status="error", message="cat_teaser camera did not provide frames")
+            return SkillResult(
+                status="cancelled" if stop_reason == "cancelled" else "ok",
+                data={
+                    "duration": round(time.monotonic() - started_at, 2),
+                    "frames": frames,
+                    "marker_seen": marker_seen,
+                    "state_counts": dict(state_counts),
+                    "engagement_peak": round(engagement_peak, 3),
+                    "pounces": pounces,
+                    "caught": catches,
+                    "stop_reason": stop_reason,
+                    "camera": source.device_label,
+                    "marker_color": marker_color,
+                    "energy": energy,
+                },
+            )
+        except ValueError as exc:
+            return SkillResult(status="error", message=str(exc))
+        except CatTeaserDependencyError as exc:
+            return SkillResult(status="error", message=str(exc))
+        except CatTeaserCameraError as exc:
+            return SkillResult(status="error", message=str(exc))
+        except Exception as exc:
+            logger.exception("cat_teaser.failed")
+            return SkillResult(status="error", message=str(exc))
+        finally:
+            try:
+                ctx.motion.stop_smooth()
+            finally:
+                await asyncio.to_thread(source.close)
+                self._cancel_event = None
+                self._source = None
+                self._motion = None
+
+    async def cancel(self) -> None:
+        if self._cancel_event is not None:
+            self._cancel_event.set()
+        if self._motion is not None:
+            self._motion.stop_smooth()
+        if self._source is not None:
+            await asyncio.to_thread(self._source.close)
+
+    def _target_for_observation(
+        self,
+        observation: CatPlayObservation,
+        *,
+        anchor: dict[str, float],
+        now: float,
+        started_at: float,
+        pause_until: float,
+        energy_scale: float,
+        max_yaw: float,
+        max_pitch: float,
+        max_wrist: float,
+    ) -> dict[str, float]:
+        state = observation.state
+        if state == "unsafe_close":
+            offsets = {"base_yaw": 0.0, "base_pitch": -max_pitch * 0.55, "wrist_pitch": -max_wrist * 0.7}
+            return self._bounded_target(anchor, offsets)
+        if now < pause_until:
+            offsets = {"base_yaw": 0.0, "base_pitch": -max_pitch * 0.35, "wrist_pitch": -max_wrist * 0.45}
+            return self._bounded_target(anchor, offsets)
+
+        elapsed = now - started_at
+        state_amp = {
+            "searching": 0.42,
+            "teasing": 0.55,
+            "engaged": 0.88,
+            "pounce": 0.35,
+            "caught": 0.18,
+            "rest": 0.28,
+            "unsafe_close": 0.0,
+        }.get(state, 0.5)
+        state_rate = {
+            "searching": 1.0,
+            "teasing": 1.25,
+            "engaged": 1.85,
+            "pounce": 0.8,
+            "caught": 0.65,
+            "rest": 0.55,
+            "unsafe_close": 0.0,
+        }.get(state, 1.0)
+        amp = state_amp * energy_scale
+        phase = elapsed * state_rate
+        yaw_offset = math.sin(phase) * max_yaw * amp
+        pitch_offset = math.sin(phase * 1.9 + math.pi / 2.0) * max_pitch * amp * 0.55
+        wrist_offset = math.cos(phase * 1.35) * max_wrist * amp
+
+        if observation.marker is not None:
+            dx = observation.marker.normalized_x - 0.5
+            dy = observation.marker.normalized_y - 0.5
+            yaw_offset += dx * max_yaw * 0.35
+            pitch_offset += dy * max_pitch * 0.25
+
+        if state == "pounce":
+            yaw_offset *= 0.35
+            pitch_offset -= max_pitch * 0.3
+            wrist_offset -= max_wrist * 0.45
+
+        offsets = {
+            "base_yaw": yaw_offset,
+            "base_pitch": pitch_offset,
+            "wrist_pitch": wrist_offset,
+        }
+        return self._bounded_target(anchor, offsets)
+
+    @staticmethod
+    def _bounded_target(anchor: dict[str, float], offsets: dict[str, float]) -> dict[str, float]:
+        target: dict[str, float] = {}
+        for joint, offset in offsets.items():
+            value = anchor.get(joint, 0.0) + float(offset)
+            limits = DEFAULT_JOINT_LIMITS.get(joint)
+            if limits is not None:
+                value = max(limits.min, min(limits.max, value))
+            target[joint] = value
+        return target
+
+    @staticmethod
+    def _velocity_for_state(state: CatPlayState, energy_scale: float) -> float:
+        base = {
+            "searching": 34.0,
+            "teasing": 42.0,
+            "engaged": 62.0,
+            "pounce": 38.0,
+            "caught": 26.0,
+            "rest": 24.0,
+            "unsafe_close": 22.0,
+        }.get(state, 36.0)
+        return max(18.0, min(78.0, base * energy_scale))
+
+    @staticmethod
+    def _pause_duration(state: CatPlayState) -> float:
+        if state == "unsafe_close":
+            return 0.9
+        if state == "caught":
+            return 0.65
+        return 0.35

--- a/lampgo/skills/executor.py
+++ b/lampgo/skills/executor.py
@@ -21,7 +21,7 @@ PRIORITY_SKILLS = {"estop", "return_safe"}
 
 _MOTION_SKILLS = {
     "nod", "headshake", "look_at", "idle_sway",
-    "dance_to_music",
+    "dance_to_music", "cat_teaser",
     "move_to", "return_safe", "estop",
     "presence_react", "face_follow",
     "play_recording", "teleop_mouse", "teleop_gamepad",

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -158,6 +158,7 @@
     look_at: { title: "注视", description: "朝指定方向看过去。" },
     idle_sway: { title: "随机摆动", description: "轻微随机摆动，呈现呼吸般的灵动感。" },
     dance_to_music: { title: "跟音乐跳舞", description: "读取音乐节奏，按风格预设做明确律动。" },
+    cat_teaser: { title: "逗猫棒互动", description: "识别逗猫棒彩色标记，根据猫咪互动状态实时摆动。" },
     move_to: { title: "移动到目标", description: "以平滑的梯形插值移动到目标关节位置。" },
     return_safe: { title: "回到安全位", description: "平滑回到固定的待机安全姿态。" },
     presence_react: { title: "人来反应", description: "检测到人时转向并展示问候表情。" },
@@ -3061,7 +3062,7 @@
   let userSkillQuery = "";
   let recordingQuery = "";
   let expressionQuery = "";
-  const FACTORY_SKILL_VISIBLE_IDS = new Set(["return_safe", "idle_sway", "dance_to_music"]);
+  const FACTORY_SKILL_VISIBLE_IDS = new Set(["return_safe", "idle_sway", "dance_to_music", "cat_teaser"]);
 
   function renderEmptyCell(grid, text) {
     const empty = document.createElement("div");

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -79,6 +79,13 @@
   const recordStartDesc = document.getElementById("record-start-desc");
   const recordTimer = document.getElementById("record-timer");
   const recordMetrics = document.getElementById("record-metrics");
+  const catTeaserDialog = document.getElementById("cat-teaser-dialog");
+  const catTeaserForm = document.getElementById("cat-teaser-form");
+  const catTeaserDurationInput = document.getElementById("cat-teaser-duration-input");
+  const catTeaserMarkerSelect = document.getElementById("cat-teaser-marker-select");
+  const catTeaserHardwareNotice = document.getElementById("cat-teaser-hardware-notice");
+  const catTeaserError = document.getElementById("cat-teaser-error");
+  const btnCatTeaserCancel = document.getElementById("btn-cat-teaser-cancel");
   const playbackModeButtons = Array.from(document.querySelectorAll("[data-playback-mode]"));
   const navButtons = Array.from(document.querySelectorAll(".nav-item[data-view]"));
   const viewSections = Array.from(document.querySelectorAll(".view[data-view]"));
@@ -179,6 +186,7 @@
 
   const expressionMetaByName = new Map();
   const recordingExpressionByName = new Map();
+  let latestStatusData = {};
 
   function expressionMeta(name) {
     return expressionMetaByName.get(String(name || ""));
@@ -2936,6 +2944,7 @@
 
   function updateStatus(data) {
     if (!data) return;
+    latestStatusData = data || {};
 
     const healthy = data.device_health === "ok" && !data.estopped;
     const jointEntries = Object.entries(data.joint_positions || {});
@@ -2965,7 +2974,12 @@
         chipCameraDot.classList.toggle("is-online", online);
         chipCameraDot.classList.toggle("is-offline", !online);
       }
-      chipCamera.title = online ? "摄像头已接入" : "摄像头未配置";
+      const catCamera = data.cat_teaser_camera || {};
+      if (data.no_hw && catCamera.fallback) {
+        chipCamera.title = "无硬件模式：逗猫将尝试使用电脑摄像头 local://0";
+      } else {
+        chipCamera.title = online ? "摄像头已接入" : "摄像头未配置";
+      }
     }
 
     if (chipLed) {
@@ -2978,6 +2992,7 @@
       }
       chipLed.title = online ? "LED 控制器已连接" : "LED 控制器未连接";
     }
+    if (catTeaserDialog && catTeaserDialog.open) renderCatTeaserHardwareNotice();
 
     if (isJointPopoverOpen()) renderJointPopoverContent();
     if (data.running_skill === "dance_to_music") {
@@ -3127,7 +3142,10 @@
         title: label.title,
         meta: label.description,
         tooltip: `${label.description}（${skill.skill_id}）`,
-        onClick: () => invokeSkill(skill.skill_id),
+        onClick: () => {
+          if (skill.skill_id === "cat_teaser") openCatTeaserDialog(skill);
+          else invokeSkill(skill.skill_id);
+        },
       });
       skillGrid.appendChild(card);
     });
@@ -3667,12 +3685,90 @@
 
   /* ---- Invoke actions ---- */
 
-  function invokeSkill(skillId) {
+  function skillParamDefault(skill, name, fallback) {
+    const params = skill && skill.parameters;
+    const spec = params && params[name];
+    if (!spec || spec.default === undefined || spec.default === null || spec.default === "") return fallback;
+    return spec.default;
+  }
+
+  function clampNumber(value, min, max, fallback) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return fallback;
+    return Math.max(min, Math.min(max, n));
+  }
+
+  function openCatTeaserDialog(skill) {
+    if (!catTeaserDialog || !catTeaserForm) {
+      invokeSkill("cat_teaser", { duration: 60, marker_color: "red" }, "逗猫棒互动 · 60 秒 · 红色标识");
+      return;
+    }
+    catTeaserDialog.dataset.skillId = "cat_teaser";
+    const duration = clampNumber(skillParamDefault(skill, "duration", 60), 1, 300, 60);
+    const marker = String(skillParamDefault(skill, "marker_color", "red") || "red").trim().toLowerCase();
+    if (catTeaserDurationInput) catTeaserDurationInput.value = String(duration);
+    if (catTeaserMarkerSelect) {
+      const hasMarkerOption = Array.from(catTeaserMarkerSelect.options).some((option) => option.value === marker);
+      catTeaserMarkerSelect.value = hasMarkerOption ? marker : "red";
+    }
+    if (catTeaserError) catTeaserError.textContent = "";
+    renderCatTeaserHardwareNotice();
+    catTeaserDialog.showModal();
+    if (catTeaserDurationInput) catTeaserDurationInput.focus();
+  }
+
+  function closeCatTeaserDialog() {
+    if (!catTeaserDialog || !catTeaserDialog.open) return;
+    catTeaserDialog.close();
+  }
+
+  function startCatTeaserFromDialog() {
+    const duration = clampNumber(catTeaserDurationInput && catTeaserDurationInput.value, 1, 300, 60);
+    const markerColor = String((catTeaserMarkerSelect && catTeaserMarkerSelect.value) || "red").trim().toLowerCase();
+    if (!duration) {
+      if (catTeaserError) catTeaserError.textContent = "请输入持续时间";
+      if (catTeaserDurationInput) catTeaserDurationInput.focus();
+      return;
+    }
+    if (catTeaserError) catTeaserError.textContent = "";
+    closeCatTeaserDialog();
+    invokeSkill(
+      "cat_teaser",
+      { duration, marker_color: markerColor },
+      `逗猫棒互动 · ${duration} 秒 · ${catTeaserMarkerLabel(markerColor)}标识`
+    );
+  }
+
+  function renderCatTeaserHardwareNotice() {
+    if (!catTeaserHardwareNotice) return;
+    const status = latestStatusData || {};
+    const catCamera = status.cat_teaser_camera || {};
+    let text = "";
+    if (status.no_hw && catCamera.fallback) {
+      text = "当前是无硬件模式：没有 LampGo 本体机械臂/灯头摄像头。逗猫算法会尝试使用电脑摄像头 local://0 作为 fallback，并通过虚拟运动模拟动作。";
+    } else if (status.no_hw || status.virtual_motion || status.hal_connected === false) {
+      text = "当前没有检测到 LampGo 本体硬件；逗猫动作不会驱动真实机械臂。";
+    }
+    catTeaserHardwareNotice.textContent = text;
+    catTeaserHardwareNotice.hidden = !text;
+  }
+
+  function catTeaserMarkerLabel(value) {
+    return {
+      red: "红色",
+      magenta: "品红",
+      green: "绿色",
+      blue: "蓝色",
+      yellow: "黄色",
+    }[value] || value || "红色";
+  }
+
+  function invokeSkill(skillId, params = {}, stepLabel = null) {
     clearEmptyState();
     const requestId = nextId();
     const bubble = addAssistantBubble(requestId);
-    addStep(getPreludeArea(ensureActivityLog(bubble)), `调用 ${skillId}`, "active");
-    send({ type: "invoke", skill_id: skillId, params: {}, wait: true, request_id: requestId });
+    addStep(getPreludeArea(ensureActivityLog(bubble)), `调用 ${stepLabel || skillId}`, "active");
+    send({ type: "invoke", skill_id: skillId, params: params || {}, wait: true, request_id: requestId });
   }
 
   function setMusicModeActive(active, requestId = null) {
@@ -6196,6 +6292,17 @@ registerProcessor("esp32-pcm-processor", Esp32PcmProcessor);
           if (recordEditError) recordEditError.textContent = `保存失败：${err && err.message ? err.message : err}`;
         });
     });
+  }
+
+  if (catTeaserForm) {
+    catTeaserForm.addEventListener("submit", (e) => {
+      e.preventDefault();
+      startCatTeaserFromDialog();
+    });
+  }
+
+  if (btnCatTeaserCancel) {
+    btnCatTeaserCancel.addEventListener("click", () => closeCatTeaserDialog());
   }
 
   if (btnRecordEditCancel) {

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -83,6 +83,7 @@
   const catTeaserForm = document.getElementById("cat-teaser-form");
   const catTeaserDurationInput = document.getElementById("cat-teaser-duration-input");
   const catTeaserMarkerSelect = document.getElementById("cat-teaser-marker-select");
+  const catTeaserSaveRecordingInput = document.getElementById("cat-teaser-save-recording-input");
   const catTeaserHardwareNotice = document.getElementById("cat-teaser-hardware-notice");
   const catTeaserError = document.getElementById("cat-teaser-error");
   const btnCatTeaserCancel = document.getElementById("btn-cat-teaser-cancel");
@@ -2306,6 +2307,12 @@
     closeCameraPopover();
   }
 
+  function cameraSetErrorLabel(error) {
+    if (error === "esp32_firmware_update_required") return "ESP32 摄像头固件版本过旧，请先更新固件后再启用。";
+    if (error === "esp32_paired_to_other") return "ESP32 摄像头已配对到其他设备，请先在设备上解除或重新配网。";
+    return `摄像头切换失败：${error || "未知错误"}`;
+  }
+
   if (chipCamera) {
     chipCamera.style.cursor = "pointer";
     chipCamera.classList.add("is-clickable");
@@ -2398,6 +2405,13 @@
         repopulateCameraPortSelect(displayPort);
         maybeSyncInitialEsp32Volume();
         if (isCameraPopoverOpen()) renderCameraPopover(false);
+        send({ type: "status", request_id: `cam_refresh_${Date.now()}` });
+      } else {
+        if (msg.result && msg.result.esp32) cameraCache.esp32 = msg.result.esp32;
+        const message = cameraSetErrorLabel(msg.error);
+        if (chipCamera) chipCamera.title = message;
+        addSystemMessage(message);
+        send({ type: "list_cameras", request_id: `cam_recover_${Date.now()}` });
         send({ type: "status", request_id: `cam_refresh_${Date.now()}` });
       }
       return;
@@ -3698,9 +3712,26 @@
     return Math.max(min, Math.min(max, n));
   }
 
+  function isCatTeaserNoHwMode() {
+    const status = latestStatusData || {};
+    return Boolean(status.no_hw);
+  }
+
+  function syncCatTeaserRecordingControlAvailability() {
+    if (!catTeaserSaveRecordingInput) return;
+    const noHw = isCatTeaserNoHwMode();
+    catTeaserSaveRecordingInput.disabled = noHw;
+    catTeaserSaveRecordingInput.title = noHw ? "--no-hw 模式下不保存摄像头视频" : "保存本次摄像头视频 MP4";
+    if (noHw) catTeaserSaveRecordingInput.checked = false;
+  }
+
   function openCatTeaserDialog(skill) {
     if (!catTeaserDialog || !catTeaserForm) {
-      invokeSkill("cat_teaser", { duration: 60, marker_color: "red" }, "逗猫棒互动 · 60 秒 · 红色标识");
+      invokeSkill(
+        "cat_teaser",
+        { duration: 60, marker_color: "red", save_recording: !isCatTeaserNoHwMode() },
+        "逗猫棒互动 · 60 秒 · 红色标识"
+      );
       return;
     }
     catTeaserDialog.dataset.skillId = "cat_teaser";
@@ -3711,6 +3742,10 @@
       const hasMarkerOption = Array.from(catTeaserMarkerSelect.options).some((option) => option.value === marker);
       catTeaserMarkerSelect.value = hasMarkerOption ? marker : "red";
     }
+    if (catTeaserSaveRecordingInput) {
+      catTeaserSaveRecordingInput.checked = Boolean(skillParamDefault(skill, "save_recording", true));
+    }
+    syncCatTeaserRecordingControlAvailability();
     if (catTeaserError) catTeaserError.textContent = "";
     renderCatTeaserHardwareNotice();
     catTeaserDialog.showModal();
@@ -3725,6 +3760,9 @@
   function startCatTeaserFromDialog() {
     const duration = clampNumber(catTeaserDurationInput && catTeaserDurationInput.value, 1, 300, 60);
     const markerColor = String((catTeaserMarkerSelect && catTeaserMarkerSelect.value) || "red").trim().toLowerCase();
+    const saveRecording = catTeaserSaveRecordingInput
+      ? Boolean(catTeaserSaveRecordingInput.checked && !catTeaserSaveRecordingInput.disabled)
+      : !isCatTeaserNoHwMode();
     if (!duration) {
       if (catTeaserError) catTeaserError.textContent = "请输入持续时间";
       if (catTeaserDurationInput) catTeaserDurationInput.focus();
@@ -3734,7 +3772,7 @@
     closeCatTeaserDialog();
     invokeSkill(
       "cat_teaser",
-      { duration, marker_color: markerColor },
+      { duration, marker_color: markerColor, save_recording: saveRecording },
       `逗猫棒互动 · ${duration} 秒 · ${catTeaserMarkerLabel(markerColor)}标识`
     );
   }
@@ -3745,10 +3783,13 @@
     const catCamera = status.cat_teaser_camera || {};
     let text = "";
     if (status.no_hw && catCamera.fallback) {
-      text = "当前是无硬件模式：没有 LampGo 本体机械臂/灯头摄像头。逗猫算法会尝试使用电脑摄像头 local://0 作为 fallback，并通过虚拟运动模拟动作。";
-    } else if (status.no_hw || status.virtual_motion || status.hal_connected === false) {
+      text = "当前是无硬件模式：没有 LampGo 本体机械臂/灯头摄像头。逗猫算法会尝试使用电脑摄像头 local://0 作为 fallback，并通过虚拟运动模拟动作；本次不会保存摄像头视频。";
+    } else if (status.no_hw) {
+      text = "当前是无硬件模式：没有 LampGo 本体机械臂/灯头摄像头；本次不会保存摄像头视频。";
+    } else if (status.virtual_motion || status.hal_connected === false) {
       text = "当前没有检测到 LampGo 本体硬件；逗猫动作不会驱动真实机械臂。";
     }
+    syncCatTeaserRecordingControlAvailability();
     catTeaserHardwareNotice.textContent = text;
     catTeaserHardwareNotice.hidden = !text;
   }

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -1202,6 +1202,44 @@
     </form>
   </dialog>
 
+  <dialog id="cat-teaser-dialog" class="record-dialog">
+    <form id="cat-teaser-form" class="record-dialog-card">
+      <div class="record-dialog-title">逗猫棒互动</div>
+      <div id="cat-teaser-hardware-notice" class="cat-teaser-hardware-notice" hidden></div>
+      <label class="record-dialog-field">
+        <span class="record-dialog-label">持续时间</span>
+        <div class="cat-teaser-duration-row">
+          <input
+            id="cat-teaser-duration-input"
+            class="record-dialog-input"
+            type="number"
+            min="1"
+            max="300"
+            step="1"
+            value="60"
+            inputmode="numeric"
+          >
+          <span class="cat-teaser-duration-unit">秒</span>
+        </div>
+      </label>
+      <label class="record-dialog-field">
+        <span class="record-dialog-label">标识颜色</span>
+        <select id="cat-teaser-marker-select" class="record-dialog-input record-dialog-select">
+          <option value="red">红色</option>
+          <option value="magenta">品红</option>
+          <option value="green">绿色</option>
+          <option value="blue">蓝色</option>
+          <option value="yellow">黄色</option>
+        </select>
+      </label>
+      <div id="cat-teaser-error" class="record-dialog-error"></div>
+      <div class="record-dialog-actions">
+        <button id="btn-cat-teaser-cancel" class="ghost-button" type="button">取消</button>
+        <button id="btn-cat-teaser-start" class="send-button" type="submit">开始逗猫</button>
+      </div>
+    </form>
+  </dialog>
+
   <dialog id="esp32-setup-dialog" class="esp32-setup-dialog">
     <div class="esp32-setup-card">
       <div class="esp32-setup-head">

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -1232,6 +1232,10 @@
           <option value="yellow">黄色</option>
         </select>
       </label>
+      <label class="cat-teaser-recording-row">
+        <input id="cat-teaser-save-recording-input" type="checkbox" checked>
+        <span>保存本次摄像头视频 MP4</span>
+      </label>
       <div id="cat-teaser-error" class="record-dialog-error"></div>
       <div class="record-dialog-actions">
         <button id="btn-cat-teaser-cancel" class="ghost-button" type="button">取消</button>

--- a/lampgo/web/static/style.css
+++ b/lampgo/web/static/style.css
@@ -3345,6 +3345,25 @@ button.device-chip.is-active {
   padding: 9px 11px;
 }
 
+.cat-teaser-recording-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-main);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.cat-teaser-recording-row input {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+}
+
+.cat-teaser-recording-row:has(input:disabled) {
+  color: var(--text-soft);
+}
+
 /* ============= Scrollbar ============= */
 
 ::-webkit-scrollbar {

--- a/lampgo/web/static/style.css
+++ b/lampgo/web/static/style.css
@@ -3322,6 +3322,29 @@ button.device-chip.is-active {
   gap: 8px;
 }
 
+.cat-teaser-duration-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.cat-teaser-duration-unit {
+  color: var(--text-soft);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.cat-teaser-hardware-notice {
+  border: 1px solid #efd0c7;
+  background: #fff7f2;
+  border-radius: 10px;
+  color: #8a5148;
+  font-size: 13px;
+  line-height: 1.55;
+  padding: 9px 11px;
+}
+
 /* ============= Scrollbar ============= */
 
 ::-webkit-scrollbar {

--- a/tests/test_cat_teaser.py
+++ b/tests/test_cat_teaser.py
@@ -3,31 +3,58 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
+from lampgo.core.config import CameraConfig
 from lampgo.core.events import EventBus
 from lampgo.core.types import JointState
+from lampgo.perception import cat_teaser as cat_perception_mod
 from lampgo.perception.cat_teaser import (
     CatPlayObservation,
     CatPlayStateEstimator,
+    CatTeaserCameraError,
     CatTeaserDebugView,
+    CatTeaserFrameSource,
     CatToyTracker,
     MarkerDetection,
 )
 from lampgo.skills.builtin import cat_teaser as cat_skill_mod
 from lampgo.skills.builtin.cat_teaser import CatTeaserSkill
 
+_POUNCE_RECTS = (
+    (96, 56, 40, 40),
+    (96, 144, 40, 40),
+    (184, 56, 40, 40),
+    (184, 144, 40, 40),
+)
 
-def _magenta_frame(*, with_marker: bool = True, motion_size: int = 0) -> np.ndarray:
+
+def _magenta_frame(
+    *,
+    with_marker: bool = True,
+    motion_size: int = 0,
+    marker_center: tuple[int, int] = (160, 120),
+    motion_origin: tuple[int, int] = (176, 105),
+    motion_rect: tuple[int, int, int, int] | None = None,
+    motion_rects: tuple[tuple[int, int, int, int], ...] = (),
+) -> np.ndarray:
     cv2 = pytest.importorskip("cv2")
     frame = np.zeros((240, 320, 3), dtype=np.uint8)
     if with_marker:
-        cv2.circle(frame, (160, 120), 16, (255, 0, 255), -1)
+        cv2.circle(frame, marker_center, 16, (255, 0, 255), -1)
+    if motion_rect is not None:
+        x, y, width, height = motion_rect
+        cv2.rectangle(frame, (x, y), (x + width, y + height), (255, 255, 255), -1)
+    for x, y, width, height in motion_rects:
+        cv2.rectangle(frame, (x, y), (x + width, y + height), (255, 255, 255), -1)
     if motion_size:
-        cv2.rectangle(frame, (176, 105), (176 + motion_size, 105 + motion_size), (255, 255, 255), -1)
+        x, y = motion_origin
+        cv2.rectangle(frame, (x, y), (x + motion_size, y + motion_size), (255, 255, 255), -1)
     return frame
 
 
@@ -68,9 +95,21 @@ def test_cat_play_state_estimator_transitions_on_synthetic_motion() -> None:
     estimator = CatPlayStateEstimator()
 
     teasing = estimator.update(_magenta_frame(), tracker.track(_magenta_frame()), timestamp=1.0)
-    engaged = estimator.update(_magenta_frame(motion_size=24), tracker.track(_magenta_frame()), timestamp=1.2)
-    pounce = estimator.update(_magenta_frame(motion_size=96), tracker.track(_magenta_frame()), timestamp=1.4)
-    caught = estimator.update(_magenta_frame(with_marker=False, motion_size=96), None, timestamp=1.6)
+    engaged = estimator.update(_magenta_frame(motion_size=44), tracker.track(_magenta_frame()), timestamp=1.2)
+    estimator.update(_magenta_frame(), tracker.track(_magenta_frame()), timestamp=1.3)
+    estimator.update(
+        _magenta_frame(motion_rects=_POUNCE_RECTS),
+        tracker.track(_magenta_frame()),
+        timestamp=1.4,
+    )
+    pounce = estimator.update(_magenta_frame(), tracker.track(_magenta_frame()), timestamp=1.6)
+    estimator.update(_magenta_frame(with_marker=False, motion_size=96, motion_origin=(96, 64)), None, timestamp=1.8)
+    estimator.update(_magenta_frame(with_marker=False), None, timestamp=2.0)
+    caught = estimator.update(
+        _magenta_frame(with_marker=False, motion_size=96, motion_origin=(96, 64)),
+        None,
+        timestamp=2.2,
+    )
 
     rest = caught
     for idx in range(12):
@@ -81,6 +120,95 @@ def test_cat_play_state_estimator_transitions_on_synthetic_motion() -> None:
     assert pounce.state == "pounce"
     assert caught.state == "caught"
     assert rest.state == "rest"
+
+
+def test_cat_play_state_estimator_ignores_marker_self_motion() -> None:
+    pytest.importorskip("cv2")
+    tracker = CatToyTracker(marker_color="magenta")
+    estimator = CatPlayStateEstimator()
+
+    frame_1 = _magenta_frame(marker_center=(140, 120))
+    frame_2 = _magenta_frame(marker_center=(190, 120))
+    frame_3 = _magenta_frame(marker_center=(220, 120))
+
+    estimator.update(frame_1, tracker.track(frame_1), timestamp=1.0)
+    moved = estimator.update(frame_2, tracker.track(frame_2), timestamp=1.2)
+    moved_again = estimator.update(frame_3, tracker.track(frame_3), timestamp=1.4)
+
+    assert moved.motion_energy < 0.045
+    assert moved.state == "teasing"
+    assert moved_again.state == "teasing"
+
+
+def test_cat_play_state_estimator_detects_visible_marker_contact() -> None:
+    pytest.importorskip("cv2")
+    tracker = CatToyTracker(marker_color="magenta")
+    estimator = CatPlayStateEstimator()
+
+    baseline = _magenta_frame()
+    estimator.update(baseline, tracker.track(baseline), timestamp=1.0)
+    touched = _magenta_frame(marker_center=(164, 122), motion_rect=(178, 96, 70, 70))
+
+    observation = estimator.update(touched, tracker.track(touched), timestamp=1.2)
+
+    assert observation.marker is not None
+    assert observation.motion_energy > 0.15
+    assert observation.contact_motion_energy > 0.27
+    assert observation.marker_disturbance > 0.05
+    assert observation.state == "caught"
+
+
+def test_cat_play_state_estimator_ignores_near_tip_hand_when_marker_is_stable() -> None:
+    pytest.importorskip("cv2")
+    tracker = CatToyTracker(marker_color="magenta")
+    estimator = CatPlayStateEstimator()
+
+    baseline = _magenta_frame()
+    estimator.update(baseline, tracker.track(baseline), timestamp=1.0)
+    near_tip_hand = _magenta_frame(motion_rect=(178, 96, 70, 70))
+
+    observation = estimator.update(near_tip_hand, tracker.track(near_tip_hand), timestamp=1.2)
+
+    assert observation.marker is not None
+    assert observation.contact_motion_energy > 0.24
+    assert observation.marker_disturbance == 0.0
+    assert observation.state != "caught"
+
+
+def test_cat_play_state_estimator_ignores_nearby_hand_without_tip_contact() -> None:
+    pytest.importorskip("cv2")
+    tracker = CatToyTracker(marker_color="magenta")
+    estimator = CatPlayStateEstimator()
+
+    baseline = _magenta_frame()
+    estimator.update(baseline, tracker.track(baseline), timestamp=1.0)
+    nearby_hand = _magenta_frame(motion_rect=(190, 80, 100, 100))
+
+    observation = estimator.update(nearby_hand, tracker.track(nearby_hand), timestamp=1.2)
+
+    assert observation.marker is not None
+    assert observation.motion_energy > 0.16
+    assert observation.state != "caught"
+
+
+def test_cat_play_state_estimator_ignores_brief_marker_loss() -> None:
+    pytest.importorskip("cv2")
+    tracker = CatToyTracker(marker_color="magenta")
+    estimator = CatPlayStateEstimator()
+
+    estimator.update(_magenta_frame(), tracker.track(_magenta_frame()), timestamp=1.0)
+    estimator.update(_magenta_frame(), tracker.track(_magenta_frame()), timestamp=1.1)
+    estimator.update(_magenta_frame(), tracker.track(_magenta_frame()), timestamp=1.2)
+    estimator.update(_magenta_frame(motion_rects=_POUNCE_RECTS), tracker.track(_magenta_frame()), timestamp=1.3)
+    pounce = estimator.update(_magenta_frame(), tracker.track(_magenta_frame()), timestamp=1.4)
+    lost_1 = estimator.update(_magenta_frame(with_marker=False, motion_size=96), None, timestamp=1.5)
+    lost_2 = estimator.update(_magenta_frame(with_marker=False), None, timestamp=1.6)
+    reacquired = estimator.update(_magenta_frame(), tracker.track(_magenta_frame()), timestamp=1.7)
+
+    assert pounce.state == "pounce"
+    assert lost_1.state == "searching"
+    assert lost_2.state == "searching"
+    assert reacquired.state != "caught"
 
 
 def test_cat_teaser_debug_view_disabled_is_noop() -> None:
@@ -95,6 +223,66 @@ def test_cat_teaser_debug_view_disabled_is_noop() -> None:
     )
 
     assert view.render(object(), observation, elapsed_s=0.0, marker_color="red") is False
+
+
+class _FakeVideoCapture:
+    def __init__(self, device, *, opened: bool = True) -> None:
+        self.device = device
+        self.opened = opened
+        self.released = False
+        self.props: dict[int, float] = {}
+
+    def isOpened(self) -> bool:
+        return self.opened
+
+    def set(self, prop: int, value: float) -> None:
+        self.props[prop] = value
+
+    def read(self):
+        return True, np.zeros((240, 320, 3), dtype=np.uint8)
+
+    def release(self) -> None:
+        self.released = True
+
+
+class _FakeCv2:
+    CAP_PROP_FRAME_WIDTH = 3
+    CAP_PROP_FRAME_HEIGHT = 4
+
+    def __init__(self) -> None:
+        self.devices: list[int | str] = []
+        self.captures: list[_FakeVideoCapture] = []
+
+    def VideoCapture(self, device, backend=None):  # noqa: N802 - mirror cv2 API
+        del backend
+        self.devices.append(device)
+        cap = _FakeVideoCapture(device)
+        self.captures.append(cap)
+        return cap
+
+
+def test_cat_teaser_frame_source_uses_local_camera_fallback(monkeypatch) -> None:
+    fake_cv2 = _FakeCv2()
+    monkeypatch.setattr(cat_perception_mod, "_import_cv2", lambda: fake_cv2)
+    source = CatTeaserFrameSource(CameraConfig(port=""), allow_local_camera_fallback=True)
+
+    source.start()
+    frame = source.read()
+
+    assert source.enabled is True
+    assert fake_cv2.devices == [0]
+    assert source.device_label == "local://0 (fallback)"
+    assert frame is not None
+    source.close()
+    assert fake_cv2.captures[0].released is True
+
+
+def test_cat_teaser_frame_source_requires_camera_without_fallback() -> None:
+    source = CatTeaserFrameSource(CameraConfig(port=""))
+
+    assert source.enabled is False
+    with pytest.raises(CatTeaserCameraError):
+        source.start()
 
 
 class _FakeFrameSource:
@@ -114,6 +302,12 @@ class _FakeFrameSource:
 
     def close(self) -> None:
         self.closed = True
+
+
+class _ImageFrameSource(_FakeFrameSource):
+    def read(self):
+        self.reads += 1
+        return _magenta_frame()
 
 
 class _FakeTracker:
@@ -147,6 +341,23 @@ class _FakeEstimator:
             motion_energy=0.1,
             engagement_score=score,
             motion_centroid=(0.5, 0.5),
+            timestamp=1.0,
+        )
+
+
+class _CaughtFirstEstimator:
+    def __init__(self) -> None:
+        self.states = iter(["caught", "engaged", "engaged"])
+
+    def update(self, frame, marker, *, timestamp=None) -> CatPlayObservation:
+        del frame, timestamp
+        state = next(self.states, "engaged")
+        return CatPlayObservation(
+            state=state,
+            marker=marker,
+            motion_energy=0.5 if state == "caught" else 0.08,
+            engagement_score=0.8 if state == "caught" else 0.4,
+            motion_centroid=(0.25, 0.5),
             timestamp=1.0,
         )
 
@@ -207,6 +418,88 @@ async def test_cat_teaser_skill_emits_bounded_linear_targets(monkeypatch) -> Non
         assert abs(target.joints["wrist_pitch"]) <= 8.0
 
 
+def test_cat_teaser_self_motion_suppression_downgrades_false_grabs() -> None:
+    marker = MarkerDetection(
+        x=160,
+        y=120,
+        radius=12,
+        area=400,
+        confidence=0.8,
+        frame_width=320,
+        frame_height=240,
+    )
+    caught = CatPlayObservation(
+        state="caught",
+        marker=None,
+        motion_energy=0.4,
+        engagement_score=0.7,
+        motion_centroid=(0.5, 0.5),
+        timestamp=1.0,
+    )
+    pounce = CatPlayObservation(
+        state="pounce",
+        marker=marker,
+        motion_energy=0.25,
+        engagement_score=0.7,
+        motion_centroid=(0.5, 0.5),
+        timestamp=1.0,
+    )
+    unsafe = CatPlayObservation(
+        state="unsafe_close",
+        marker=marker,
+        motion_energy=0.25,
+        engagement_score=0.0,
+        motion_centroid=(0.5, 0.5),
+        timestamp=1.0,
+    )
+
+    assert CatTeaserSkill._suppress_self_motion_observation(
+        caught,
+        now=1.0,
+        suppression_until=1.2,
+    ).state == "searching"
+    assert CatTeaserSkill._suppress_self_motion_observation(
+        pounce,
+        now=1.0,
+        suppression_until=1.2,
+    ).state == "engaged"
+    assert CatTeaserSkill._suppress_self_motion_observation(
+        unsafe,
+        now=1.0,
+        suppression_until=1.2,
+    ).state == "unsafe_close"
+    assert CatTeaserSkill._suppress_self_motion_observation(
+        caught,
+        now=1.3,
+        suppression_until=1.2,
+    ).state == "caught"
+
+
+@pytest.mark.asyncio
+async def test_cat_teaser_skill_escape_dashes_on_caught(monkeypatch) -> None:
+    source = _FakeFrameSource()
+    monkeypatch.setattr(cat_skill_mod, "CatToyTracker", _FakeTracker)
+    monkeypatch.setattr(cat_skill_mod, "CatPlayStateEstimator", _CaughtFirstEstimator)
+    motion = _FakeMotion()
+    skill = CatTeaserSkill(lambda: source)
+
+    result = await skill.execute(
+        _fake_context(motion),
+        duration=0.18,
+        camera_fps=12,
+        max_yaw=25,
+        max_pitch=14,
+        max_wrist_pitch=8,
+        debug_view=False,
+        log_events=False,
+    )
+
+    assert result.status == "ok"
+    assert result.data["escape_dashes"] >= 1
+    assert any(target.max_velocity >= 70.0 for target in motion.targets)
+    assert any(target.joints["base_yaw"] >= 12.0 for target in motion.targets)
+
+
 @pytest.mark.asyncio
 async def test_cat_teaser_skill_cancels_cleanly(monkeypatch) -> None:
     source = _FakeFrameSource()
@@ -233,7 +526,7 @@ async def test_cat_teaser_skill_cancels_cleanly(monkeypatch) -> None:
 async def test_cat_teaser_skill_prints_touch_event_log(monkeypatch, capsys) -> None:
     source = _FakeFrameSource()
     monkeypatch.setattr(cat_skill_mod, "CatToyTracker", _FakeTracker)
-    monkeypatch.setattr(cat_skill_mod, "CatPlayStateEstimator", _FakeEstimator)
+    monkeypatch.setattr(cat_skill_mod, "CatPlayStateEstimator", _CaughtFirstEstimator)
     motion = _FakeMotion()
     skill = CatTeaserSkill(lambda: source)
 
@@ -242,8 +535,59 @@ async def test_cat_teaser_skill_prints_touch_event_log(monkeypatch, capsys) -> N
 
     assert result.status == "ok"
     assert "有触碰动作" in out
+    assert "contact=" in out
+    assert "disturb=" in out
     assert result.data["event_counts"]["touch"] >= 1
     assert any(event["type"] == "touch" for event in result.data["events"])
+
+
+@pytest.mark.asyncio
+async def test_cat_teaser_skill_saves_camera_video(monkeypatch, tmp_path) -> None:
+    cv2 = pytest.importorskip("cv2")
+    source = _ImageFrameSource()
+    monkeypatch.setattr(cat_skill_mod, "CatToyTracker", _FakeTracker)
+    monkeypatch.setattr(cat_skill_mod, "CatPlayStateEstimator", _FakeEstimator)
+    motion = _FakeMotion()
+    skill = CatTeaserSkill(lambda: source)
+
+    result = await skill.execute(
+        _fake_context(motion),
+        duration=0.25,
+        camera_fps=12,
+        debug_view=False,
+        log_events=False,
+        recording_dir=str(tmp_path),
+    )
+
+    recording = result.data["recording"]
+    session_dir = Path(recording["path"])
+    video_path = session_dir / "cat_teaser.mp4"
+    frame_records = (session_dir / "frames.jsonl").read_text(encoding="utf-8").splitlines()
+    metadata = json.loads((session_dir / "metadata.json").read_text(encoding="utf-8"))
+
+    assert result.status == "ok"
+    assert session_dir.parent == tmp_path
+    assert recording["enabled"] is True
+    assert recording["video_path"] == str(video_path)
+    assert video_path.exists()
+    assert video_path.stat().st_size > 0
+    capture = cv2.VideoCapture(str(video_path))
+    try:
+        assert capture.isOpened()
+        ok, decoded_frame = capture.read()
+        assert ok is True
+        assert decoded_frame is not None
+    finally:
+        capture.release()
+    assert recording["frames_written"] >= 1
+    assert len(frame_records) == recording["frames_written"]
+    first_record = json.loads(frame_records[0])
+    assert first_record["frame"] == 1
+    assert first_record["state"] in {"teasing", "engaged", "pounce", "caught", "unsafe_close"}
+    assert metadata["marker_color"] == "red"
+    assert metadata["video"] == "cat_teaser.mp4"
+    assert metadata["video_codec"] == "mp4v"
+    assert metadata["frames_written"] == recording["frames_written"]
 
 
 @pytest.mark.asyncio
@@ -271,7 +615,28 @@ def test_cat_teaser_is_registered_and_exposes_parameters() -> None:
     cat_teaser = next(skill for skill in skills if skill["skill_id"] == "cat_teaser")
 
     assert cat_teaser["label"] == "逗猫棒互动"
-    assert cat_teaser["parameters"]["marker_color"]["default"] == "magenta"
+    assert cat_teaser["parameters"]["marker_color"]["default"] == "red"
     assert cat_teaser["parameters"]["duration"]["default"] == 60.0
     assert cat_teaser["parameters"]["debug_view"]["default"] is True
     assert cat_teaser["parameters"]["log_events"]["default"] is True
+    assert cat_teaser["parameters"]["save_recording"]["default"] is True
+    assert cat_teaser["parameters"]["recording_dir"]["default"] == ""
+
+
+def test_no_hw_server_enables_cat_teaser_local_camera_fallback() -> None:
+    from lampgo.core.config import LampgoConfig
+    from lampgo.server import LampgoServer
+
+    server = LampgoServer(LampgoConfig(no_hw=True))
+    source = server._make_cat_teaser_frame_source()
+    status = server._handle_status()["result"]
+
+    assert source.enabled is True
+    assert source.device_label == "local://0 (fallback)"
+    assert status["camera_ready"] is True
+    assert status["cat_teaser_camera"] == {
+        "mode": "local_no_hw_fallback",
+        "label": "local://0 (fallback)",
+        "fallback": True,
+        "hardware_present": False,
+    }

--- a/tests/test_cat_teaser.py
+++ b/tests/test_cat_teaser.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-from lampgo.core.config import CameraConfig
+from lampgo.core.config import CameraConfig, DeviceConfig, DeviceEsp32Config, LampgoConfig
 from lampgo.core.events import EventBus
 from lampgo.core.types import JointState
 from lampgo.perception import cat_teaser as cat_perception_mod
@@ -285,6 +285,19 @@ def test_cat_teaser_frame_source_requires_camera_without_fallback() -> None:
         source.start()
 
 
+def test_cat_teaser_frame_source_rejects_non_local_camera_strings(monkeypatch) -> None:
+    fake_cv2 = _FakeCv2()
+    monkeypatch.setattr(cat_perception_mod, "_import_cv2", lambda: fake_cv2)
+    source = CatTeaserFrameSource(CameraConfig(port="https://example.invalid/stream.mjpg"))
+
+    with pytest.raises(CatTeaserCameraError):
+        source.start()
+
+    assert source.enabled is False
+    assert fake_cv2.devices == []
+    assert source.device_label == ""
+
+
 class _FakeFrameSource:
     device_label = "fake://camera"
 
@@ -547,6 +560,7 @@ async def test_cat_teaser_skill_prints_touch_event_log(monkeypatch, capsys) -> N
 @pytest.mark.asyncio
 async def test_cat_teaser_skill_saves_camera_video(monkeypatch, tmp_path) -> None:
     cv2 = pytest.importorskip("cv2")
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
     source = _ImageFrameSource()
     monkeypatch.setattr(cat_skill_mod, "CatToyTracker", _FakeTracker)
     monkeypatch.setattr(cat_skill_mod, "CatPlayStateEstimator", _FakeEstimator)
@@ -559,7 +573,7 @@ async def test_cat_teaser_skill_saves_camera_video(monkeypatch, tmp_path) -> Non
         camera_fps=12,
         debug_view=False,
         log_events=False,
-        recording_dir=str(tmp_path),
+        recording_dir="session-tests",
     )
 
     recording = result.data["recording"]
@@ -569,7 +583,7 @@ async def test_cat_teaser_skill_saves_camera_video(monkeypatch, tmp_path) -> Non
     metadata = json.loads((session_dir / "metadata.json").read_text(encoding="utf-8"))
 
     assert result.status == "ok"
-    assert session_dir.parent == tmp_path
+    assert session_dir.parent == tmp_path / "cat_teaser_recordings" / "session-tests"
     assert recording["enabled"] is True
     assert recording["video_path"] == str(video_path)
     assert video_path.exists()
@@ -596,6 +610,7 @@ async def test_cat_teaser_skill_saves_camera_video(monkeypatch, tmp_path) -> Non
 @pytest.mark.asyncio
 async def test_cat_teaser_skill_disables_recording_when_not_allowed(monkeypatch, tmp_path) -> None:
     pytest.importorskip("cv2")
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
     source = _ImageFrameSource()
     monkeypatch.setattr(cat_skill_mod, "CatToyTracker", _FakeTracker)
     monkeypatch.setattr(cat_skill_mod, "CatPlayStateEstimator", _FakeEstimator)
@@ -609,13 +624,40 @@ async def test_cat_teaser_skill_disables_recording_when_not_allowed(monkeypatch,
         debug_view=False,
         log_events=False,
         save_recording=True,
-        recording_dir=str(tmp_path),
+        recording_dir="session-tests",
     )
 
     assert result.status == "ok"
     assert result.data["recording"]["enabled"] is False
     assert result.data["recording"]["video_path"] is None
-    assert not list(tmp_path.iterdir())
+    assert not (tmp_path / "cat_teaser_recordings").exists()
+
+
+@pytest.mark.asyncio
+async def test_cat_teaser_skill_rejects_unsafe_recording_dir() -> None:
+    source = _FakeFrameSource()
+    motion = _FakeMotion()
+    skill = CatTeaserSkill(lambda: source)
+
+    result = await skill.execute(_fake_context(motion), recording_dir="/tmp/cat-videos")
+
+    assert result.status == "error"
+    assert "recording_dir must be a simple subdirectory name" in result.message
+    assert source.started is False
+    assert motion.stopped is False
+
+
+@pytest.mark.asyncio
+async def test_cat_teaser_skill_returns_error_for_bad_numeric_param() -> None:
+    source = _FakeFrameSource()
+    motion = _FakeMotion()
+    skill = CatTeaserSkill(lambda: source)
+
+    result = await skill.execute(_fake_context(motion), duration=None)
+
+    assert result.status == "error"
+    assert source.started is False
+    assert motion.stopped is False
 
 
 @pytest.mark.asyncio
@@ -652,7 +694,6 @@ def test_cat_teaser_is_registered_and_exposes_parameters() -> None:
 
 
 def test_no_hw_server_enables_cat_teaser_local_camera_fallback() -> None:
-    from lampgo.core.config import LampgoConfig
     from lampgo.server import LampgoServer
 
     server = LampgoServer(LampgoConfig(no_hw=True))
@@ -668,3 +709,42 @@ def test_no_hw_server_enables_cat_teaser_local_camera_fallback() -> None:
         "fallback": True,
         "hardware_present": False,
     }
+
+
+def test_server_rejects_unsupported_camera_port() -> None:
+    from lampgo.server import LampgoServer
+
+    server = LampgoServer(
+        LampgoConfig(
+            device=DeviceConfig(motor_port="/dev/null"),
+            camera=CameraConfig(port="0"),
+        )
+    )
+
+    result = server._handle_set_camera("https://example.invalid/stream.mjpg")
+
+    assert result["ok"] is False
+    assert result["error"] == "unsupported_camera_port"
+    assert server.config.camera.port == "0"
+    assert server.config.device_esp32.enabled is False
+
+
+def test_server_marks_offline_esp32_camera_not_ready() -> None:
+    from lampgo.server import LampgoServer
+
+    server = LampgoServer(
+        LampgoConfig(
+            device=DeviceConfig(motor_port="/dev/null"),
+            device_esp32=DeviceEsp32Config(enabled=True),
+        )
+    )
+    server.esp32 = SimpleNamespace(
+        is_online=lambda: False,
+        get_status=lambda: {"device": {"needs_firmware_update": False}, "blocked_devices_count": 0},
+        get_active_host=lambda: "192.168.4.1",
+    )
+
+    status = server._handle_status()["result"]
+
+    assert status["camera_ready"] is False
+    assert status["cat_teaser_camera"]["mode"] == "esp32"

--- a/tests/test_cat_teaser.py
+++ b/tests/test_cat_teaser.py
@@ -13,6 +13,7 @@ from lampgo.core.types import JointState
 from lampgo.perception.cat_teaser import (
     CatPlayObservation,
     CatPlayStateEstimator,
+    CatTeaserDebugView,
     CatToyTracker,
     MarkerDetection,
 )
@@ -30,6 +31,14 @@ def _magenta_frame(*, with_marker: bool = True, motion_size: int = 0) -> np.ndar
     return frame
 
 
+def _red_frame(*, with_marker: bool = True) -> np.ndarray:
+    cv2 = pytest.importorskip("cv2")
+    frame = np.zeros((240, 320, 3), dtype=np.uint8)
+    if with_marker:
+        cv2.circle(frame, (160, 120), 16, (0, 0, 255), -1)
+    return frame
+
+
 def test_cat_toy_tracker_detects_magenta_marker_and_blank_frame() -> None:
     pytest.importorskip("cv2")
     tracker = CatToyTracker(marker_color="magenta")
@@ -41,6 +50,16 @@ def test_cat_toy_tracker_detects_magenta_marker_and_blank_frame() -> None:
     assert 0.45 < detection.normalized_x < 0.55
     assert 0.45 < detection.normalized_y < 0.55
     assert tracker.track(_magenta_frame(with_marker=False)) is None
+
+
+def test_cat_toy_tracker_detects_red_marker() -> None:
+    pytest.importorskip("cv2")
+    tracker = CatToyTracker(marker_color="red")
+
+    detection = tracker.track(_red_frame())
+
+    assert detection is not None
+    assert detection.confidence > 0.2
 
 
 def test_cat_play_state_estimator_transitions_on_synthetic_motion() -> None:
@@ -62,6 +81,20 @@ def test_cat_play_state_estimator_transitions_on_synthetic_motion() -> None:
     assert pounce.state == "pounce"
     assert caught.state == "caught"
     assert rest.state == "rest"
+
+
+def test_cat_teaser_debug_view_disabled_is_noop() -> None:
+    view = CatTeaserDebugView(enabled=False)
+    observation = CatPlayObservation(
+        state="teasing",
+        marker=None,
+        motion_energy=0.0,
+        engagement_score=0.0,
+        motion_centroid=None,
+        timestamp=1.0,
+    )
+
+    assert view.render(object(), observation, elapsed_s=0.0, marker_color="red") is False
 
 
 class _FakeFrameSource:
@@ -157,6 +190,8 @@ async def test_cat_teaser_skill_emits_bounded_linear_targets(monkeypatch) -> Non
         max_yaw=25,
         max_pitch=14,
         max_wrist_pitch=8,
+        debug_view=False,
+        log_events=False,
     )
 
     assert result.status == "ok"
@@ -180,7 +215,9 @@ async def test_cat_teaser_skill_cancels_cleanly(monkeypatch) -> None:
     motion = _FakeMotion()
     skill = CatTeaserSkill(lambda: source)
 
-    task = asyncio.create_task(skill.execute(_fake_context(motion), duration=5, camera_fps=12))
+    task = asyncio.create_task(
+        skill.execute(_fake_context(motion), duration=5, camera_fps=12, debug_view=False, log_events=False)
+    )
     while source.reads == 0:
         await asyncio.sleep(0.01)
     await skill.cancel()
@@ -190,6 +227,23 @@ async def test_cat_teaser_skill_cancels_cleanly(monkeypatch) -> None:
     assert result.data["stop_reason"] == "cancelled"
     assert source.closed is True
     assert motion.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_cat_teaser_skill_prints_touch_event_log(monkeypatch, capsys) -> None:
+    source = _FakeFrameSource()
+    monkeypatch.setattr(cat_skill_mod, "CatToyTracker", _FakeTracker)
+    monkeypatch.setattr(cat_skill_mod, "CatPlayStateEstimator", _FakeEstimator)
+    motion = _FakeMotion()
+    skill = CatTeaserSkill(lambda: source)
+
+    result = await skill.execute(_fake_context(motion), duration=0.4, camera_fps=12, debug_view=False)
+    out = capsys.readouterr().out
+
+    assert result.status == "ok"
+    assert "有触碰动作" in out
+    assert result.data["event_counts"]["touch"] >= 1
+    assert any(event["type"] == "touch" for event in result.data["events"])
 
 
 @pytest.mark.asyncio
@@ -219,3 +273,5 @@ def test_cat_teaser_is_registered_and_exposes_parameters() -> None:
     assert cat_teaser["label"] == "逗猫棒互动"
     assert cat_teaser["parameters"]["marker_color"]["default"] == "magenta"
     assert cat_teaser["parameters"]["duration"]["default"] == 60.0
+    assert cat_teaser["parameters"]["debug_view"]["default"] is True
+    assert cat_teaser["parameters"]["log_events"]["default"] is True

--- a/tests/test_cat_teaser.py
+++ b/tests/test_cat_teaser.py
@@ -1,0 +1,221 @@
+"""Tests for local visual cat teaser behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from lampgo.core.events import EventBus
+from lampgo.core.types import JointState
+from lampgo.perception.cat_teaser import (
+    CatPlayObservation,
+    CatPlayStateEstimator,
+    CatToyTracker,
+    MarkerDetection,
+)
+from lampgo.skills.builtin import cat_teaser as cat_skill_mod
+from lampgo.skills.builtin.cat_teaser import CatTeaserSkill
+
+
+def _magenta_frame(*, with_marker: bool = True, motion_size: int = 0) -> np.ndarray:
+    cv2 = pytest.importorskip("cv2")
+    frame = np.zeros((240, 320, 3), dtype=np.uint8)
+    if with_marker:
+        cv2.circle(frame, (160, 120), 16, (255, 0, 255), -1)
+    if motion_size:
+        cv2.rectangle(frame, (176, 105), (176 + motion_size, 105 + motion_size), (255, 255, 255), -1)
+    return frame
+
+
+def test_cat_toy_tracker_detects_magenta_marker_and_blank_frame() -> None:
+    pytest.importorskip("cv2")
+    tracker = CatToyTracker(marker_color="magenta")
+
+    detection = tracker.track(_magenta_frame())
+
+    assert detection is not None
+    assert detection.confidence > 0.2
+    assert 0.45 < detection.normalized_x < 0.55
+    assert 0.45 < detection.normalized_y < 0.55
+    assert tracker.track(_magenta_frame(with_marker=False)) is None
+
+
+def test_cat_play_state_estimator_transitions_on_synthetic_motion() -> None:
+    pytest.importorskip("cv2")
+    tracker = CatToyTracker(marker_color="magenta")
+    estimator = CatPlayStateEstimator()
+
+    teasing = estimator.update(_magenta_frame(), tracker.track(_magenta_frame()), timestamp=1.0)
+    engaged = estimator.update(_magenta_frame(motion_size=24), tracker.track(_magenta_frame()), timestamp=1.2)
+    pounce = estimator.update(_magenta_frame(motion_size=96), tracker.track(_magenta_frame()), timestamp=1.4)
+    caught = estimator.update(_magenta_frame(with_marker=False, motion_size=96), None, timestamp=1.6)
+
+    rest = caught
+    for idx in range(12):
+        rest = estimator.update(_magenta_frame(with_marker=False), None, timestamp=4.0 + idx * 0.3)
+
+    assert teasing.state == "teasing"
+    assert engaged.state in {"engaged", "pounce"}
+    assert pounce.state == "pounce"
+    assert caught.state == "caught"
+    assert rest.state == "rest"
+
+
+class _FakeFrameSource:
+    device_label = "fake://camera"
+
+    def __init__(self) -> None:
+        self.started = False
+        self.closed = False
+        self.reads = 0
+
+    def start(self) -> None:
+        self.started = True
+
+    def read(self):
+        self.reads += 1
+        return object()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeTracker:
+    def __init__(self, *, marker_color: str = "magenta") -> None:
+        self.marker_color = marker_color
+
+    def track(self, frame) -> MarkerDetection:
+        del frame
+        return MarkerDetection(
+            x=170,
+            y=110,
+            radius=14,
+            area=500,
+            confidence=0.9,
+            frame_width=320,
+            frame_height=240,
+        )
+
+
+class _FakeEstimator:
+    def __init__(self) -> None:
+        self.states = iter(["teasing", "engaged", "pounce", "caught", "unsafe_close"])
+
+    def update(self, frame, marker, *, timestamp=None) -> CatPlayObservation:
+        del frame, timestamp
+        state = next(self.states, "engaged")
+        score = {"teasing": 0.1, "engaged": 0.55, "pounce": 0.8, "caught": 0.7, "unsafe_close": 0.0}[state]
+        return CatPlayObservation(
+            state=state,
+            marker=marker,
+            motion_energy=0.1,
+            engagement_score=score,
+            motion_centroid=(0.5, 0.5),
+            timestamp=1.0,
+        )
+
+
+class _FakeMotion:
+    is_running = True
+
+    def __init__(self) -> None:
+        self.current_state = JointState(positions={"base_yaw": 0.0, "base_pitch": 0.0, "wrist_pitch": 0.0})
+        self.targets = []
+        self.stopped = False
+
+    def update_target(self, target) -> None:
+        self.targets.append(target)
+
+    def stop_smooth(self) -> None:
+        self.stopped = True
+
+
+def _fake_context(motion: _FakeMotion):
+    return SimpleNamespace(
+        motion=motion,
+        led=SimpleNamespace(is_connected=False),
+        events=EventBus(),
+        state=motion.current_state,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cat_teaser_skill_emits_bounded_linear_targets(monkeypatch) -> None:
+    source = _FakeFrameSource()
+    monkeypatch.setattr(cat_skill_mod, "CatToyTracker", _FakeTracker)
+    monkeypatch.setattr(cat_skill_mod, "CatPlayStateEstimator", _FakeEstimator)
+    motion = _FakeMotion()
+    skill = CatTeaserSkill(lambda: source)
+
+    result = await skill.execute(
+        _fake_context(motion),
+        duration=0.35,
+        camera_fps=12,
+        max_yaw=25,
+        max_pitch=14,
+        max_wrist_pitch=8,
+    )
+
+    assert result.status == "ok"
+    assert result.data["frames"] >= 2
+    assert result.data["marker_seen"] >= 2
+    assert source.closed is True
+    assert motion.stopped is True
+    assert motion.targets
+    for target in motion.targets:
+        assert target.style == "linear"
+        assert abs(target.joints["base_yaw"]) <= 25.0
+        assert abs(target.joints["base_pitch"]) <= 14.0
+        assert abs(target.joints["wrist_pitch"]) <= 8.0
+
+
+@pytest.mark.asyncio
+async def test_cat_teaser_skill_cancels_cleanly(monkeypatch) -> None:
+    source = _FakeFrameSource()
+    monkeypatch.setattr(cat_skill_mod, "CatToyTracker", _FakeTracker)
+    monkeypatch.setattr(cat_skill_mod, "CatPlayStateEstimator", _FakeEstimator)
+    motion = _FakeMotion()
+    skill = CatTeaserSkill(lambda: source)
+
+    task = asyncio.create_task(skill.execute(_fake_context(motion), duration=5, camera_fps=12))
+    while source.reads == 0:
+        await asyncio.sleep(0.01)
+    await skill.cancel()
+    result = await task
+
+    assert result.status == "cancelled"
+    assert result.data["stop_reason"] == "cancelled"
+    assert source.closed is True
+    assert motion.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_cat_teaser_skill_rejects_unknown_marker_color() -> None:
+    source = _FakeFrameSource()
+    motion = _FakeMotion()
+    skill = CatTeaserSkill(lambda: source)
+
+    result = await skill.execute(_fake_context(motion), marker_color="orange", duration=1)
+
+    assert result.status == "error"
+    assert "Unsupported marker_color" in result.message
+    assert source.started is False
+    assert motion.stopped is False
+
+
+def test_cat_teaser_is_registered_and_exposes_parameters() -> None:
+    from lampgo.core.config import LampgoConfig
+    from lampgo.server import LampgoServer
+
+    server = LampgoServer(LampgoConfig(no_hw=True))
+    server._register_builtin_skills()
+
+    skills = server._handle_skills()["result"]["skills"]
+    cat_teaser = next(skill for skill in skills if skill["skill_id"] == "cat_teaser")
+
+    assert cat_teaser["label"] == "逗猫棒互动"
+    assert cat_teaser["parameters"]["marker_color"]["default"] == "magenta"
+    assert cat_teaser["parameters"]["duration"]["default"] == 60.0

--- a/tests/test_cat_teaser.py
+++ b/tests/test_cat_teaser.py
@@ -511,10 +511,13 @@ async def test_cat_teaser_skill_cancels_cleanly(monkeypatch) -> None:
     task = asyncio.create_task(
         skill.execute(_fake_context(motion), duration=5, camera_fps=12, debug_view=False, log_events=False)
     )
-    while source.reads == 0:
-        await asyncio.sleep(0.01)
+    async def _wait_for_first_read() -> None:
+        while source.reads == 0:
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(_wait_for_first_read(), timeout=2.0)
     await skill.cancel()
-    result = await task
+    result = await asyncio.wait_for(task, timeout=2.0)
 
     assert result.status == "cancelled"
     assert result.data["stop_reason"] == "cancelled"
@@ -588,6 +591,31 @@ async def test_cat_teaser_skill_saves_camera_video(monkeypatch, tmp_path) -> Non
     assert metadata["video"] == "cat_teaser.mp4"
     assert metadata["video_codec"] == "mp4v"
     assert metadata["frames_written"] == recording["frames_written"]
+
+
+@pytest.mark.asyncio
+async def test_cat_teaser_skill_disables_recording_when_not_allowed(monkeypatch, tmp_path) -> None:
+    pytest.importorskip("cv2")
+    source = _ImageFrameSource()
+    monkeypatch.setattr(cat_skill_mod, "CatToyTracker", _FakeTracker)
+    monkeypatch.setattr(cat_skill_mod, "CatPlayStateEstimator", _FakeEstimator)
+    motion = _FakeMotion()
+    skill = CatTeaserSkill(lambda: source, allow_recording=False)
+
+    result = await skill.execute(
+        _fake_context(motion),
+        duration=0.25,
+        camera_fps=12,
+        debug_view=False,
+        log_events=False,
+        save_recording=True,
+        recording_dir=str(tmp_path),
+    )
+
+    assert result.status == "ok"
+    assert result.data["recording"]["enabled"] is False
+    assert result.data["recording"]["video_path"] is None
+    assert not list(tmp_path.iterdir())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Refine local cat teaser contact detection to reduce false grabs from lamp self-motion or nearby hands.
- Add red-marker defaults, Web duration/color controls, MP4 session recording, and per-frame event metadata.
- Support no-hw fallback to the local computer camera, local://0, with an explicit Web notice that no LampGo body hardware is present.

## Validation
- uv run pytest tests/test_cat_teaser.py -> 20 passed.
- uv run pytest -> 211 passed, 1 existing Starlette deprecation warning.
- uv run ruff check lampgo/perception/cat_teaser.py lampgo/server.py lampgo/skills/builtin/cat_teaser.py tests/test_cat_teaser.py -> passed.
- node --check lampgo/web/static/app.js -> passed.
- uv run ruff check lampgo tests -> fails on existing repository lint issues outside this feature area (import ordering, line length, unused imports, etc.).

## Notes
- Web/manual smoke was not run in this publish pass; the implementation keeps cat_teaser callable from Web, CLI, HTTP, and LLM skill invocation.
- README.zh-CN.md is an untracked local draft and is intentionally not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增“逗猫棒互动（cat_teaser）”：支持基于本地视觉识别互动状态、调试可视化与事件统计，并可按需录制视频/帧记录。
  - 前端新增独立弹窗，支持设置持续时间、标记颜色与保存选项；无硬件场景有提示与回退逻辑。
- **改进**
  - 状态页新增逗猫棒摄像头可用性/模式信息；切换摄像头失败时更及时刷新界面。
  - 设备未连接时，cat_teaser 将跳过执行并返回明确结果。
- **文档**
  - 更新使用说明与常用命令示例。
- **测试**
  - 新增端到端与单元测试，覆盖识别、状态机、录制与异常场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->