### PR TITLE
Update code owner to shelly-tang

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ninsmiracle
+* @shelly-tang


### PR DESCRIPTION
## Summary
- Change the global CODEOWNERS entry from `@ninsmiracle` to `@shelly-tang`.

## Impact
- Future PRs that require code owner review will request `@shelly-tang` instead of `@ninsmiracle`.
- This PR itself may still need the current code owner/admin approval because the existing rule is active until this lands.

## Validation
- Not run; CODEOWNERS-only metadata change.
