### PR TITLE
Add composable expressions for recorded actions

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,182 @@
+# YareLampGo
+
+[English](README.md) | 简体中文
+
+> 把机械臂台灯变成普通人也能玩起来的桌面小伙伴：能听你说话，能看见环境，能自己动起来，还会用动作和表情回应你。
+
+[License: GPL v3](LICENSE)
+[Python 3.12+](https://www.python.org/downloads/)
+[Powered by uv](https://github.com/astral-sh/uv)
+
+YareLampGo 的目标很简单：降低机械臂和具身智能的使用门槛，让没有技术背景的普通人也可以玩起来。
+过去这种 5 自由度机械臂更像实验室设备，普通人很难上手；
+YareLampGo 把电机、灯光、摄像头、麦克风和大模型接成一个本地软件系统，让开发者、创作者和普通玩家可以用网页、命令行、自然语言或 Agent 快速做出有趣的桌面互动。
+
+仓库内的 `lampgo` 仍作为 **YareLampGo** 项目的内部简称，用于简化 Python 包名、CLI 命令、配置目录和 OpenClaw 插件标识使用。
+
+> 图片占位：这里放一张当前开源版本的真实桌面演示图或动图，建议路径 `docs/images/readme/hero-demo.gif`。
+
+项目默认提供本地 Web 控制台、CLI、HTTP / WebSocket 接口和 OpenClaw 插件，也支持无硬件模式。你可以先把软件玩法跑通，再接真实设备。
+
+## 主要亮点
+
+- **自然语言控制真实台灯**：一句“点个头”“看向我”“做个害羞表情”，就能触发动作、灯光、语音和 Agent 行动。
+- **Web 控制台开箱可用**：浏览器里完成聊天、动作播放、动作录制、表情切换、设备状态和配置管理。
+- **友好的机器校准流程**：第一次拿到机器、换电机或重装结构件后，先 `detect` 再 `calibrate`，减少新设备误动风险。
+- **动作可以录制和复用**：手动摆动台灯录制参数文件，之后可以通过 Web、CLI、自然语言或 OpenClaw 再次调用。
+- **非技术用户也能扩展玩法**：可以用自然语言描述“欢迎回家”“被夸后害羞一下”这类场景，新增自己的原子动作或组合动作，并沉淀成适合自己的桌面 skill。
+- **Agent 可以调用真实硬件**：接入 OpenClaw 后，Agent 能读取状态、控制关节、切换 LED 表情、抓取摄像头画面并向用户确认。
+- **无硬件也能先开发**：没有真实台灯时使用 `--no-hw`，仍然可以调 Web UI、配置、技能、路由和 Agent 流程。
+
+> 图片占位：这里放 Web 控制台截图，建议路径 `docs/images/readme/web-console.png`。
+
+## 适合谁
+
+- **普通软件开发者**：想做真实硬件互动，但不想从电机控制和串口协议开始学。
+- **自媒体和内容创作者**：想让桌面设备会动、会回应、会表演，做出更有记忆点的视频或直播互动。
+- **AI 硬件原型团队**：想快速验证桌面机械臂、智能台灯和具身 AI 的新场景。
+- **Agent 应用团队**：想让 Agent 不只操作网页和文件，也能调用真实电机、灯光、摄像头和语音。
+
+## 快速开始
+
+### 1. 安装 uv
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+macOS 也可以使用：
+
+```bash
+brew install uv
+```
+
+### 2. 获取源码并安装依赖
+
+```bash
+git clone https://github.com/ninsmiracle/YareLampGo.git
+cd YareLampGo
+uv sync
+```
+
+### 3. 完成首次配置
+
+```bash
+uv run lampgo onboard
+```
+
+引导流程会检查环境、配置硬件串口、写入模型凭证、导入人设，并在检测到 OpenClaw 时提示安装插件。配置文件默认写入 `~/.lampgo/`，敏感凭证保存在 `~/.lampgo/credentials.json`。
+
+### 4. 新机器先校准
+
+首次连接真实硬件、换过电机、重装结构件或更换控制板后，请先完成电机校准，再运行大幅动作。
+
+```bash
+uv run lampgo detect
+uv run lampgo calibrate
+```
+
+### 5. 启动 Web 控制台
+
+```bash
+uv run lampgo run --web
+```
+
+打开 [http://127.0.0.1:8420](http://127.0.0.1:8420)，即可使用聊天、动作、录制、表情和设置面板。
+
+没有硬件时可以先启动纯软件模式：
+
+```bash
+uv run lampgo run --web --no-hw
+```
+
+### macOS 音乐律动权限
+
+`uv run lampgo onboard` 会自动准备音乐律动需要的系统音频组件。首次使用“音乐律动”时，macOS 会请求“屏幕录制/屏幕与系统音频录制”权限；允许后请重启 YareLampGo 再进入音乐律动。
+
+## 常用玩法
+
+```bash
+uv run lampgo help                         # 查看常用调试命令
+uv run lampgo status                       # 查询守护进程状态
+uv run lampgo detect                       # 自动探测串口
+uv run lampgo skills                       # 列出可用技能
+
+uv run lampgo text "做个害羞的表情"          # 自然语言路由
+uv run lampgo invoke dance                 # 调用内置技能
+uv run lampgo move base_yaw=30             # 直接移动指定关节
+uv run lampgo play shy                     # 回放录制动作
+uv run lampgo record my_action --fps 30    # 手动录制新动作
+
+uv run lampgo calibrate                    # 交互式电机校准
+uv run lampgo estop                        # 紧急停止
+uv run lampgo clear                        # 清理进程并释放串口
+```
+
+更多步骤见 [快速上手](docs/getting-started/quick-start.md)。
+
+> 图片占位：这里放 1-2 张动作演示 GIF，例如点头、害羞、跳舞或回安全位，建议路径 `docs/images/readme/motion-demo.gif`。
+
+## 架构一眼看懂
+
+```mermaid
+flowchart LR
+  user["用户 / Agent"] --> entry["Web UI / CLI / Voice / OpenClaw"]
+  entry --> server["LampgoServer"]
+  server --> skills["IntentRouter + SkillExecutor"]
+  skills --> safety["MotionRuntime + SafetyKernel"]
+  safety --> hardware["5-DOF 电机 / LED / Camera / Mic"]
+```
+
+
+
+所有动作最终都会经过 `MotionRuntime` 和 `SafetyKernel`，再写入真实硬件。更完整的模块说明见 [系统架构](docs/architecture.md)。
+
+## 文档
+
+
+| 分类   | 文档                                                                                                                  |
+| ---- | ------------------------------------------------------------------------------------------------------------------- |
+| 入门   | [文档中心](docs/README_zh.md)、[快速上手](docs/getting-started/quick-start.md)、[配置说明](docs/getting-started/configuration.md) |
+| 使用指南 | [动作与表情](docs/guides/motion-and-expression.md)、[OpenClaw 集成](docs/guides/openclaw-integration.md)                    |
+| 硬件   | [硬件公开资料](docs/hardware/README.md)、[接线表](docs/hardware/wiring.md)、[结构件文件](assets/printable/README.md)                |
+| 架构   | [系统架构](docs/architecture.md)、[项目说明](docs/project_description.md)                                                    |
+| 开发   | [贡献指南](docs/development/contributing.md)、[示例代码](examples/)                                                          |
+
+
+## OpenClaw 集成
+
+YareLampGo 可以作为 OpenClaw 的硬件配件运行，让 Agent 读取台灯状态、控制关节、播放动作、切换 LED 表情、抓取摄像头画面、写入记忆或向用户发起确认。
+
+```bash
+uv run lampgo run --web
+uv run lampgo install-openclaw --yes
+```
+
+集成细节见 [OpenClaw 集成指南](docs/guides/openclaw-integration.md)。
+
+## 参与贡献
+
+欢迎把你做出的动作、桌面互动 case、组合 skill 场景、OpenClaw 玩法、硬件适配和文档经验共享回本仓库。可以从这些入口开始：
+
+- 动作资产：录制后整理为 `assets/recordings/` 下的 CSV，并补一份简短说明。
+- 使用案例和脚本：放到 `examples/` 或文档中，说明适合什么场景。
+- 组合 skill 场景：参考 `docs/examples/` 和 [组合技能](docs/composed_skills.md)，尽量写清触发方式、动作步骤和安全边界。
+
+最简贡献流程：
+
+```bash
+uv sync --group dev
+uv run ruff check lampgo tests
+uv run pytest
+```
+
+一个 PR 聚焦一个主题。涉及硬件或动作时，请说明测试设备、串口、校准文件、动作效果和是否覆盖 `--no-hw` 模式。更多细节见 [贡献指南](docs/development/contributing.md)。
+
+## License
+
+本仓库的软件代码基于 [GNU General Public License v3.0 only](LICENSE) 开源。作者与归属信息见 [AUTHORS.md](AUTHORS.md)、[COPYRIGHT](COPYRIGHT) 和 [NOTICE](NOTICE)。
+
+硬件、外观、运行时 3D 模型和 3D 打印资料不默认跟随主软件许可证；资产授权见 [ASSET_LICENSES.md](ASSET_LICENSES.md)。
+当前 GLB 作为 Web 可视化资产使用 CC-BY-NC-SA-4.0，允许非商用展示、分享和改造；公开的社区复刻/可打印外观结构件位于 [assets/printable/](assets/printable/README.md)，包括 V1.0 STEP/STP 文件和预览图，默认使用 CERN-OHL-W-2.0。
+生产 CAD、供应商生产图纸、报价和工艺文件不包含在公开仓库中，除非文件被明确列入资产授权表或本地许可说明。

--- a/assets/calibration/AL02.json
+++ b/assets/calibration/AL02.json
@@ -2,46 +2,46 @@
   "base_yaw": {
     "id": 1,
     "drive_mode": 0,
-    "homing_offset": -1513,
-    "range_min": 1048,
-    "range_max": 3539,
+    "homing_offset": 1435,
+    "range_min": 1289,
+    "range_max": 2990,
     "neutral_raw": 2047,
-    "neutral_degrees": -21.7
+    "neutral_degrees": -8.1
   },
   "base_pitch": {
     "id": 2,
     "drive_mode": 0,
-    "homing_offset": 1670,
-    "range_min": 1511,
-    "range_max": 3248,
-    "neutral_raw": 2047,
-    "neutral_degrees": -29.2
+    "homing_offset": 386,
+    "range_min": 1897,
+    "range_max": 2447,
+    "neutral_raw": 2046,
+    "neutral_degrees": -11.1
   },
   "elbow_pitch": {
     "id": 3,
     "drive_mode": 0,
-    "homing_offset": -1520,
-    "range_min": 1591,
-    "range_max": 3021,
+    "homing_offset": 1522,
+    "range_min": 2046,
+    "range_max": 2866,
     "neutral_raw": 2047,
-    "neutral_degrees": -22.8
+    "neutral_degrees": -36.0
   },
   "wrist_roll": {
     "id": 4,
     "drive_mode": 0,
-    "homing_offset": 437,
-    "range_min": 1146,
-    "range_max": 2967,
+    "homing_offset": 825,
+    "range_min": 1497,
+    "range_max": 2593,
     "neutral_raw": 2047,
-    "neutral_degrees": -0.8
+    "neutral_degrees": 0.2
   },
   "wrist_pitch": {
     "id": 5,
     "drive_mode": 0,
-    "homing_offset": 1513,
-    "range_min": 1608,
-    "range_max": 2836,
+    "homing_offset": 1376,
+    "range_min": 1025,
+    "range_max": 3159,
     "neutral_raw": 2047,
-    "neutral_degrees": -15.4
+    "neutral_degrees": -4.0
   }
 }

--- a/assets/calibration/AL03.json
+++ b/assets/calibration/AL03.json
@@ -2,46 +2,46 @@
   "base_yaw": {
     "id": 1,
     "drive_mode": 0,
-    "homing_offset": 1514,
-    "range_min": 856,
-    "range_max": 3066,
-    "neutral_raw": 2046,
-    "neutral_degrees": 7.5
+    "homing_offset": 1132,
+    "range_min": 1011,
+    "range_max": 3132,
+    "neutral_raw": 2047,
+    "neutral_degrees": -2.2
   },
   "base_pitch": {
     "id": 2,
     "drive_mode": 0,
-    "homing_offset": 372,
-    "range_min": 1641,
-    "range_max": 2522,
+    "homing_offset": -1569,
+    "range_min": 886,
+    "range_max": 2561,
     "neutral_raw": 2047,
-    "neutral_degrees": -3.0
+    "neutral_degrees": 28.4
   },
   "elbow_pitch": {
     "id": 3,
     "drive_mode": 0,
-    "homing_offset": 1691,
-    "range_min": 1984,
-    "range_max": 2733,
+    "homing_offset": -173,
+    "range_min": 1339,
+    "range_max": 2626,
     "neutral_raw": 2047,
-    "neutral_degrees": -27.4
+    "neutral_degrees": 5.7
   },
   "wrist_roll": {
     "id": 4,
     "drive_mode": 0,
-    "homing_offset": 934,
-    "range_min": 1540,
-    "range_max": 2416,
+    "homing_offset": 1362,
+    "range_min": 1431,
+    "range_max": 2744,
     "neutral_raw": 2047,
-    "neutral_degrees": 6.1
+    "neutral_degrees": -3.6
   },
   "wrist_pitch": {
     "id": 5,
     "drive_mode": 0,
-    "homing_offset": 1431,
-    "range_min": 955,
-    "range_max": 3172,
+    "homing_offset": 1432,
+    "range_min": 977,
+    "range_max": 3111,
     "neutral_raw": 2047,
-    "neutral_degrees": -1.5
+    "neutral_degrees": 0.3
   }
 }

--- a/assets/calibration/AL03.json
+++ b/assets/calibration/AL03.json
@@ -1,0 +1,47 @@
+{
+  "base_yaw": {
+    "id": 1,
+    "drive_mode": 0,
+    "homing_offset": 1514,
+    "range_min": 856,
+    "range_max": 3066,
+    "neutral_raw": 2046,
+    "neutral_degrees": 7.5
+  },
+  "base_pitch": {
+    "id": 2,
+    "drive_mode": 0,
+    "homing_offset": 372,
+    "range_min": 1641,
+    "range_max": 2522,
+    "neutral_raw": 2047,
+    "neutral_degrees": -3.0
+  },
+  "elbow_pitch": {
+    "id": 3,
+    "drive_mode": 0,
+    "homing_offset": 1691,
+    "range_min": 1984,
+    "range_max": 2733,
+    "neutral_raw": 2047,
+    "neutral_degrees": -27.4
+  },
+  "wrist_roll": {
+    "id": 4,
+    "drive_mode": 0,
+    "homing_offset": 934,
+    "range_min": 1540,
+    "range_max": 2416,
+    "neutral_raw": 2047,
+    "neutral_degrees": 6.1
+  },
+  "wrist_pitch": {
+    "id": 5,
+    "drive_mode": 0,
+    "homing_offset": 1431,
+    "range_min": 955,
+    "range_max": 3172,
+    "neutral_raw": 2047,
+    "neutral_degrees": -1.5
+  }
+}

--- a/docs/guides/expression-authoring.md
+++ b/docs/guides/expression-authoring.md
@@ -1,0 +1,98 @@
+# LampGo Expression Authoring
+
+LampGo expressions are reusable compositions, not a single animation file:
+
+- `EyeClip` is a 320x172 C6 LCD asset containing eyes only.
+- `LedEffect` is an S3 program for a mouth, symbol, direction, or accent.
+- `ExpressionPreset` references one optional eye and one optional LED effect.
+
+At least one channel must be present. The two channels start at `t=0` and use
+the same 0-1 phase over a default three-second duration. Micro-expressions play
+once unless the caller explicitly selects `loop`.
+
+## Design Rules
+
+1. Keep the C6 image black except for the eyes. Do not draw a mouth, product
+   shell, LED board, text, or status UI into an eye sprite.
+2. Use the 51x9 LED board for mouths, arrows, hearts, symbols, and broad color
+   accents. LED effects are programs, never image sprite sheets.
+3. Reuse parameterized effects. One `arrow` effect with a `direction` parameter
+   is preferred over four copied programs.
+4. Use 30 eye frames at 10fps and target 3.0 seconds. The accepted range is
+   8-12fps and 2.5-3.5 seconds.
+5. A transient composition may be previewed or played without being saved.
+   An LLM must receive explicit user confirmation before saving a preset.
+6. Do not emit arbitrary code, unbounded loops, dynamic allocation, or custom
+   frame buffers. LED DSL version 1 only accepts `mouth`, `arrow`, `heart`, and
+   `pulse` templates.
+
+## Capacity Contract
+
+- Eye package: at most 256KiB.
+- Current C6 partition: 5 eyes, 896KiB installed budget, 256KiB reserve.
+- Product C6 partition: 10 eyes, 3MiB installed budget, 1MiB reserve.
+- S3 custom LED effects: 24 files, 8KiB each, 192KiB total.
+- S3 presets: 64 files, 1KiB each, 64KiB total.
+- Composition brightness is capped at 96 to protect the shared power and Wi-Fi
+  stability envelope. The normal default is 64.
+- The device rejects writes that cross a quota. It never evicts another asset.
+
+The S3 keeps LCD uploads only as staging data. After the C6 acknowledges size
+and SHA256 validation, the S3 removes its LCD copy. The C6 writes to a temporary
+file and replaces the installed eye only after validation succeeds.
+
+## Runtime Discovery
+
+Agents must query the live catalog before choosing ids:
+
+```text
+GET /api/eyes
+GET /api/led-effects
+GET /api/expression-presets
+GET /api/device/expression-capabilities
+```
+
+Play a saved preset:
+
+```json
+POST /api/expressions/play
+{"preset_id":"dizzy"}
+```
+
+Play a transient composition without saving it:
+
+```json
+POST /api/expressions/play
+{
+  "eye_clip_id": "dizzy_eyes",
+  "led_effect_id": "arrow",
+  "led_params": {
+    "direction": "right",
+    "color": "#00ff88",
+    "brightness": 64,
+    "intensity": 0.8
+  },
+  "playback": "once",
+  "duration_ms": 3000
+}
+```
+
+Save only after the user confirms:
+
+```json
+POST /api/expression-presets
+{
+  "preset_id": "dizzy_right",
+  "label": "Dizzy right",
+  "eye_clip_id": "dizzy_eyes",
+  "led_effect_id": "arrow",
+  "led_params": {"direction":"right","color":"#00ff88"},
+  "playback": "once",
+  "duration_ms": 3000,
+  "confirmed": true
+}
+```
+
+The legacy `dizzy` cache is exposed without copying binary data as
+`dizzy_eyes + dizzy_mouth -> dizzy preset`. Existing `clip_id=dizzy` callers
+continue to work.

--- a/docs/schemas/expression-preset.schema.json
+++ b/docs/schemas/expression-preset.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lampgo.local/schemas/expression-preset.schema.json",
+  "title": "LampGo Expression Preset",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["preset_id", "playback", "duration_ms"],
+  "anyOf": [
+    {"required": ["eye_clip_id"]},
+    {"required": ["led_effect_id"]}
+  ],
+  "properties": {
+    "preset_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]{0,31}$"},
+    "label": {"type": "string", "maxLength": 64},
+    "description": {"type": "string", "maxLength": 240},
+    "eye_clip_id": {"type": ["string", "null"]},
+    "led_effect_id": {"type": ["string", "null"]},
+    "led_params": {"type": "object"},
+    "playback": {"enum": ["once", "loop"]},
+    "duration_ms": {"type": "integer", "minimum": 2500, "maximum": 3500},
+    "confirmed": {"const": true}
+  }
+}

--- a/docs/schemas/eye-clip.schema.json
+++ b/docs/schemas/eye-clip.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lampgo.local/schemas/eye-clip.schema.json",
+  "title": "LampGo Eye Clip",
+  "type": "object",
+  "required": ["eye_clip_id", "fps", "duration_ms", "frame_count", "lcd"],
+  "properties": {
+    "eye_clip_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]{0,31}$"},
+    "default_led_effect_id": {"type": ["string", "null"]},
+    "fps": {"type": "integer", "minimum": 8, "maximum": 12},
+    "duration_ms": {"type": "integer", "minimum": 2500, "maximum": 3500},
+    "frame_count": {"type": "integer", "minimum": 1},
+    "lcd": {
+      "type": "object",
+      "required": ["width", "height", "bytes", "sha256"],
+      "properties": {
+        "width": {"const": 320},
+        "height": {"const": 172},
+        "bytes": {"type": "integer", "maximum": 262144},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    }
+  }
+}

--- a/docs/schemas/led-effect.schema.json
+++ b/docs/schemas/led-effect.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lampgo.local/schemas/led-effect.schema.json",
+  "title": "LampGo LED Effect",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["effect_id", "role", "program"],
+  "properties": {
+    "effect_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]{0,31}$"},
+    "label": {"type": "string", "maxLength": 64},
+    "role": {"enum": ["mouth", "symbol", "direction", "accent"]},
+    "program": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "template"],
+      "properties": {
+        "version": {"const": 1},
+        "template": {"enum": ["mouth", "arrow", "heart", "pulse"]},
+        "variant": {"enum": ["smile", "open", "flat", "dizzy"]},
+        "defaults": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "color": {"type": "string", "pattern": "^#[0-9a-fA-F]{6}$"},
+            "secondary_color": {"type": "string", "pattern": "^#[0-9a-fA-F]{6}$"},
+            "brightness": {"type": "integer", "minimum": 1, "maximum": 96},
+            "intensity": {"type": "number", "minimum": 0.1, "maximum": 1.0},
+            "direction": {"enum": ["left", "right", "up", "down"]}
+          }
+        }
+      }
+    }
+  }
+}

--- a/lampgo/core/led.py
+++ b/lampgo/core/led.py
@@ -210,6 +210,34 @@ class LEDController:
     def off(self) -> bool:
         return self.set_mode(0)
 
+    def play_expression(self, expression_id: str, **overrides: Any) -> tuple[bool, dict[str, Any] | None]:
+        """Resolve and play a preset, eye clip, or LED effect without saving it."""
+        try:
+            from lampgo.expression_library import resolve_expression
+
+            request: dict[str, Any] = {"expression_id": expression_id}
+            request.update({key: value for key, value in overrides.items() if value is not None})
+            composition = resolve_expression(request)
+        except Exception as exc:
+            logger.warning("led.expression_resolve_failed", expression_id=expression_id, error=str(exc))
+            return False, None
+
+        effect = composition.get("led_effect") or {}
+        payload: dict[str, Any] = {
+            "eye_clip_id": composition.get("eye_storage_clip_id"),
+            "led_effect_id": composition.get("led_effect_id"),
+            "led_params": composition.get("led_params") or {},
+            "playback": composition.get("playback") or "once",
+            "duration_ms": int(composition.get("duration_ms") or 3000),
+        }
+        if composition.get("preset_id"):
+            payload["preset_id"] = composition["preset_id"]
+        if effect.get("mode") is not None:
+            payload["led_mode"] = int(effect["mode"])
+        if isinstance(effect.get("program"), dict):
+            payload["led_program"] = effect["program"]
+        return self._send_remote_path("/device/expressions/play", payload, reason="expression_play"), composition
+
     def _send(self, command: str) -> bool:
         if self._serial is None:
             logger.debug("led.send_skipped (not connected)", cmd=command.strip())
@@ -231,6 +259,9 @@ class LEDController:
             return False
 
     def _send_remote(self, payload: dict[str, Any]) -> bool:
+        return self._send_remote_path("/device/led", payload, reason="led")
+
+    def _send_remote_path(self, path: str, payload: dict[str, Any], *, reason: str) -> bool:
         manager = self._esp32_manager
         if manager is None:
             logger.debug("led.remote_send_skipped (no esp32 manager)", payload=payload)
@@ -247,10 +278,10 @@ class LEDController:
             return False
 
         try:
-            body = manager.with_owner_auth(payload, reason="led") if hasattr(manager, "with_owner_auth") else payload
+            body = manager.with_owner_auth(payload, reason=reason) if hasattr(manager, "with_owner_auth") else payload
             import httpx
 
-            resp = httpx.post(f"{base_url}/device/led", json=body, timeout=2.0, trust_env=False)
+            resp = httpx.post(f"{base_url}{path}", json=body, timeout=5.0, trust_env=False)
             ok = resp.status_code < 400
             if ok:
                 try:
@@ -263,11 +294,12 @@ class LEDController:
                 mark_healthy = getattr(manager, "mark_active_healthy", None)
                 if callable(mark_healthy):
                     mark_healthy()
-                logger.info("led.remote_sent", payload=payload, base_url=base_url)
+                logger.info("led.remote_sent", path=path, payload=payload, base_url=base_url)
             else:
                 logger.warning(
                     "led.remote_send_failed",
                     payload=payload,
+                    path=path,
                     base_url=base_url,
                     status=resp.status_code,
                     body=resp.text[:200],
@@ -285,6 +317,7 @@ class LEDController:
             logger.warning(
                 "led.remote_ack_timeout_assumed_sent",
                 payload=payload,
+                path=path,
                 base_url=base_url,
                 error=str(exc),
                 error_type=type(exc).__name__,
@@ -294,6 +327,7 @@ class LEDController:
             logger.warning(
                 "led.remote_send_failed",
                 payload=payload,
+                path=path,
                 base_url=base_url,
                 error=str(exc),
                 error_type=type(exc).__name__,

--- a/lampgo/core/led.py
+++ b/lampgo/core/led.py
@@ -238,6 +238,10 @@ class LEDController:
             payload["led_program"] = effect["program"]
         return self._send_remote_path("/device/expressions/play", payload, reason="expression_play"), composition
 
+    def stop_expression(self) -> bool:
+        """Stop a composed eye/LED expression on the paired device."""
+        return self._send_remote_path("/device/expressions/stop", {}, reason="expression_stop")
+
     def _send(self, command: str) -> bool:
         if self._serial is None:
             logger.debug("led.send_skipped (not connected)", cmd=command.strip())

--- a/lampgo/core/led.py
+++ b/lampgo/core/led.py
@@ -187,7 +187,17 @@ class LEDController:
             return False
 
         if self._serial is None:
-            return self._send_remote({"mode": mode})
+            expression = LED_MODE_NAMES.get(mode, str(mode))
+            payload: dict[str, Any] = {"mode": mode, "expression": expression}
+            try:
+                from lampgo.expression_clips import clip_for_expression
+
+                clip = clip_for_expression(expression)
+                if clip:
+                    payload["clip_id"] = str(clip.get("clip_id") or "")
+            except Exception:
+                pass
+            return self._send_remote(payload)
         return self._send(f"m{mode}\n")
 
     def set_brightness(self, brightness: int) -> bool:

--- a/lampgo/device/esp32.py
+++ b/lampgo/device/esp32.py
@@ -136,6 +136,8 @@ class Esp32DeviceManager:
         self._preferred_health_ok = False
         self._preferred_health_ok_at = 0.0
         self._preferred_fallback_snapshot: Esp32Device | None = None
+        self._transfer_lock = asyncio.Lock()
+        self._active_transfers = 0
         self._owner_id = _load_or_create_owner_id()
         self._owner_label = f"{socket.gethostname()}:{config.preferred_host or 'lampgo'}"
         self._pairing_secret = _load_or_create_pairing_secret()
@@ -292,6 +294,9 @@ class Esp32DeviceManager:
                 logger.exception("esp32.health_loop_failed")
 
     async def _probe_all(self) -> None:
+        if self.is_transfer_active():
+            self.mark_active_healthy()
+            return
         async with self._lock:
             devices = list(self._devices.values())
         for dev in devices:
@@ -478,6 +483,8 @@ class Esp32DeviceManager:
         dev = self._pick_active()
         if dev is None:
             return False
+        if self.is_transfer_active():
+            return True
         if not dev.last_health_ok:
             return False
         return (time.monotonic() - dev.last_health_ok_at) < HEALTH_TTL_S + 10.0
@@ -489,6 +496,9 @@ class Esp32DeviceManager:
         even when the main HTTP health endpoint is slow or wedged.
         """
         return self._config.enabled and self._pick_active() is not None
+
+    def is_transfer_active(self) -> bool:
+        return self._active_transfers > 0
 
     def mark_active_healthy(self) -> None:
         """Mark the active device healthy after a successful non-HTTP channel.
@@ -629,6 +639,7 @@ class Esp32DeviceManager:
             "enabled": self._config.enabled,
             "configured": dev is not None,
             "online": self.is_online(),
+            "transfer_active": self.is_transfer_active(),
             "session_used": self._session_used,
             "preferred_host": self._config.preferred_host,
             "owner_id": self._owner_id,
@@ -712,6 +723,44 @@ class Esp32DeviceManager:
         if dev is None or self._http is None:
             return 503, {"ok": False, "error": "no_device"}, "application/json"
         return await self._post_to_device(dev, path, json_body)
+
+    async def proxy_post_bytes(
+        self,
+        path: str,
+        payload: bytes,
+        *,
+        params: dict[str, Any] | None = None,
+        content_type: str = "application/octet-stream",
+    ) -> tuple[int, dict[str, Any], str]:
+        dev = self._pick_active()
+        if dev is None or self._http is None:
+            return 503, {"ok": False, "error": "no_device"}, "application/json"
+        async with self._transfer_lock:
+            self._active_transfers += 1
+            self.mark_active_healthy()
+            try:
+                upload_timeout_s = max(float(self._config.http_timeout_s), min(180.0, 30.0 + len(payload) / 4_000.0))
+                resp = await self._http.post(
+                    f"{dev.base_url}{path}",
+                    params=params or {},
+                    content=payload,
+                    headers={"Content-Type": content_type},
+                    timeout=upload_timeout_s,
+                )
+                if resp.status_code < 400:
+                    dev.last_health_ok = True
+                    dev.last_health_ok_at = time.monotonic()
+                    self.mark_active_healthy()
+                response_content_type = resp.headers.get("content-type", "application/json")
+                try:
+                    body = resp.json()
+                except Exception:
+                    body = {"ok": resp.status_code < 400, "raw": resp.text}
+                return resp.status_code, body, response_content_type
+            except httpx.HTTPError as exc:
+                return 502, {"ok": False, "error": f"proxy_failed: {exc}"}, "application/json"
+            finally:
+                self._active_transfers = max(0, self._active_transfers - 1)
 
     async def snapshot_jpeg(self) -> bytes | None:
         dev = self._pick_active()

--- a/lampgo/expression_clips.py
+++ b/lampgo/expression_clips.py
@@ -1,0 +1,408 @@
+"""LCD expression clip asset pipeline for device micro-expressions."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import re
+import struct
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from lampgo import personastore
+
+TARGET_DURATION_S = 3.0
+MIN_DURATION_S = 2.5
+MAX_DURATION_S = 3.5
+MIN_FPS = 8
+MAX_FPS = 12
+DEFAULT_FPS = 10
+MAX_CLIPS = 10
+MAX_LCD_BYTES = 720 * 1024
+
+LCD_WIDTH = 320
+LCD_HEIGHT = 172
+
+LCD_MAGIC = b"LGLCD1"
+
+_SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,32}$")
+
+
+class ExpressionClipError(ValueError):
+    """Raised when a source asset cannot become a device-safe expression clip."""
+
+
+@dataclass(frozen=True)
+class ExpressionClipPackage:
+    clip_id: str
+    expression: str
+    fps: int
+    duration_ms: int
+    frame_count: int
+    source_filename: str
+    source_content_type: str
+    lcd_bytes: int
+    lcd_sha256: str
+    led_effect: str
+    path: Path
+
+    def to_manifest(self) -> dict[str, Any]:
+        return {
+            "clip_id": self.clip_id,
+            "expression": self.expression,
+            "fps": self.fps,
+            "duration_ms": self.duration_ms,
+            "frame_count": self.frame_count,
+            "source_filename": self.source_filename,
+            "source_content_type": self.source_content_type,
+            "lcd": {
+                "width": LCD_WIDTH,
+                "height": LCD_HEIGHT,
+                "bytes": self.lcd_bytes,
+                "sha256": self.lcd_sha256,
+                "filename": "lcd.bin",
+            },
+            "led": {
+                "type": "procedural",
+                "effect": self.led_effect,
+            },
+            "sync": {
+                "status": "unsynced",
+                "last_synced_at": None,
+                "device": None,
+            },
+        }
+
+
+def expression_clip_root() -> Path:
+    root = personastore.lampgo_home() / "expression_clips"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def sanitize_clip_id(value: str) -> str:
+    clip_id = re.sub(r"[^a-zA-Z0-9_-]+", "-", value.strip()).strip("-_").lower()
+    if not clip_id:
+        raise ExpressionClipError("clip_id is required")
+    if not _SAFE_ID_RE.match(clip_id):
+        raise ExpressionClipError("clip_id must be 1-32 chars: letters, numbers, dash, underscore")
+    return clip_id
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _clip_dir(clip_id: str) -> Path:
+    return expression_clip_root() / sanitize_clip_id(clip_id)
+
+
+def _manifest_path(clip_id: str) -> Path:
+    return _clip_dir(clip_id) / "manifest.json"
+
+
+def list_expression_clips() -> list[dict[str, Any]]:
+    clips: list[dict[str, Any]] = []
+    root = expression_clip_root()
+    for manifest in sorted(root.glob("*/manifest.json")):
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if isinstance(data, dict):
+            data.setdefault("path", str(manifest.parent))
+            clips.append(data)
+    return clips
+
+
+def clip_for_expression(expression: str) -> dict[str, Any] | None:
+    wanted = expression.strip().lower()
+    if not wanted:
+        return None
+    for clip in list_expression_clips():
+        if str(clip.get("expression") or "").strip().lower() == wanted:
+            return clip
+    return None
+
+
+def load_expression_clip(clip_id: str) -> dict[str, Any]:
+    path = _manifest_path(clip_id)
+    if not path.exists():
+        raise ExpressionClipError(f"expression clip not found: {clip_id}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ExpressionClipError(f"invalid manifest for clip: {clip_id}")
+    return data
+
+
+def update_expression_clip_sync(clip_id: str, *, status: str, device: dict[str, Any] | None = None) -> dict[str, Any]:
+    import time
+
+    path = _manifest_path(clip_id)
+    manifest = load_expression_clip(clip_id)
+    sync = dict(manifest.get("sync") or {})
+    sync.update(
+        {
+            "status": status,
+            "last_synced_at": time.time() if status == "synced" else sync.get("last_synced_at"),
+            "device": device,
+        }
+    )
+    manifest["sync"] = sync
+    path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return manifest
+
+
+def build_sync_chunks(clip_id: str, *, chunk_size: int = 64) -> list[dict[str, Any]]:
+    """Return small JSON-safe chunks for S3 sync and UART relay to C6."""
+    manifest = load_expression_clip(clip_id)
+    clip_dir = _clip_dir(clip_id)
+    chunks: list[dict[str, Any]] = [
+        {
+            "action": "begin",
+            "clip_id": manifest["clip_id"],
+            "expression": manifest["expression"],
+            "fps": manifest["fps"],
+            "duration_ms": manifest["duration_ms"],
+            "frame_count": manifest["frame_count"],
+            "lcd_bytes": manifest["lcd"]["bytes"],
+            "lcd_sha256": manifest["lcd"]["sha256"],
+            "led_effect": (manifest.get("led") or {}).get("effect") or manifest["expression"],
+        }
+    ]
+
+    payload = (clip_dir / "lcd.bin").read_bytes()
+    for offset in range(0, len(payload), chunk_size):
+        part = payload[offset : offset + chunk_size]
+        chunks.append(
+            {
+                "action": "chunk",
+                "clip_id": manifest["clip_id"],
+                "target": "lcd",
+                "offset": offset,
+                "data": part.hex(),
+            }
+        )
+    chunks.append({"action": "commit", "clip_id": manifest["clip_id"]})
+    return chunks
+
+
+def create_expression_clip(
+    *,
+    clip_id: str,
+    expression: str,
+    source_bytes: bytes,
+    filename: str,
+    content_type: str = "",
+    fps: int = DEFAULT_FPS,
+    duration_s: float | None = None,
+    grid_rows: int | None = None,
+    grid_cols: int | None = None,
+) -> dict[str, Any]:
+    clip_id = sanitize_clip_id(clip_id)
+    expression = (expression or clip_id).strip().lower()
+    if not expression:
+        raise ExpressionClipError("expression is required")
+    if len(list_expression_clips()) >= MAX_CLIPS and not _manifest_path(clip_id).exists():
+        raise ExpressionClipError(f"maximum expression clips reached: {MAX_CLIPS}")
+    if fps < MIN_FPS or fps > MAX_FPS:
+        raise ExpressionClipError(f"fps must be between {MIN_FPS} and {MAX_FPS}")
+    if not source_bytes:
+        raise ExpressionClipError("source file is empty")
+
+    frames = _decode_source_frames(
+        source_bytes,
+        filename=filename,
+        grid_rows=grid_rows,
+        grid_cols=grid_cols,
+    )
+    if not frames:
+        raise ExpressionClipError("no frames decoded from source")
+
+    actual_duration_s = duration_s if duration_s is not None else len(frames) / float(fps)
+    if actual_duration_s < MIN_DURATION_S or actual_duration_s > MAX_DURATION_S:
+        raise ExpressionClipError(
+            f"duration must be {MIN_DURATION_S:.1f}-{MAX_DURATION_S:.1f}s; got {actual_duration_s:.2f}s"
+        )
+
+    duration_ms = int(round(actual_duration_s * 1000))
+    lcd_payload = _encode_lcd_package(frames, fps=fps, duration_ms=duration_ms)
+    if len(lcd_payload) > MAX_LCD_BYTES:
+        raise ExpressionClipError(
+            "converted LCD clip exceeds device cache budget "
+            f"(lcd={len(lcd_payload)} bytes)"
+        )
+
+    clip_dir = _clip_dir(clip_id)
+    clip_dir.mkdir(parents=True, exist_ok=True)
+    source_suffix = Path(filename or "source.bin").suffix or ".bin"
+    (clip_dir / f"source{source_suffix}").write_bytes(source_bytes)
+    (clip_dir / "lcd.bin").write_bytes(lcd_payload)
+    stale_led = clip_dir / "led.bin"
+    if stale_led.exists():
+        stale_led.unlink()
+
+    package = ExpressionClipPackage(
+        clip_id=clip_id,
+        expression=expression,
+        fps=fps,
+        duration_ms=duration_ms,
+        frame_count=len(frames),
+        source_filename=filename or "upload",
+        source_content_type=content_type,
+        lcd_bytes=len(lcd_payload),
+        lcd_sha256=_sha256(lcd_payload),
+        led_effect=expression,
+        path=clip_dir,
+    )
+    manifest = package.to_manifest()
+    (clip_dir / "manifest.json").write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return manifest
+
+
+def _decode_source_frames(
+    source_bytes: bytes,
+    *,
+    filename: str,
+    grid_rows: int | None,
+    grid_cols: int | None,
+) -> list[np.ndarray]:
+    suffix = Path(filename or "").suffix.lower()
+    if suffix == ".zip":
+        return _decode_zip_frames(source_bytes)
+    if suffix in {".png", ".jpg", ".jpeg", ".webp", ".bmp"}:
+        image = _decode_image(source_bytes)
+        if grid_rows and grid_cols:
+            return _slice_sprite_sheet(image, rows=grid_rows, cols=grid_cols)
+        return [image]
+    if suffix in {".gif", ".mp4", ".mov", ".m4v", ".avi", ".webm"}:
+        return _decode_video_frames(source_bytes, suffix=suffix)
+    raise ExpressionClipError(f"unsupported source type: {suffix or filename or 'unknown'}")
+
+
+def _require_cv2():
+    try:
+        import cv2
+    except Exception as exc:  # pragma: no cover - exact ImportError varies by platform
+        raise ExpressionClipError("opencv-python is required for expression clip conversion") from exc
+    return cv2
+
+
+def _decode_image(source_bytes: bytes) -> np.ndarray:
+    cv2 = _require_cv2()
+    data = np.frombuffer(source_bytes, dtype=np.uint8)
+    image = cv2.imdecode(data, cv2.IMREAD_COLOR)
+    if image is None:
+        raise ExpressionClipError("image decode failed")
+    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+
+
+def _decode_video_frames(source_bytes: bytes, *, suffix: str) -> list[np.ndarray]:
+    cv2 = _require_cv2()
+    frames: list[np.ndarray] = []
+    with tempfile.NamedTemporaryFile(suffix=suffix) as tmp:
+        tmp.write(source_bytes)
+        tmp.flush()
+        cap = cv2.VideoCapture(tmp.name)
+        try:
+            while True:
+                ok, frame = cap.read()
+                if not ok:
+                    break
+                frames.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+        finally:
+            cap.release()
+    return frames
+
+
+def _decode_zip_frames(source_bytes: bytes) -> list[np.ndarray]:
+    frames: list[np.ndarray] = []
+    with zipfile.ZipFile(io.BytesIO(source_bytes)) as zf:
+        names = sorted(
+            name
+            for name in zf.namelist()
+            if Path(name).suffix.lower() in {".png", ".jpg", ".jpeg", ".webp", ".bmp"} and not name.endswith("/")
+        )
+        for name in names:
+            frames.append(_decode_image(zf.read(name)))
+    return frames
+
+
+def _slice_sprite_sheet(image: np.ndarray, *, rows: int, cols: int) -> list[np.ndarray]:
+    if rows <= 0 or cols <= 0:
+        raise ExpressionClipError("grid_rows and grid_cols must be positive")
+    height, width = image.shape[:2]
+    cell_w = width // cols
+    cell_h = height // rows
+    if cell_w <= 0 or cell_h <= 0:
+        raise ExpressionClipError("sprite sheet grid is larger than the source image")
+    frames: list[np.ndarray] = []
+    for row in range(rows):
+        for col in range(cols):
+            frame = image[row * cell_h : (row + 1) * cell_h, col * cell_w : (col + 1) * cell_w]
+            frames.append(frame.copy())
+    return frames
+
+
+def _rgb_to_rgb565(frame: np.ndarray) -> np.ndarray:
+    rgb = frame.astype(np.uint16)
+    red = (rgb[:, :, 0] >> 3) << 11
+    green = (rgb[:, :, 1] >> 2) << 5
+    blue = rgb[:, :, 2] >> 3
+    return (red | green | blue).astype(np.uint16)
+
+
+def _resize_rgb(frame: np.ndarray, width: int, height: int) -> np.ndarray:
+    cv2 = _require_cv2()
+    return cv2.resize(frame, (width, height), interpolation=cv2.INTER_AREA)
+
+
+def _encode_lcd_package(frames: list[np.ndarray], *, fps: int, duration_ms: int) -> bytes:
+    out = bytearray()
+    out += LCD_MAGIC
+    out += struct.pack("<HHHH", LCD_WIDTH, LCD_HEIGHT, len(frames), fps)
+    previous: np.ndarray | None = None
+    frame_duration_ms = max(1, int(round(duration_ms / len(frames))))
+    for frame in frames:
+        rgb565 = _rgb_to_rgb565(_resize_rgb(frame, LCD_WIDTH, LCD_HEIGHT))
+        if previous is None:
+            x0, y0, x1, y1 = 0, 0, LCD_WIDTH - 1, LCD_HEIGHT - 1
+        else:
+            changed = rgb565 != previous
+            if not np.any(changed):
+                x0, y0, x1, y1 = 0, 0, 1, 1
+            else:
+                ys, xs = np.where(changed)
+                x0, x1 = int(xs.min()), int(xs.max())
+                y0, y1 = int(ys.min()), int(ys.max())
+        patch = rgb565[y0 : y1 + 1, x0 : x1 + 1]
+        runs = _rle_rgb565(patch.reshape(-1))
+        out += struct.pack("<HHHHHH", x0, y0, patch.shape[1], patch.shape[0], frame_duration_ms, len(runs))
+        for count, color in runs:
+            out += struct.pack("<HH", count, color)
+        previous = rgb565
+    return bytes(out)
+
+
+def _rle_rgb565(values: np.ndarray) -> list[tuple[int, int]]:
+    if values.size == 0:
+        return []
+    runs: list[tuple[int, int]] = []
+    current = int(values[0])
+    count = 0
+    for value in values:
+        value_int = int(value)
+        if value_int == current and count < 65535:
+            count += 1
+            continue
+        runs.append((count, current))
+        current = value_int
+        count = 1
+    runs.append((count, current))
+    return runs

--- a/lampgo/expression_clips.py
+++ b/lampgo/expression_clips.py
@@ -24,7 +24,7 @@ MIN_FPS = 8
 MAX_FPS = 12
 DEFAULT_FPS = 10
 MAX_CLIPS = 10
-MAX_LCD_BYTES = 720 * 1024
+MAX_LCD_BYTES = 256 * 1024
 
 LCD_WIDTH = 320
 LCD_HEIGHT = 172
@@ -50,6 +50,10 @@ class ExpressionClipPackage:
     lcd_bytes: int
     lcd_sha256: str
     led_effect: str
+    default_led_effect_id: str | None
+    source_stored_filename: str
+    grid_rows: int | None
+    grid_cols: int | None
     path: Path
 
     def to_manifest(self) -> dict[str, Any]:
@@ -61,6 +65,16 @@ class ExpressionClipPackage:
             "frame_count": self.frame_count,
             "source_filename": self.source_filename,
             "source_content_type": self.source_content_type,
+            "kind": "eye_clip",
+            "eye_clip_id": self.clip_id,
+            "default_led_effect_id": self.default_led_effect_id,
+            "source": {
+                "filename": self.source_filename,
+                "stored_filename": self.source_stored_filename,
+                "content_type": self.source_content_type,
+                "grid_rows": self.grid_rows,
+                "grid_cols": self.grid_cols,
+            },
             "lcd": {
                 "width": LCD_WIDTH,
                 "height": LCD_HEIGHT,
@@ -141,6 +155,23 @@ def load_expression_clip(clip_id: str) -> dict[str, Any]:
     return data
 
 
+def load_expression_clip_lcd_payload(clip_id: str) -> bytes:
+    manifest = load_expression_clip(clip_id)
+    lcd_meta = manifest.get("lcd") or {}
+    filename = str(lcd_meta.get("filename") or "lcd.bin")
+    path = _clip_dir(clip_id) / filename
+    if not path.exists():
+        raise ExpressionClipError(f"lcd payload not found for clip: {clip_id}")
+    payload = path.read_bytes()
+    expected_size = int(lcd_meta.get("bytes") or 0)
+    expected_sha = str(lcd_meta.get("sha256") or "")
+    if expected_size and len(payload) != expected_size:
+        raise ExpressionClipError(f"lcd payload size mismatch for clip: {clip_id}")
+    if expected_sha and _sha256(payload) != expected_sha:
+        raise ExpressionClipError(f"lcd payload sha mismatch for clip: {clip_id}")
+    return payload
+
+
 def update_expression_clip_sync(clip_id: str, *, status: str, device: dict[str, Any] | None = None) -> dict[str, Any]:
     import time
 
@@ -204,6 +235,7 @@ def create_expression_clip(
     duration_s: float | None = None,
     grid_rows: int | None = None,
     grid_cols: int | None = None,
+    default_led_effect_id: str | None = None,
 ) -> dict[str, Any]:
     clip_id = sanitize_clip_id(clip_id)
     expression = (expression or clip_id).strip().lower()
@@ -242,7 +274,8 @@ def create_expression_clip(
     clip_dir = _clip_dir(clip_id)
     clip_dir.mkdir(parents=True, exist_ok=True)
     source_suffix = Path(filename or "source.bin").suffix or ".bin"
-    (clip_dir / f"source{source_suffix}").write_bytes(source_bytes)
+    source_stored_filename = f"source{source_suffix}"
+    (clip_dir / source_stored_filename).write_bytes(source_bytes)
     (clip_dir / "lcd.bin").write_bytes(lcd_payload)
     stale_led = clip_dir / "led.bin"
     if stale_led.exists():
@@ -259,6 +292,10 @@ def create_expression_clip(
         lcd_bytes=len(lcd_payload),
         lcd_sha256=_sha256(lcd_payload),
         led_effect=expression,
+        default_led_effect_id=(default_led_effect_id or "").strip().lower() or None,
+        source_stored_filename=source_stored_filename,
+        grid_rows=grid_rows,
+        grid_cols=grid_cols,
         path=clip_dir,
     )
     manifest = package.to_manifest()

--- a/lampgo/expression_library.py
+++ b/lampgo/expression_library.py
@@ -30,7 +30,7 @@ MAX_PRESET_BYTES = 1024
 PRESET_BUDGET_BYTES = 64 * 1024
 
 ALLOWED_ROLES = {"mouth", "symbol", "direction", "accent"}
-ALLOWED_TEMPLATES = {"mouth", "arrow", "heart", "pulse"}
+ALLOWED_TEMPLATES = {"mouth", "arrow", "heart", "pulse", "codex"}
 ALLOWED_PLAYBACK = {"once", "loop"}
 ALLOWED_DIRECTIONS = {"left", "right", "up", "down"}
 ALLOWED_MOUTH_VARIANTS = {"smile", "open", "flat", "dizzy"}
@@ -215,6 +215,26 @@ def _virtual_effects() -> list[dict[str, Any]]:
             },
         }
     )
+    effects.append(
+        {
+            "effect_id": "codex",
+            "label": "CODEX 闪烁字标",
+            "role": "symbol",
+            "source": "template",
+            "animated": True,
+            "program": {
+                "version": 1,
+                "template": "codex",
+                "defaults": {
+                    "color": "#f4f4f4",
+                    "secondary_color": "#00d8ff",
+                    "brightness": 64,
+                    "intensity": 1.0,
+                },
+            },
+            "parameter_schema": _template_parameter_schema("codex"),
+        }
+    )
     if any(eye["storage_clip_id"] == "dizzy" for eye in list_eyes()):
         effects.append(
             {
@@ -322,7 +342,7 @@ def save_led_effect(raw: dict[str, Any]) -> dict[str, Any]:
         "label": label,
         "role": role,
         "source": "custom",
-        "animated": program["template"] in {"mouth", "heart", "pulse"},
+        "animated": program["template"] in {"mouth", "heart", "pulse", "codex"},
         "program": program,
         "parameter_schema": _template_parameter_schema(program["template"]),
     }

--- a/lampgo/expression_library.py
+++ b/lampgo/expression_library.py
@@ -1,0 +1,607 @@
+"""Reusable eye, LED effect, and expression preset library.
+
+The LCD eye payload remains owned by :mod:`lampgo.expression_clips`.  This
+module adds the product-level many-to-many model without duplicating binary
+assets: presets only reference an eye clip and an LED effect.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from lampgo import personastore
+from lampgo.core.led import led_expression_catalog
+from lampgo.expression_clips import list_expression_clips, load_expression_clip
+
+MAX_EYES_CURRENT = 5
+MAX_EYE_BYTES = 256 * 1024
+C6_INSTALLED_BUDGET_BYTES = 896 * 1024
+C6_RESERVED_BYTES = 256 * 1024
+C6_STAGING_BYTES = 256 * 1024
+
+MAX_CUSTOM_LED_EFFECTS = 24
+MAX_LED_EFFECT_BYTES = 8 * 1024
+LED_EFFECT_BUDGET_BYTES = 192 * 1024
+MAX_PRESETS = 64
+MAX_PRESET_BYTES = 1024
+PRESET_BUDGET_BYTES = 64 * 1024
+
+ALLOWED_ROLES = {"mouth", "symbol", "direction", "accent"}
+ALLOWED_TEMPLATES = {"mouth", "arrow", "heart", "pulse"}
+ALLOWED_PLAYBACK = {"once", "loop"}
+ALLOWED_DIRECTIONS = {"left", "right", "up", "down"}
+ALLOWED_MOUTH_VARIANTS = {"smile", "open", "flat", "dizzy"}
+_SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+_HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+
+class ExpressionLibraryError(ValueError):
+    """Raised when an expression-library object is invalid or unsafe."""
+
+
+def expression_library_root() -> Path:
+    root = personastore.lampgo_home() / "expression_library"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _led_effect_dir() -> Path:
+    path = expression_library_root() / "led_effects"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _preset_dir() -> Path:
+    path = expression_library_root() / "presets"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def sanitize_library_id(value: str, *, field: str = "id") -> str:
+    normalized = str(value or "").strip().lower()
+    if not _SAFE_ID_RE.fullmatch(normalized):
+        raise ExpressionLibraryError(f"{field} must be 1-32 lowercase letters, numbers, dash, or underscore")
+    return normalized
+
+
+def _read_json_objects(directory: Path) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            item = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if isinstance(item, dict):
+            items.append(item)
+    return items
+
+
+def _encoded_json(data: dict[str, Any]) -> bytes:
+    return (json.dumps(data, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> int:
+    encoded = _encoded_json(data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_bytes(encoded)
+    temporary.replace(path)
+    return len(encoded)
+
+
+def eye_public_id(clip_id: str) -> str:
+    """Expose the legacy dizzy cache as the product-level ``dizzy_eyes``."""
+    return "dizzy_eyes" if clip_id == "dizzy" else clip_id
+
+
+def eye_storage_id(eye_clip_id: str) -> str:
+    eye_clip_id = sanitize_library_id(eye_clip_id, field="eye_clip_id")
+    return "dizzy" if eye_clip_id == "dizzy_eyes" else eye_clip_id
+
+
+def list_eyes() -> list[dict[str, Any]]:
+    eyes: list[dict[str, Any]] = []
+    for manifest in list_expression_clips():
+        clip_id = str(manifest.get("clip_id") or "").strip().lower()
+        if not clip_id:
+            continue
+        lcd = dict(manifest.get("lcd") or {})
+        source = dict(manifest.get("source") or {})
+        source.setdefault("filename", manifest.get("source_filename"))
+        source.setdefault("content_type", manifest.get("source_content_type"))
+        eyes.append(
+            {
+                "eye_clip_id": eye_public_id(clip_id),
+                "storage_clip_id": clip_id,
+                "label": str(manifest.get("label") or manifest.get("expression") or clip_id),
+                "fps": int(manifest.get("fps") or 0),
+                "duration_ms": int(manifest.get("duration_ms") or 0),
+                "frame_count": int(manifest.get("frame_count") or 0),
+                "lcd": lcd,
+                "source": source,
+                "default_led_effect_id": manifest.get("default_led_effect_id"),
+                "sync": dict(manifest.get("sync") or {}),
+            }
+        )
+    return eyes
+
+
+def load_eye(eye_clip_id: str) -> dict[str, Any]:
+    storage_id = eye_storage_id(eye_clip_id)
+    load_expression_clip(storage_id)
+    for eye in list_eyes():
+        if eye["storage_clip_id"] == storage_id:
+            return eye
+    raise ExpressionLibraryError(f"eye clip not found: {eye_clip_id}")
+
+
+def eye_source_path(eye_clip_id: str) -> Path:
+    eye = load_eye(eye_clip_id)
+    storage_id = str(eye["storage_clip_id"])
+    manifest = load_expression_clip(storage_id)
+    directory = personastore.lampgo_home() / "expression_clips" / storage_id
+    filename = str((manifest.get("source") or {}).get("stored_filename") or "")
+    if filename:
+        candidate = directory / Path(filename).name
+        if candidate.exists():
+            return candidate
+    candidates = sorted(path for path in directory.glob("source.*") if path.is_file())
+    if not candidates:
+        raise ExpressionLibraryError(f"eye source not found: {eye_clip_id}")
+    return candidates[0]
+
+
+def set_eye_default_led(eye_clip_id: str, led_effect_id: str | None) -> dict[str, Any]:
+    storage_id = eye_storage_id(eye_clip_id)
+    manifest = load_expression_clip(storage_id)
+    normalized_effect = str(led_effect_id or "").strip().lower() or None
+    if normalized_effect:
+        load_led_effect(normalized_effect)
+    manifest["default_led_effect_id"] = normalized_effect
+    path = personastore.lampgo_home() / "expression_clips" / storage_id / "manifest.json"
+    _atomic_write_json(path, manifest)
+    return load_eye(eye_clip_id)
+
+
+def _builtin_role(name: str) -> str:
+    if name in {"left", "right", "up", "down", "check", "cross", "exclaim", "question"}:
+        return "direction" if name in ALLOWED_DIRECTIONS else "symbol"
+    if name in {"smiley", "sad", "surprised", "blush", "angry", "thinking", "sleep", "helpless", "cool"}:
+        return "mouth"
+    return "accent"
+
+
+def _builtin_parameters(name: str) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "brightness": {"type": "integer", "minimum": 1, "maximum": 96, "default": 64},
+        "intensity": {"type": "number", "minimum": 0.1, "maximum": 1.0, "default": 1.0},
+    }
+    if name in ALLOWED_DIRECTIONS:
+        schema["direction"] = {"type": "string", "enum": sorted(ALLOWED_DIRECTIONS), "default": name}
+    return schema
+
+
+def _virtual_effects() -> list[dict[str, Any]]:
+    effects: list[dict[str, Any]] = []
+    for item in led_expression_catalog():
+        name = str(item["name"])
+        effects.append(
+            {
+                "effect_id": name,
+                "label": str(item.get("label") or name),
+                "role": _builtin_role(name),
+                "source": "builtin",
+                "animated": bool(item.get("animated")),
+                "mode": int(item["mode"]),
+                "parameter_schema": _builtin_parameters(name),
+            }
+        )
+    effects.append(
+        {
+            "effect_id": "arrow",
+            "label": "参数化箭头",
+            "role": "direction",
+            "source": "template",
+            "animated": False,
+            "program": {"version": 1, "template": "arrow", "defaults": {"direction": "right", "color": "#00ff88"}},
+            "parameter_schema": {
+                "direction": {"type": "string", "enum": sorted(ALLOWED_DIRECTIONS), "default": "right"},
+                "color": {"type": "string", "format": "color", "default": "#00ff88"},
+                "brightness": {"type": "integer", "minimum": 1, "maximum": 96, "default": 64},
+                "intensity": {"type": "number", "minimum": 0.1, "maximum": 1.0, "default": 1.0},
+            },
+        }
+    )
+    if any(eye["storage_clip_id"] == "dizzy" for eye in list_eyes()):
+        effects.append(
+            {
+                "effect_id": "dizzy_mouth",
+                "label": "眩晕大嘴",
+                "role": "mouth",
+                "source": "migration",
+                "animated": True,
+                "program": {
+                    "version": 1,
+                    "template": "mouth",
+                    "variant": "dizzy",
+                    "defaults": {"color": "#ffffff", "secondary_color": "#ff2d7a", "intensity": 1.0},
+                },
+                "parameter_schema": _template_parameter_schema("mouth"),
+            }
+        )
+    return effects
+
+
+def _template_parameter_schema(template: str) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "color": {"type": "string", "format": "color", "default": "#ffffff"},
+        "brightness": {"type": "integer", "minimum": 1, "maximum": 96, "default": 64},
+        "intensity": {"type": "number", "minimum": 0.1, "maximum": 1.0, "default": 1.0},
+    }
+    if template == "arrow":
+        schema["direction"] = {"type": "string", "enum": sorted(ALLOWED_DIRECTIONS), "default": "right"}
+    return schema
+
+
+def _normalize_color(value: Any, *, field: str) -> str:
+    color = str(value or "").strip().lower()
+    if not _HEX_COLOR_RE.fullmatch(color):
+        raise ExpressionLibraryError(f"{field} must be a #RRGGBB color")
+    return color
+
+
+def _validate_program(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ExpressionLibraryError("program must be an object")
+    if int(raw.get("version") or 1) != 1:
+        raise ExpressionLibraryError("program.version must be 1")
+    template = str(raw.get("template") or "").strip().lower()
+    if template not in ALLOWED_TEMPLATES:
+        raise ExpressionLibraryError(f"program.template must be one of: {', '.join(sorted(ALLOWED_TEMPLATES))}")
+    variant = str(raw.get("variant") or "").strip().lower()
+    if template == "mouth" and not variant:
+        variant = "open"
+    if template == "mouth" and variant and variant not in ALLOWED_MOUTH_VARIANTS:
+        raise ExpressionLibraryError(f"mouth variant must be one of: {', '.join(sorted(ALLOWED_MOUTH_VARIANTS))}")
+    defaults_raw = raw.get("defaults") or {}
+    if not isinstance(defaults_raw, dict):
+        raise ExpressionLibraryError("program.defaults must be an object")
+    defaults: dict[str, Any] = {}
+    for key in ("color", "secondary_color"):
+        if key in defaults_raw:
+            defaults[key] = _normalize_color(defaults_raw[key], field=f"program.defaults.{key}")
+    if "brightness" in defaults_raw:
+        defaults["brightness"] = max(1, min(96, int(defaults_raw["brightness"])))
+    if "intensity" in defaults_raw:
+        defaults["intensity"] = max(0.1, min(1.0, float(defaults_raw["intensity"])))
+    if "direction" in defaults_raw:
+        direction = str(defaults_raw["direction"]).strip().lower()
+        if direction not in ALLOWED_DIRECTIONS:
+            raise ExpressionLibraryError("program.defaults.direction is invalid")
+        defaults["direction"] = direction
+    program: dict[str, Any] = {"version": 1, "template": template, "defaults": defaults}
+    if variant:
+        program["variant"] = variant
+    return program
+
+
+def list_led_effects() -> list[dict[str, Any]]:
+    custom = _read_json_objects(_led_effect_dir())
+    by_id = {str(item["effect_id"]): item for item in _virtual_effects()}
+    for item in custom:
+        effect_id = str(item.get("effect_id") or "")
+        if effect_id:
+            by_id[effect_id] = item
+    return list(by_id.values())
+
+
+def load_led_effect(effect_id: str) -> dict[str, Any]:
+    effect_id = sanitize_library_id(effect_id, field="led_effect_id")
+    for effect in list_led_effects():
+        if effect["effect_id"] == effect_id:
+            return effect
+    raise ExpressionLibraryError(f"LED effect not found: {effect_id}")
+
+
+def save_led_effect(raw: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ExpressionLibraryError("LED effect must be an object")
+    effect_id = sanitize_library_id(str(raw.get("effect_id") or ""), field="effect_id")
+    if any(effect["effect_id"] == effect_id for effect in _virtual_effects()):
+        raise ExpressionLibraryError("built-in and migration LED effects cannot be overwritten")
+    role = str(raw.get("role") or "accent").strip().lower()
+    if role not in ALLOWED_ROLES:
+        raise ExpressionLibraryError(f"role must be one of: {', '.join(sorted(ALLOWED_ROLES))}")
+    label = str(raw.get("label") or effect_id).strip()[:64]
+    program = _validate_program(raw.get("program"))
+    item = {
+        "effect_id": effect_id,
+        "label": label,
+        "role": role,
+        "source": "custom",
+        "animated": program["template"] in {"mouth", "heart", "pulse"},
+        "program": program,
+        "parameter_schema": _template_parameter_schema(program["template"]),
+    }
+    encoded = _encoded_json(item)
+    if len(encoded) > MAX_LED_EFFECT_BYTES:
+        raise ExpressionLibraryError(f"LED effect exceeds {MAX_LED_EFFECT_BYTES} byte limit")
+    directory = _led_effect_dir()
+    path = directory / f"{effect_id}.json"
+    existing = _read_json_objects(directory)
+    if not path.exists() and len(existing) >= MAX_CUSTOM_LED_EFFECTS:
+        raise ExpressionLibraryError(f"maximum custom LED effects reached: {MAX_CUSTOM_LED_EFFECTS}")
+    used_without_current = sum(
+        len(_encoded_json(item)) for item in existing if str(item.get("effect_id") or "") != effect_id
+    )
+    if used_without_current + len(encoded) > LED_EFFECT_BUDGET_BYTES:
+        raise ExpressionLibraryError("custom LED effect storage budget exceeded")
+    _atomic_write_json(path, item)
+    return item
+
+
+def _normalize_led_params(raw: Any, effect: dict[str, Any] | None) -> dict[str, Any]:
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ExpressionLibraryError("led_params must be an object")
+    params: dict[str, Any] = {}
+    if "color" in raw:
+        params["color"] = _normalize_color(raw["color"], field="led_params.color")
+    if "secondary_color" in raw:
+        params["secondary_color"] = _normalize_color(raw["secondary_color"], field="led_params.secondary_color")
+    if "brightness" in raw:
+        brightness = int(raw["brightness"])
+        if not 1 <= brightness <= 96:
+            raise ExpressionLibraryError("led_params.brightness must be 1-96")
+        params["brightness"] = brightness
+    if "intensity" in raw:
+        intensity = float(raw["intensity"])
+        if not 0.1 <= intensity <= 1.0:
+            raise ExpressionLibraryError("led_params.intensity must be 0.1-1.0")
+        params["intensity"] = intensity
+    if "direction" in raw:
+        direction = str(raw["direction"]).strip().lower()
+        if direction not in ALLOWED_DIRECTIONS:
+            raise ExpressionLibraryError("led_params.direction is invalid")
+        params["direction"] = direction
+    allowed = {"color", "secondary_color", "brightness", "intensity", "direction"}
+    unknown = sorted(set(raw) - allowed)
+    if unknown:
+        raise ExpressionLibraryError(f"unsupported led_params: {', '.join(unknown)}")
+    if effect and effect.get("source") == "builtin" and "color" in params:
+        # Firmware built-ins use their authored palettes. Keep the value for UI
+        # round-tripping, while the device may ignore it.
+        params["color"] = params["color"]
+    return params
+
+
+def _stored_presets() -> list[dict[str, Any]]:
+    return _read_json_objects(_preset_dir())
+
+
+def _virtual_dizzy_preset() -> dict[str, Any] | None:
+    if not any(eye["eye_clip_id"] == "dizzy_eyes" for eye in list_eyes()):
+        return None
+    return {
+        "preset_id": "dizzy",
+        "label": "眩晕",
+        "description": "蚊香眼与眩晕大嘴联动",
+        "eye_clip_id": "dizzy_eyes",
+        "led_effect_id": "dizzy_mouth",
+        "led_params": {},
+        "playback": "once",
+        "duration_ms": 3000,
+        "source": "migration",
+    }
+
+
+def list_expression_presets() -> list[dict[str, Any]]:
+    by_id: dict[str, dict[str, Any]] = {}
+    dizzy = _virtual_dizzy_preset()
+    if dizzy:
+        by_id["dizzy"] = dizzy
+    for item in _stored_presets():
+        preset_id = str(item.get("preset_id") or "")
+        if preset_id:
+            by_id[preset_id] = item
+    return list(by_id.values())
+
+
+def load_expression_preset(preset_id: str) -> dict[str, Any]:
+    preset_id = sanitize_library_id(preset_id, field="preset_id")
+    for preset in list_expression_presets():
+        if preset["preset_id"] == preset_id:
+            return preset
+    raise ExpressionLibraryError(f"expression preset not found: {preset_id}")
+
+
+def save_expression_preset(raw: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ExpressionLibraryError("preset must be an object")
+    preset_id = sanitize_library_id(str(raw.get("preset_id") or ""), field="preset_id")
+    eye_id = str(raw.get("eye_clip_id") or "").strip().lower() or None
+    led_id = str(raw.get("led_effect_id") or "").strip().lower() or None
+    if not eye_id and not led_id:
+        raise ExpressionLibraryError("preset requires an eye_clip_id or led_effect_id")
+    eye = load_eye(eye_id) if eye_id else None
+    effect = load_led_effect(led_id) if led_id else None
+    playback = str(raw.get("playback") or "once").strip().lower()
+    if playback not in ALLOWED_PLAYBACK:
+        raise ExpressionLibraryError("playback must be once or loop")
+    duration_ms = int(raw.get("duration_ms") or (eye or {}).get("duration_ms") or 3000)
+    if not 2500 <= duration_ms <= 3500:
+        raise ExpressionLibraryError("duration_ms must be 2500-3500")
+    item = {
+        "preset_id": preset_id,
+        "label": str(raw.get("label") or preset_id).strip()[:64],
+        "description": str(raw.get("description") or "").strip()[:240],
+        "eye_clip_id": eye_id,
+        "led_effect_id": led_id,
+        "led_params": _normalize_led_params(raw.get("led_params"), effect),
+        "playback": playback,
+        "duration_ms": duration_ms,
+        "source": str(raw.get("source") or "user").strip()[:32],
+    }
+    encoded = _encoded_json(item)
+    if len(encoded) > MAX_PRESET_BYTES:
+        raise ExpressionLibraryError(f"preset exceeds {MAX_PRESET_BYTES} byte limit")
+    directory = _preset_dir()
+    path = directory / f"{preset_id}.json"
+    existing = _stored_presets()
+    if not path.exists() and len(existing) >= MAX_PRESETS:
+        raise ExpressionLibraryError(f"maximum expression presets reached: {MAX_PRESETS}")
+    used_without_current = sum(
+        len(_encoded_json(item)) for item in existing if str(item.get("preset_id") or "") != preset_id
+    )
+    if used_without_current + len(encoded) > PRESET_BUDGET_BYTES:
+        raise ExpressionLibraryError("expression preset storage budget exceeded")
+    _atomic_write_json(path, item)
+    return item
+
+
+def resolve_expression(raw: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ExpressionLibraryError("expression request must be an object")
+    preset: dict[str, Any] | None = None
+    preset_id = str(raw.get("preset_id") or "").strip().lower()
+    expression_id = str(raw.get("expression_id") or "").strip().lower()
+    if preset_id:
+        preset = load_expression_preset(preset_id)
+    elif expression_id:
+        try:
+            preset = load_expression_preset(expression_id)
+        except ExpressionLibraryError:
+            preset = None
+
+    eye_id = str(raw.get("eye_clip_id") or (preset or {}).get("eye_clip_id") or "").strip().lower() or None
+    led_explicit = "led_effect_id" in raw
+    led_id = str(raw.get("led_effect_id") or "").strip().lower() if led_explicit else str(
+        (preset or {}).get("led_effect_id") or ""
+    ).strip().lower()
+    if expression_id and not preset and not eye_id and not led_id:
+        try:
+            load_eye(expression_id)
+            eye_id = expression_id
+        except Exception:
+            load_led_effect(expression_id)
+            led_id = expression_id
+
+    eye = load_eye(eye_id) if eye_id else None
+    if not led_explicit and not led_id and eye:
+        led_id = str(eye.get("default_led_effect_id") or "").strip().lower()
+    effect = load_led_effect(led_id) if led_id else None
+    if not eye and not effect:
+        raise ExpressionLibraryError("expression requires an eye clip or LED effect")
+
+    merged_params = dict((preset or {}).get("led_params") or {})
+    merged_params.update(raw.get("led_params") or {})
+    playback = str(raw.get("playback") or (preset or {}).get("playback") or "once").strip().lower()
+    if playback not in ALLOWED_PLAYBACK:
+        raise ExpressionLibraryError("playback must be once or loop")
+    duration_ms = int(
+        raw.get("duration_ms") or (preset or {}).get("duration_ms") or (eye or {}).get("duration_ms") or 3000
+    )
+    if not 2500 <= duration_ms <= 3500:
+        raise ExpressionLibraryError("duration_ms must be 2500-3500")
+    return {
+        "preset_id": (preset or {}).get("preset_id"),
+        "eye_clip_id": eye_id,
+        "eye_storage_clip_id": (eye or {}).get("storage_clip_id"),
+        "led_effect_id": led_id or None,
+        "led_effect": effect,
+        "led_params": _normalize_led_params(merged_params, effect),
+        "playback": playback,
+        "duration_ms": duration_ms,
+        "persist": False,
+    }
+
+
+def expression_capabilities() -> dict[str, Any]:
+    eyes = list_eyes()
+    custom_effects = [item for item in _read_json_objects(_led_effect_dir())]
+    presets = _stored_presets()
+    eye_used = sum(int((item.get("lcd") or {}).get("bytes") or 0) for item in eyes)
+    led_used = sum(len(_encoded_json(item)) for item in custom_effects)
+    preset_used = sum(len(_encoded_json(item)) for item in presets)
+    return {
+        "eyes": {
+            "installed": len(eyes),
+            "max_count": MAX_EYES_CURRENT,
+            "used_bytes": eye_used,
+            "budget_bytes": C6_INSTALLED_BUDGET_BYTES,
+            "single_max_bytes": MAX_EYE_BYTES,
+            "reserved_bytes": C6_RESERVED_BYTES,
+            "staging_bytes": C6_STAGING_BYTES,
+        },
+        "led_effects": {
+            "installed_custom": len(custom_effects),
+            "builtin": len(led_expression_catalog()),
+            "max_custom_count": MAX_CUSTOM_LED_EFFECTS,
+            "used_bytes": led_used,
+            "budget_bytes": LED_EFFECT_BUDGET_BYTES,
+            "single_max_bytes": MAX_LED_EFFECT_BYTES,
+        },
+        "presets": {
+            "installed": len(presets),
+            "max_count": MAX_PRESETS,
+            "used_bytes": preset_used,
+            "budget_bytes": PRESET_BUDGET_BYTES,
+            "single_max_bytes": MAX_PRESET_BYTES,
+        },
+    }
+
+
+def build_expression_prompt() -> str:
+    eyes = ", ".join(item["eye_clip_id"] for item in list_eyes()) or "none"
+    effects = ", ".join(item["effect_id"] for item in list_led_effects())
+    presets = ", ".join(item["preset_id"] for item in list_expression_presets()) or "none"
+    return (
+        "Expression capabilities:\n"
+        f"- Eye clips (C6): {eyes}\n"
+        f"- LED effects (S3): {effects}\n"
+        f"- Saved presets: {presets}\n"
+        "Use saved presets when possible. A transient composition may be played without saving; "
+        "saving a new preset requires explicit user confirmation."
+    )
+
+
+def expression_schemas() -> dict[str, Any]:
+    return {
+        "eye_clip": {
+            "type": "object",
+            "required": ["eye_clip_id", "fps", "duration_ms", "frame_count", "lcd"],
+            "properties": {
+                "eye_clip_id": {"type": "string", "pattern": _SAFE_ID_RE.pattern},
+                "default_led_effect_id": {"type": ["string", "null"]},
+                "fps": {"type": "integer", "minimum": 8, "maximum": 12},
+                "duration_ms": {"type": "integer", "minimum": 2500, "maximum": 3500},
+            },
+        },
+        "led_effect": {
+            "type": "object",
+            "required": ["effect_id", "role", "program"],
+            "properties": {
+                "effect_id": {"type": "string", "pattern": _SAFE_ID_RE.pattern},
+                "role": {"enum": sorted(ALLOWED_ROLES)},
+                "program": {
+                    "type": "object",
+                    "properties": {"version": {"const": 1}, "template": {"enum": sorted(ALLOWED_TEMPLATES)}},
+                },
+            },
+        },
+        "expression_preset": {
+            "type": "object",
+            "required": ["preset_id", "playback", "duration_ms"],
+            "properties": {
+                "preset_id": {"type": "string", "pattern": _SAFE_ID_RE.pattern},
+                "eye_clip_id": {"type": ["string", "null"]},
+                "led_effect_id": {"type": ["string", "null"]},
+                "playback": {"enum": sorted(ALLOWED_PLAYBACK)},
+                "duration_ms": {"type": "integer", "minimum": 2500, "maximum": 3500},
+            },
+        },
+    }

--- a/lampgo/recordings.py
+++ b/lampgo/recordings.py
@@ -8,10 +8,12 @@ name.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
 MAX_RECORDING_DESCRIPTION_CHARS = 500
+_SAFE_PRESET_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
 LED_EXPRESSION_KEYS = (
     "off",
     "red",
@@ -79,6 +81,11 @@ def _normalize_expression(value: Any) -> str:
     return key if key in LED_EXPRESSION_KEYS else ""
 
 
+def _normalize_expression_preset(value: Any) -> str:
+    preset_id = str(value or "").strip().lower()
+    return preset_id if _SAFE_PRESET_ID_RE.match(preset_id) else ""
+
+
 def normalize_recording_description(value: Any) -> str:
     text = str(value or "").replace("\r\n", "\n").replace("\r", "\n").strip()
     lines = [line.strip() for line in text.split("\n") if line.strip()]
@@ -94,6 +101,7 @@ def parse_recording_metadata(text: str) -> dict[str, str]:
     """Parse optional recording sidecar metadata, preserving old plain text files."""
     description_parts: list[str] = []
     expression = ""
+    expression_preset = ""
 
     for raw_line in str(text or "").replace("\r\n", "\n").replace("\r", "\n").split("\n"):
         line = raw_line.strip()
@@ -103,6 +111,8 @@ def parse_recording_metadata(text: str) -> dict[str, str]:
         normalized_key = key.strip().lower()
         if sep and normalized_key == "expression":
             expression = _normalize_expression(value) or expression
+        elif sep and normalized_key in {"expression_preset", "preset", "preset_id"}:
+            expression_preset = _normalize_expression_preset(value) or expression_preset
         elif sep and normalized_key in {"prompt", "description"}:
             description_parts.append(value.strip())
         else:
@@ -111,28 +121,37 @@ def parse_recording_metadata(text: str) -> dict[str, str]:
     return {
         "description": normalize_recording_description("\n".join(description_parts)),
         "expression": expression,
+        "expression_preset": expression_preset,
     }
 
 
 def read_recording_metadata(csv_path: Path) -> dict[str, str]:
     path = recording_description_path(csv_path)
     if not path.exists():
-        return {"description": "", "expression": ""}
+        return {"description": "", "expression": "", "expression_preset": ""}
     try:
         return parse_recording_metadata(path.read_text(encoding="utf-8"))
     except Exception:
-        return {"description": "", "expression": ""}
+        return {"description": "", "expression": "", "expression_preset": ""}
 
 
 def read_recording_description(csv_path: Path) -> str:
     return read_recording_metadata(csv_path)["description"]
 
 
-def write_recording_description(csv_path: Path, description: str, expression: str = "") -> None:
+def write_recording_description(
+    csv_path: Path,
+    description: str,
+    expression: str = "",
+    expression_preset: str = "",
+) -> None:
     text = normalize_recording_description(description)
     expression = _normalize_expression(expression)
+    expression_preset = _normalize_expression_preset(expression_preset)
     path = recording_description_path(csv_path)
     lines = []
+    if expression_preset:
+        lines.append(f"expression_preset={expression_preset}")
     if expression:
         lines.append(f"expression={expression}")
     if text:
@@ -187,6 +206,7 @@ def list_recording_catalog(recordings_dir: Path) -> list[dict[str, str]]:
             "path": str(csv_path),
             "description": metadata["description"],
             "expression": metadata["expression"],
+            "expression_preset": metadata["expression_preset"],
         }
     user_dir = recordings_dir / "user"
     if user_dir.is_dir():
@@ -198,6 +218,7 @@ def list_recording_catalog(recordings_dir: Path) -> list[dict[str, str]]:
                 "path": str(csv_path),
                 "description": metadata["description"],
                 "expression": metadata["expression"],
+                "expression_preset": metadata["expression_preset"],
             }
     _assign_catalog_expressions(entries)
     return [entries[name] for name in sorted(entries)]
@@ -211,8 +232,8 @@ def build_recording_actions_prompt(recordings_dir: Path) -> str:
         "Recorded action library (dynamic; loaded from CSV/TXT files):",
         "- Use `play_recording` with the exact `name` when the user's request, camera scene, emotion, "
         "or conversation context matches an action description.",
-        "- If a listed recording includes an `expression=...` hint, prefer that expression before or "
-        "alongside the action unless the user explicitly asked for a different mood.",
+        "- If a listed recording includes `expression_preset=...`, pass it to `play_recording` so C6 eyes "
+        "and the S3 LED panel start together. Otherwise use `expression=...` as the LED-only fallback.",
         "- Do not invent recording names. If no listed action fits, use another tool or speak instead.",
     ]
     if not catalog:
@@ -223,7 +244,13 @@ def build_recording_actions_prompt(recordings_dir: Path) -> str:
         source = "我的录制" if item.get("source") == "user" else "内置动作"
         desc = item.get("description") or "暂无动作说明；仅在用户明确点名该动作名时使用。"
         expression = item.get("expression")
-        if expression:
+        expression_preset = item.get("expression_preset")
+        if expression_preset:
+            fallback = f" | expression={expression}" if expression else ""
+            lines.append(
+                f"- name={name} | source={source} | expression_preset={expression_preset}{fallback} | prompt={desc}"
+            )
+        elif expression:
             lines.append(f"- name={name} | source={source} | expression={expression} | prompt={desc}")
         else:
             lines.append(f"- name={name} | source={source} | prompt={desc}")

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -395,6 +395,7 @@ class LampgoServer:
                 overwrite=bool(data.get("overwrite", False)),
                 description=str(data.get("description", "") or data.get("prompt", "")),
                 expression=str(data.get("expression", "")),
+                expression_preset=str(data.get("expression_preset", "") or data.get("preset_id", "")),
             )
 
         if cmd == "recording_discard":
@@ -573,6 +574,7 @@ class LampgoServer:
         overwrite: bool = False,
         description: str = "",
         expression: str = "",
+        expression_preset: str = "",
     ) -> dict[str, Any]:
         """Persist buffered recording frames to <recordings_dir>/user/<name>.csv."""
         async with self._record_lock:
@@ -600,7 +602,7 @@ class LampgoServer:
                 }
 
             path = rec.save(name)
-            write_recording_description(Path(path), description, expression)
+            write_recording_description(Path(path), description, expression, expression_preset)
             frames = rec.frame_count
             self._record_recorder = None
             self._record_started_at = 0.0
@@ -615,6 +617,7 @@ class LampgoServer:
                     "path": str(path),
                     "description": description,
                     "expression": expression,
+                    "expression_preset": expression_preset,
                     "frames": frames,
                     "record_playback_notes": {
                         "record": "samples HAL joint positions only (no style interpolation)",

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -179,7 +179,10 @@ class LampgoServer:
         )
 
     def _recording_actions_prompt(self) -> str:
-        return build_recording_actions_prompt(Path(self.config.recordings_dir))
+        from lampgo.expression_library import build_expression_prompt
+
+        recordings = build_recording_actions_prompt(Path(self.config.recordings_dir))
+        return f"{recordings}\n\n{build_expression_prompt()}".strip()
 
     # ---- user / composed skills (JSON-defined, created by OpenClaw & UI) ----
 

--- a/lampgo/skills/builtin/expression_skills.py
+++ b/lampgo/skills/builtin/expression_skills.py
@@ -11,15 +11,21 @@ from lampgo.skills.base import ParameterSpec, Skill, SkillContext
 
 class SetExpressionSkill(Skill):
     skill_id = "set_expression"
-    description = "Set an LED expression (e.g. smiley, heart, angry, myu7gt)."
+    description = "Play a dynamic expression preset, eye clip, or LED effect without saving a new preset."
     parameters = {
         "expression": ParameterSpec(
             name="expression",
             type="str",
-            description=f"Expression name. Options: {', '.join(LED_EXPRESSIONS.keys())}",
+            description=(
+                "Expression preset, eye clip, or LED effect id. Built-ins include: "
+                f"{', '.join(LED_EXPRESSIONS.keys())}. Dynamic ids are listed by /api/expressions."
+            ),
         ),
         "brightness": ParameterSpec(
             name="brightness", type="int", required=False, default=200, description="Brightness 1-255"
+        ),
+        "playback": ParameterSpec(
+            name="playback", type="str", required=False, default="once", description="once or loop"
         ),
     }
 
@@ -30,8 +36,18 @@ class SetExpressionSkill(Skill):
 
         canonical = canonical_expression_name(str(expression))
         if canonical is None:
-            valid = ", ".join(LED_EXPRESSIONS.keys())
-            return SkillResult(status="error", message=f"Unknown expression: {expression}. Valid: {valid}")
+            ok, composition = ctx.led.play_expression(
+                str(expression),
+                playback=str(params.get("playback") or "once"),
+                led_params={"brightness": min(96, int(params.get("brightness") or 64))},
+            )
+            if not ok or composition is None:
+                valid = ", ".join(LED_EXPRESSIONS.keys())
+                return SkillResult(
+                    status="error",
+                    message=f"Unknown or unavailable expression: {expression}. Built-ins: {valid}",
+                )
+            return SkillResult(status="ok", data={"expression": str(expression), "composition": composition})
 
         brightness = params.get("brightness")
         if brightness is not None:

--- a/lampgo/skills/builtin/playback_skills.py
+++ b/lampgo/skills/builtin/playback_skills.py
@@ -94,6 +94,12 @@ class PlayRecordingSkill(Skill):
             required=False,
             description="Optional LED expression to apply before playback",
         ),
+        "expression_preset": ParameterSpec(
+            name="expression_preset",
+            type="str",
+            required=False,
+            description="Optional ExpressionPreset id looped on C6 eyes and S3 LED for the full recording playback",
+        ),
         "playback_mode": ParameterSpec(
             name="playback_mode",
             type="str",
@@ -103,17 +109,36 @@ class PlayRecordingSkill(Skill):
         ),
     }
 
-    _motion = None
-
     def __init__(self, recordings_dir: Path) -> None:
         self._recordings_dir = recordings_dir
+        self._motion = None
+        self._expression_controller = None
+
+    def _stop_bound_expression(self, *, name: str = "") -> None:
+        controller = self._expression_controller
+        self._expression_controller = None
+        if controller is None:
+            return
+        stop_expression = getattr(controller, "stop_expression", None)
+        if not callable(stop_expression):
+            logger.warning("playback.expression_preset_stop_unavailable", name=name)
+            return
+        try:
+            if stop_expression():
+                logger.info("playback.expression_preset_stopped", name=name)
+            else:
+                logger.warning("playback.expression_preset_stop_failed", name=name)
+        except Exception:
+            logger.exception("playback.expression_preset_stop_error", name=name)
 
     async def execute(self, ctx: SkillContext, **params: Any) -> SkillResult:
-        self._motion = ctx.motion
+        self._motion = None
+        self._expression_controller = None
         name = params.get("name", "")
         if not name:
             return SkillResult(status="error", message="Recording name required")
         expression = str(params.get("expression", "")).strip()
+        expression_preset = str(params.get("expression_preset", "") or params.get("preset_id", "")).strip()
         raw_mode = params.get("playback_mode")
         if raw_mode is None or not str(raw_mode).strip():
             # Fall back to the server-wide default configured via Web UI /
@@ -147,15 +172,40 @@ class PlayRecordingSkill(Skill):
         fps = int(params.get("fps", 0)) or DEFAULT_RECORDING_FPS_OVERRIDES.get(name, detected_fps)
         logger.info("playback.start", name=name, frames=len(frames), fps=fps, playback_mode=playback_mode)
 
-        if expression:
-            if ctx.led.is_connected:
-                if not ctx.led.set_mode(expression):
-                    return SkillResult(status="error", message=f"Unknown expression: {expression}")
-                logger.info("playback.expression_applied", name=name, expression=expression)
-            else:
-                logger.warning("playback.expression_skipped_led_disconnected", name=name, expression=expression)
-
         try:
+            if expression_preset:
+                play_expression = getattr(ctx.led, "play_expression", None)
+                if not callable(play_expression):
+                    return SkillResult(
+                        status="error",
+                        message="Expression presets require an LED/expression controller",
+                    )
+                ok, composition = play_expression(expression_preset, playback="loop")
+                if composition is None:
+                    return SkillResult(status="error", message=f"Unknown expression preset: {expression_preset}")
+                if ok:
+                    self._expression_controller = ctx.led
+                    logger.info(
+                        "playback.expression_preset_applied",
+                        name=name,
+                        expression_preset=expression_preset,
+                        playback="loop",
+                    )
+                else:
+                    logger.warning(
+                        "playback.expression_preset_skipped_device_unavailable",
+                        name=name,
+                        expression_preset=expression_preset,
+                    )
+            elif expression:
+                if ctx.led.is_connected:
+                    if not ctx.led.set_mode(expression):
+                        return SkillResult(status="error", message=f"Unknown expression: {expression}")
+                    logger.info("playback.expression_applied", name=name, expression=expression)
+                else:
+                    logger.warning("playback.expression_skipped_led_disconnected", name=name, expression=expression)
+
+            self._motion = ctx.motion
             # Trajectory-based: stream the full frame sequence at original FPS.
             # The recorded human motion already contains natural acceleration/deceleration;
             # no style easing is applied on top.
@@ -164,32 +214,35 @@ class PlayRecordingSkill(Skill):
             if not await _await_done(done, timeout=timeout):
                 logger.warning("playback.timeout", name=name, frames=len(frames), fps=fps)
                 return SkillResult(status="error", message=f"Playback '{name}' timed out")
+
+            # Return to safe: goal-based (only the target pose is known).
+            safe = get_safe_position()
+            logger.info("playback.return_safe_start", name=name, target=safe)
+            return_done = ctx.motion.move_to(
+                MotionTarget(joints=dict(safe), max_velocity=60.0, anticipation=False)
+            )
+            if not await _await_done(return_done, timeout=RETURN_SAFE_TIMEOUT_S):
+                logger.warning("playback.return_safe_timeout", name=name, target=safe)
+                return SkillResult(status="error", message=f"Playback '{name}' finished but return_safe timed out")
+            logger.info("playback.return_safe_done", name=name)
+
+            return SkillResult(
+                status="ok",
+                data={
+                    "name": name,
+                    "frames": len(frames),
+                    "fps": fps,
+                    "playback_mode": playback_mode,
+                    "expression": expression or None,
+                    "expression_preset": expression_preset or None,
+                    "returned_safe": True,
+                },
+            )
         finally:
             self._motion = None
-
-        # Return to safe: goal-based (only the target pose is known).
-        safe = get_safe_position()
-        logger.info("playback.return_safe_start", name=name, target=safe)
-        return_done = ctx.motion.move_to(
-            MotionTarget(joints=dict(safe), max_velocity=60.0, anticipation=False)
-        )
-        if not await _await_done(return_done, timeout=RETURN_SAFE_TIMEOUT_S):
-            logger.warning("playback.return_safe_timeout", name=name, target=safe)
-            return SkillResult(status="error", message=f"Playback '{name}' finished but return_safe timed out")
-        logger.info("playback.return_safe_done", name=name)
-
-        return SkillResult(
-            status="ok",
-            data={
-                "name": name,
-                "frames": len(frames),
-                "fps": fps,
-                "playback_mode": playback_mode,
-                "expression": expression or None,
-                "returned_safe": True,
-            },
-        )
+            self._stop_bound_expression(name=name)
 
     async def cancel(self) -> None:
         if self._motion is not None:
             self._motion.stop_immediate()
+        self._stop_bound_expression()

--- a/lampgo/web/gateway.py
+++ b/lampgo/web/gateway.py
@@ -33,11 +33,25 @@ from lampgo.core.led import led_expression_catalog
 from lampgo.device.audio_stream import redact_ws_owner_token
 from lampgo.expression_clips import (
     ExpressionClipError,
-    build_sync_chunks,
     create_expression_clip,
     list_expression_clips,
     load_expression_clip,
+    load_expression_clip_lcd_payload,
     update_expression_clip_sync,
+)
+from lampgo.expression_library import (
+    ExpressionLibraryError,
+    expression_capabilities,
+    expression_schemas,
+    eye_source_path,
+    eye_storage_id,
+    list_expression_presets,
+    list_eyes,
+    list_led_effects,
+    resolve_expression,
+    save_expression_preset,
+    save_led_effect,
+    set_eye_default_led,
 )
 from lampgo.perception.camera import CameraCapture
 from lampgo.recordings import (
@@ -202,6 +216,16 @@ class WebGateway:
             Route("/api/recordings/aliases", self.api_recording_aliases, methods=["GET", "POST"]),
             Route("/api/expressions", self.api_expressions),
             Route("/api/expression-clips", self.api_expression_clips, methods=["GET", "POST"]),
+            Route("/api/eyes", self.api_eyes, methods=["GET"]),
+            Route("/api/eyes/{eye_id:str}", self.api_eye_update, methods=["POST"]),
+            Route("/api/eyes/{eye_id:str}/source", self.api_eye_source, methods=["GET"]),
+            Route("/api/eyes/{eye_id:str}/sync", self.api_eye_sync, methods=["POST"]),
+            Route("/api/led-effects", self.api_led_effects, methods=["GET", "POST"]),
+            Route("/api/expression-presets", self.api_expression_presets, methods=["GET", "POST"]),
+            Route("/api/expressions/preview", self.api_expression_preview, methods=["POST"]),
+            Route("/api/expressions/play", self.api_expression_play, methods=["POST"]),
+            Route("/api/expressions/stop", self.api_expression_stop, methods=["POST"]),
+            Route("/api/device/expression-capabilities", self.api_expression_capabilities, methods=["GET"]),
             Route("/api/camera/snap", self.api_camera_snap),
             Route("/api/sensor/context", self.api_sensor_context),
             Route("/api/openclaw/ask", self.api_openclaw_ask, methods=["POST"]),
@@ -808,9 +832,164 @@ class WebGateway:
                 "result": {
                     "expressions": self._list_expressions(),
                     "expression_catalog": self._list_expression_catalog(),
+                    "eyes": list_eyes(),
+                    "led_effects": list_led_effects(),
+                    "presets": list_expression_presets(),
                 },
             }
         )
+
+    async def api_eyes(self, request: Request) -> JSONResponse:
+        return JSONResponse(
+            {
+                "ok": True,
+                "result": {
+                    "eyes": list_eyes(),
+                    "capacity": expression_capabilities()["eyes"],
+                    "schema": expression_schemas()["eye_clip"],
+                },
+            }
+        )
+
+    async def api_eye_source(self, request: Request) -> FileResponse | JSONResponse:
+        eye_id = str(request.path_params.get("eye_id") or "")
+        try:
+            path = eye_source_path(eye_id)
+        except (ExpressionLibraryError, ExpressionClipError) as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=404)
+        return FileResponse(path)
+
+    async def api_eye_update(self, request: Request) -> JSONResponse:
+        eye_id = str(request.path_params.get("eye_id") or "")
+        try:
+            body = await request.json()
+            if not isinstance(body, dict):
+                raise ExpressionLibraryError("eye update body must be an object")
+            eye = set_eye_default_led(eye_id, body.get("default_led_effect_id"))
+        except (ExpressionLibraryError, ExpressionClipError, ValueError, TypeError) as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+        return JSONResponse({"ok": True, "result": {"eye": eye}})
+
+    async def api_eye_sync(self, request: Request) -> JSONResponse:
+        eye_id = str(request.path_params.get("eye_id") or "")
+        return await self._sync_eye_response(eye_id)
+
+    async def api_led_effects(self, request: Request) -> JSONResponse:
+        if request.method == "GET":
+            return JSONResponse(
+                {
+                    "ok": True,
+                    "result": {
+                        "led_effects": list_led_effects(),
+                        "capacity": expression_capabilities()["led_effects"],
+                        "schema": expression_schemas()["led_effect"],
+                    },
+                }
+            )
+        try:
+            body = await request.json()
+            effect = save_led_effect(body)
+        except (ExpressionLibraryError, ValueError, TypeError) as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+        return JSONResponse({"ok": True, "result": {"led_effect": effect}})
+
+    async def api_expression_presets(self, request: Request) -> JSONResponse:
+        if request.method == "GET":
+            return JSONResponse(
+                {
+                    "ok": True,
+                    "result": {
+                        "presets": list_expression_presets(),
+                        "capacity": expression_capabilities()["presets"],
+                        "schema": expression_schemas()["expression_preset"],
+                    },
+                }
+            )
+        try:
+            body = await request.json()
+            if not isinstance(body, dict):
+                raise ExpressionLibraryError("preset body must be an object")
+            if body.get("confirmed") is not True:
+                raise ExpressionLibraryError("saving a preset requires confirmed=true")
+            preset = save_expression_preset(body)
+        except (ExpressionLibraryError, ValueError, TypeError) as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+        return JSONResponse({"ok": True, "result": {"preset": preset}})
+
+    async def api_expression_preview(self, request: Request) -> JSONResponse:
+        try:
+            body = await request.json()
+            composition = resolve_expression(body)
+        except (ExpressionLibraryError, ExpressionClipError, ValueError, TypeError) as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+        duration_ms = int(composition["duration_ms"])
+        return JSONResponse(
+            {
+                "ok": True,
+                "result": {
+                    "composition": composition,
+                    "preview": {
+                        "duration_ms": duration_ms,
+                        "phase_start": 0.0,
+                        "phase_end": 1.0,
+                        "channels_start_together": True,
+                    },
+                },
+            }
+        )
+
+    async def _play_resolved_expression(self, composition: dict[str, Any]) -> tuple[int, Any]:
+        if not self.server.esp32:
+            return 503, {"ok": False, "error": "no_device"}
+        effect = composition.get("led_effect") or {}
+        payload: dict[str, Any] = {
+            "eye_clip_id": composition.get("eye_storage_clip_id"),
+            "led_effect_id": composition.get("led_effect_id"),
+            "led_params": composition.get("led_params") or {},
+            "playback": composition.get("playback") or "once",
+            "duration_ms": int(composition.get("duration_ms") or 3000),
+        }
+        if composition.get("preset_id"):
+            payload["preset_id"] = composition["preset_id"]
+        if effect.get("mode") is not None:
+            payload["led_mode"] = int(effect["mode"])
+        if isinstance(effect.get("program"), dict):
+            payload["led_program"] = effect["program"]
+        payload = self.server.esp32.with_owner_auth(payload, reason="expression_play")
+        status, response, _ = await self.server.esp32.proxy_post("/device/expressions/play", payload)
+        return status, response
+
+    async def api_expression_play(self, request: Request) -> JSONResponse:
+        try:
+            body = await request.json()
+            composition = resolve_expression(body)
+        except (ExpressionLibraryError, ExpressionClipError, ValueError, TypeError) as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+        status, device_body = await self._play_resolved_expression(composition)
+        ok = status < 400 and not (isinstance(device_body, dict) and device_body.get("ok") is False)
+        return JSONResponse(
+            {"ok": ok, "result": {"composition": composition, "device": device_body}},
+            status_code=status,
+        )
+
+    async def api_expression_stop(self, request: Request) -> JSONResponse:
+        if not self.server.esp32:
+            return JSONResponse({"ok": False, "error": "no_device"}, status_code=503)
+        payload = self.server.esp32.with_owner_auth({}, reason="expression_stop")
+        status, body, _ = await self.server.esp32.proxy_post("/device/expressions/stop", payload)
+        return JSONResponse(body if isinstance(body, dict) else {"ok": False, "raw": str(body)}, status_code=status)
+
+    async def api_expression_capabilities(self, request: Request) -> JSONResponse:
+        local = expression_capabilities()
+        device: Any = None
+        if self.server.esp32:
+            try:
+                status, body, _ = await self.server.esp32.proxy_get("/device/expression-capabilities")
+                if status < 400 and isinstance(body, dict):
+                    device = body.get("result") or body
+            except Exception:
+                logger.exception("expression_capabilities.device_failed")
+        return JSONResponse({"ok": True, "result": {"library": local, "device": device}})
 
     async def api_expression_clips(self, request: Request) -> JSONResponse:
         if request.method == "GET":
@@ -850,6 +1029,7 @@ class WebGateway:
                 "duration_s": float(body["duration_s"]) if body.get("duration_s") is not None else None,
                 "grid_rows": int(body["grid_rows"]) if body.get("grid_rows") is not None else None,
                 "grid_cols": int(body["grid_cols"]) if body.get("grid_cols") is not None else None,
+                "default_led_effect_id": str(body.get("default_led_effect_id") or "") or None,
             }
 
         query = request.query_params
@@ -865,6 +1045,7 @@ class WebGateway:
             "duration_s": float(query["duration_s"]) if query.get("duration_s") else None,
             "grid_rows": int(query["grid_rows"]) if query.get("grid_rows") else None,
             "grid_cols": int(query["grid_cols"]) if query.get("grid_cols") else None,
+            "default_led_effect_id": query.get("default_led_effect_id") or None,
         }
 
     async def api_camera_snap(self, request: Request) -> JSONResponse:
@@ -2251,7 +2432,12 @@ class WebGateway:
         wake_requested_model = ""
         wake_supported_models: list[str] = []
         led_status: dict[str, Any] = {}
-        if cfg.enabled and self.server.esp32:
+        transfer_active = bool(
+            self.server.esp32
+            and hasattr(self.server.esp32, "is_transfer_active")
+            and self.server.esp32.is_transfer_active()
+        )
+        if cfg.enabled and self.server.esp32 and not transfer_active:
             try:
                 device_status_code, device_body, _ = await asyncio.wait_for(
                     self.server.esp32.proxy_get("/device/status"),
@@ -2298,6 +2484,7 @@ class WebGateway:
                     "led": led_status,
                     "configured": status["configured"],
                     "online": status["online"],
+                    "transfer_active": status.get("transfer_active", False),
                     "session_used": status["session_used"],
                     "owner_id": status.get("owner_id"),
                     "owner_label": status.get("owner_label"),
@@ -2369,14 +2556,23 @@ class WebGateway:
             return JSONResponse({"ok": False, "error": "invalid JSON body"}, status_code=400)
         if not isinstance(patch, dict):
             return JSONResponse({"ok": False, "error": "body must be object"}, status_code=400)
+        candidate = str(patch.get("preset_id") or patch.get("clip_id") or patch.get("expression") or "").strip().lower()
+        preset_ids = {str(item.get("preset_id") or "") for item in list_expression_presets()}
+        if patch.get("preset_id") or candidate in preset_ids:
+            try:
+                request_body = dict(patch)
+                request_body["preset_id"] = str(patch.get("preset_id") or candidate)
+                composition = resolve_expression(request_body)
+            except (ExpressionLibraryError, ExpressionClipError, ValueError, TypeError) as exc:
+                return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+            status, body = await self._play_resolved_expression(composition)
+            return JSONResponse(self._with_expression_catalog(body), status_code=status)
         if self.server.esp32 and hasattr(self.server.esp32, "with_owner_auth"):
             patch = self.server.esp32.with_owner_auth(patch, reason="led")
         status, body, _ = await self.server.esp32.proxy_post("/device/led", patch)
         return JSONResponse(self._with_expression_catalog(body), status_code=status)
 
     async def api_esp32_expression_clip_sync(self, request: Request) -> JSONResponse:
-        if not self.server.esp32:
-            return JSONResponse({"ok": False, "error": "no_device"}, status_code=503)
         try:
             body = await request.json()
         except Exception:
@@ -2387,35 +2583,55 @@ class WebGateway:
         clip_id = str(body.get("clip_id") or request.query_params.get("clip_id") or "").strip()
         if not clip_id:
             return JSONResponse({"ok": False, "error": "clip_id required"}, status_code=400)
+        return await self._sync_eye_response(clip_id)
+
+    async def _sync_eye_response(self, eye_id: str) -> JSONResponse:
+        if not self.server.esp32:
+            return JSONResponse({"ok": False, "error": "no_device"}, status_code=503)
         try:
+            clip_id = eye_storage_id(eye_id)
             manifest = load_expression_clip(clip_id)
-            chunks = build_sync_chunks(clip_id)
-        except ExpressionClipError as exc:
+            payload = load_expression_clip_lcd_payload(clip_id)
+        except (ExpressionClipError, ExpressionLibraryError) as exc:
             return JSONResponse({"ok": False, "error": str(exc)}, status_code=404)
         except Exception as exc:
             logger.exception("expression_clip.sync_prepare_failed", clip_id=clip_id)
             return JSONResponse({"ok": False, "error": f"sync prepare failed: {exc}"}, status_code=500)
 
-        sent = 0
-        last_status = 200
-        last_body: Any = {"ok": True}
-        for chunk in chunks:
-            patch = self.server.esp32.with_owner_auth(chunk, reason="expression_clip")
-            status, resp, _ = await self.server.esp32.proxy_post("/device/expression-clips/sync", patch)
-            sent += 1
-            last_status = status
-            last_body = resp
-            if status >= 400 or (isinstance(resp, dict) and resp.get("ok") is False):
-                device = self.server.esp32.get_status().get("device")
-                update_expression_clip_sync(clip_id, status="sync_failed", device=device)
-                return JSONResponse(
-                    {
-                        "ok": False,
-                        "error": "device sync failed",
-                        "result": {"sent_chunks": sent, "device_status": status, "device_body": resp},
+        lcd_meta = manifest.get("lcd") or {}
+        query = {
+            "clip_id": manifest["clip_id"],
+            "expression": manifest["expression"],
+            "fps": manifest["fps"],
+            "duration_ms": manifest["duration_ms"],
+            "frame_count": manifest["frame_count"],
+            "lcd_bytes": int(lcd_meta.get("bytes") or len(payload)),
+            "lcd_sha256": str(lcd_meta.get("sha256") or ""),
+            "led_effect": (manifest.get("led") or {}).get("effect") or manifest["expression"],
+        }
+        query = self.server.esp32.with_owner_auth(query, reason="expression_clip")
+        status, last_body, _ = await self.server.esp32.proxy_post_bytes(
+            "/device/expression-clips/upload",
+            payload,
+            params=query,
+        )
+        c6_confirmed = isinstance(last_body, dict) and last_body.get("c6_confirmed") is True
+        if status >= 400 or (isinstance(last_body, dict) and last_body.get("ok") is False) or not c6_confirmed:
+            device = self.server.esp32.get_status().get("device")
+            update_expression_clip_sync(clip_id, status="sync_failed", device=device)
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": "device sync failed" if status >= 400 else "C6 did not confirm clip sync",
+                    "result": {
+                        "transfer_mode": "bulk",
+                        "sent_chunks": 1,
+                        "device_status": status,
+                        "device_body": last_body,
                     },
-                    status_code=status if status >= 400 else 502,
-                )
+                },
+                status_code=status if status >= 400 else 502,
+            )
 
         device = self.server.esp32.get_status().get("device")
         manifest = update_expression_clip_sync(clip_id, status="synced", device=device)
@@ -2424,8 +2640,9 @@ class WebGateway:
                 "ok": True,
                 "result": {
                     "clip": manifest,
-                    "sent_chunks": sent,
-                    "device_status": last_status,
+                    "transfer_mode": "bulk",
+                    "sent_chunks": 1,
+                    "device_status": status,
                     "device_body": last_body,
                 },
             }
@@ -3645,6 +3862,9 @@ class WebGateway:
                     "result": {
                         "expressions": self._list_expressions(),
                         "expression_catalog": self._list_expression_catalog(),
+                        "eyes": list_eyes(),
+                        "led_effects": list_led_effects(),
+                        "presets": list_expression_presets(),
                     },
                     "request_id": request_id,
                 }

--- a/lampgo/web/gateway.py
+++ b/lampgo/web/gateway.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import hmac
 import ipaddress
 import json
@@ -30,6 +31,14 @@ from lampgo.core.config import LLMConfig, WebConfig
 from lampgo.core.events import AgentFinished, ChatMessage, IntentResolved, IntentRouting
 from lampgo.core.led import led_expression_catalog
 from lampgo.device.audio_stream import redact_ws_owner_token
+from lampgo.expression_clips import (
+    ExpressionClipError,
+    build_sync_chunks,
+    create_expression_clip,
+    list_expression_clips,
+    load_expression_clip,
+    update_expression_clip_sync,
+)
 from lampgo.perception.camera import CameraCapture
 from lampgo.recordings import (
     build_recording_actions_prompt,
@@ -192,6 +201,7 @@ class WebGateway:
             Route("/api/recordings/delete", self.api_recordings_delete, methods=["POST"]),
             Route("/api/recordings/aliases", self.api_recording_aliases, methods=["GET", "POST"]),
             Route("/api/expressions", self.api_expressions),
+            Route("/api/expression-clips", self.api_expression_clips, methods=["GET", "POST"]),
             Route("/api/camera/snap", self.api_camera_snap),
             Route("/api/sensor/context", self.api_sensor_context),
             Route("/api/openclaw/ask", self.api_openclaw_ask, methods=["POST"]),
@@ -220,6 +230,7 @@ class WebGateway:
             Route("/api/device/snapshot", self.api_esp32_snapshot, methods=["GET"]),
             Route("/api/device/config", self.api_esp32_config, methods=["GET", "POST"]),
             Route("/api/device/led", self.api_esp32_led, methods=["GET", "POST"]),
+            Route("/api/device/expression-clips/sync", self.api_esp32_expression_clip_sync, methods=["POST"]),
             Route("/api/device/pair", self.api_esp32_pair, methods=["POST"]),
             Route("/api/device/unpair", self.api_esp32_unpair, methods=["POST"]),
             Route("/api/device/claim", self.api_esp32_claim, methods=["POST"]),
@@ -800,6 +811,61 @@ class WebGateway:
                 },
             }
         )
+
+    async def api_expression_clips(self, request: Request) -> JSONResponse:
+        if request.method == "GET":
+            return JSONResponse({"ok": True, "result": {"clips": list_expression_clips()}})
+
+        try:
+            payload = await self._read_expression_clip_upload(request)
+            manifest = create_expression_clip(**payload)
+        except ExpressionClipError as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+        except Exception as exc:
+            logger.exception("expression_clip.create_failed")
+            return JSONResponse({"ok": False, "error": f"clip conversion failed: {exc}"}, status_code=500)
+
+        return JSONResponse({"ok": True, "result": {"clip": manifest}})
+
+    async def _read_expression_clip_upload(self, request: Request) -> dict[str, Any]:
+        content_type = request.headers.get("content-type", "")
+        if content_type.startswith("application/json"):
+            body = await request.json()
+            if not isinstance(body, dict):
+                raise ExpressionClipError("JSON body must be an object")
+            encoded = str(body.get("content_base64") or "")
+            if not encoded:
+                raise ExpressionClipError("content_base64 is required for JSON uploads")
+            try:
+                source_bytes = base64.b64decode(encoded, validate=True)
+            except Exception as exc:
+                raise ExpressionClipError("content_base64 is invalid") from exc
+            return {
+                "clip_id": str(body.get("clip_id") or body.get("expression") or ""),
+                "expression": str(body.get("expression") or body.get("clip_id") or ""),
+                "source_bytes": source_bytes,
+                "filename": str(body.get("filename") or "upload.bin"),
+                "content_type": str(body.get("content_type") or ""),
+                "fps": int(body.get("fps") or 10),
+                "duration_s": float(body["duration_s"]) if body.get("duration_s") is not None else None,
+                "grid_rows": int(body["grid_rows"]) if body.get("grid_rows") is not None else None,
+                "grid_cols": int(body["grid_cols"]) if body.get("grid_cols") is not None else None,
+            }
+
+        query = request.query_params
+        source_bytes = await request.body()
+        filename = query.get("filename") or "upload.bin"
+        return {
+            "clip_id": query.get("clip_id") or query.get("expression") or "",
+            "expression": query.get("expression") or query.get("clip_id") or "",
+            "source_bytes": source_bytes,
+            "filename": filename,
+            "content_type": content_type,
+            "fps": int(query.get("fps") or 10),
+            "duration_s": float(query["duration_s"]) if query.get("duration_s") else None,
+            "grid_rows": int(query["grid_rows"]) if query.get("grid_rows") else None,
+            "grid_cols": int(query["grid_cols"]) if query.get("grid_cols") else None,
+        }
 
     async def api_camera_snap(self, request: Request) -> JSONResponse:
         camera = self._make_camera_capture()
@@ -2307,6 +2373,63 @@ class WebGateway:
             patch = self.server.esp32.with_owner_auth(patch, reason="led")
         status, body, _ = await self.server.esp32.proxy_post("/device/led", patch)
         return JSONResponse(self._with_expression_catalog(body), status_code=status)
+
+    async def api_esp32_expression_clip_sync(self, request: Request) -> JSONResponse:
+        if not self.server.esp32:
+            return JSONResponse({"ok": False, "error": "no_device"}, status_code=503)
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        if not isinstance(body, dict):
+            return JSONResponse({"ok": False, "error": "body must be object"}, status_code=400)
+
+        clip_id = str(body.get("clip_id") or request.query_params.get("clip_id") or "").strip()
+        if not clip_id:
+            return JSONResponse({"ok": False, "error": "clip_id required"}, status_code=400)
+        try:
+            manifest = load_expression_clip(clip_id)
+            chunks = build_sync_chunks(clip_id)
+        except ExpressionClipError as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=404)
+        except Exception as exc:
+            logger.exception("expression_clip.sync_prepare_failed", clip_id=clip_id)
+            return JSONResponse({"ok": False, "error": f"sync prepare failed: {exc}"}, status_code=500)
+
+        sent = 0
+        last_status = 200
+        last_body: Any = {"ok": True}
+        for chunk in chunks:
+            patch = self.server.esp32.with_owner_auth(chunk, reason="expression_clip")
+            status, resp, _ = await self.server.esp32.proxy_post("/device/expression-clips/sync", patch)
+            sent += 1
+            last_status = status
+            last_body = resp
+            if status >= 400 or (isinstance(resp, dict) and resp.get("ok") is False):
+                device = self.server.esp32.get_status().get("device")
+                update_expression_clip_sync(clip_id, status="sync_failed", device=device)
+                return JSONResponse(
+                    {
+                        "ok": False,
+                        "error": "device sync failed",
+                        "result": {"sent_chunks": sent, "device_status": status, "device_body": resp},
+                    },
+                    status_code=status if status >= 400 else 502,
+                )
+
+        device = self.server.esp32.get_status().get("device")
+        manifest = update_expression_clip_sync(clip_id, status="synced", device=device)
+        return JSONResponse(
+            {
+                "ok": True,
+                "result": {
+                    "clip": manifest,
+                    "sent_chunks": sent,
+                    "device_status": last_status,
+                    "device_body": last_body,
+                },
+            }
+        )
 
     async def api_esp32_pair(self, request: Request) -> JSONResponse:
         if not self.server.esp32:
@@ -3826,7 +3949,25 @@ class WebGateway:
         return [item["name"] for item in self._list_expression_catalog()]
 
     def _list_expression_catalog(self) -> list[dict[str, Any]]:
-        return led_expression_catalog()
+        clips_by_expression = {
+            str(clip.get("expression") or "").strip().lower(): clip
+            for clip in list_expression_clips()
+            if str(clip.get("expression") or "").strip()
+        }
+        catalog: list[dict[str, Any]] = []
+        for item in led_expression_catalog():
+            enriched = dict(item)
+            clip = clips_by_expression.get(str(item.get("name") or "").strip().lower())
+            if clip:
+                enriched["clip_available"] = True
+                enriched["clip_id"] = clip.get("clip_id")
+                enriched["clip_duration_ms"] = clip.get("duration_ms")
+                enriched["clip_frame_count"] = clip.get("frame_count")
+                enriched["clip_sync"] = clip.get("sync")
+            else:
+                enriched["clip_available"] = False
+            catalog.append(enriched)
+        return catalog
 
     def _with_expression_catalog(self, body: Any) -> dict[str, Any]:
         if not isinstance(body, dict):

--- a/lampgo/web/gateway.py
+++ b/lampgo/web/gateway.py
@@ -724,6 +724,7 @@ class WebGateway:
         name = str(body.get("name", "")).strip()
         description = str(body.get("description", "") or body.get("prompt", "")).strip()
         expression = str(body.get("expression", "")).strip()
+        expression_preset = str(body.get("expression_preset", "") or body.get("preset_id", "")).strip()
         if not name or not re.match(r"^[\w\-]+$", name):
             return JSONResponse({"ok": False, "error": "name must be non-empty alphanumeric/dash/underscore"}, status_code=400)
 
@@ -735,7 +736,7 @@ class WebGateway:
                 return JSONResponse({"ok": False, "error": "built-in recording cannot be edited"}, status_code=400)
             return JSONResponse({"ok": False, "error": "user recording not found"}, status_code=404)
 
-        write_recording_description(csv_path, description, expression)
+        write_recording_description(csv_path, description, expression, expression_preset)
         self.server._refresh_llm_skill_tools()
         return JSONResponse(
             {
@@ -746,6 +747,7 @@ class WebGateway:
                     "path": str(csv_path),
                     "description": description or None,
                     "expression": expression or None,
+                    "expression_preset": expression_preset or None,
                     "recordings": self._list_recordings(),
                 },
             }
@@ -765,6 +767,7 @@ class WebGateway:
         alias = str(body.get("alias", "")).strip()
         description = str(body.get("description", "") or body.get("prompt", "")).strip()
         expression = str(body.get("expression", "")).strip()
+        expression_preset = str(body.get("expression_preset", "") or body.get("preset_id", "")).strip()
 
         if not name or not re.match(r"^[\w\-]+$", name):
             return JSONResponse({"ok": False, "error": "name must be non-empty alphanumeric/dash/underscore"}, status_code=400)
@@ -776,7 +779,7 @@ class WebGateway:
         user_dir.mkdir(parents=True, exist_ok=True)
         csv_path = user_dir / f"{name}.csv"
         csv_path.write_text(csv_content, encoding="utf-8")
-        write_recording_description(csv_path, description, expression)
+        write_recording_description(csv_path, description, expression, expression_preset)
 
         if alias:
             alias_path = recordings_dir / "aliases.json"
@@ -798,6 +801,7 @@ class WebGateway:
                     "alias": alias or None,
                     "description": description or None,
                     "expression": expression or None,
+                    "expression_preset": expression_preset or None,
                     "recordings": self._list_recordings(),
                 },
             }
@@ -3838,6 +3842,7 @@ class WebGateway:
                 overwrite=bool(msg.get("overwrite", False)),
                 description=str(msg.get("description", "") or msg.get("prompt", "")),
                 expression=str(msg.get("expression", "")),
+                expression_preset=str(msg.get("expression_preset", "") or msg.get("preset_id", "")),
             )
             result["request_id"] = request_id
             await ws.send_json(result)

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -220,6 +220,7 @@
 
   const expressionMetaByName = new Map();
   const recordingExpressionByName = new Map();
+  const recordingExpressionPresetByName = new Map();
   let expressionEyes = [];
   let expressionLedEffects = [];
   let expressionPresets = [];
@@ -236,6 +237,50 @@
   function expressionLabel(name) {
     const meta = expressionMeta(name);
     return (meta && meta.label) || EXPRESSION_LABELS_CN[name] || name;
+  }
+
+  function expressionPresetById(presetId) {
+    const id = String(presetId || "").trim();
+    if (!id) return null;
+    return expressionPresets.find((preset) => String(preset.preset_id || "") === id) || null;
+  }
+
+  function expressionPresetLabel(presetId) {
+    const id = String(presetId || "").trim();
+    const preset = expressionPresetById(id);
+    return (preset && (preset.label || preset.preset_id)) || id;
+  }
+
+  function normalizeRecordingExpressionChoice(value) {
+    const raw = String(value || "").trim();
+    if (!raw) return "";
+    if (raw.startsWith("preset:") || raw.startsWith("led:")) return raw;
+    return expressionPresetById(raw) ? `preset:${raw}` : `led:${raw}`;
+  }
+
+  function splitRecordingExpressionChoice(value) {
+    const normalized = normalizeRecordingExpressionChoice(value);
+    if (normalized.startsWith("preset:")) {
+      return { expression_preset: normalized.slice("preset:".length), expression: "" };
+    }
+    if (normalized.startsWith("led:")) {
+      return { expression_preset: "", expression: normalized.slice("led:".length) };
+    }
+    return { expression_preset: "", expression: "" };
+  }
+
+  function recordingExpressionChoiceValue(recording) {
+    const expressionPreset = getRecordingExpressionPreset(recording);
+    if (expressionPreset) return `preset:${expressionPreset}`;
+    const expression = getRecordingExpression(recording);
+    return expression ? `led:${expression}` : "";
+  }
+
+  function recordingExpressionChoiceLabel(recording) {
+    const expressionPreset = getRecordingExpressionPreset(recording);
+    if (expressionPreset) return `组合 ${expressionPresetLabel(expressionPreset)}`;
+    const expression = getRecordingExpression(recording);
+    return `表情 ${expressionLabel(expression)}`;
   }
 
   function normalizeExpressionEntries(entries) {
@@ -273,23 +318,47 @@
 
   function populateExpressionSelect(selectEl, preferred) {
     if (!selectEl) return;
-    const selected = String(preferred || selectEl.value || "smiley").trim();
+    const selected = normalizeRecordingExpressionChoice(preferred || selectEl.value || "");
     const names = latestExpressions.length ? latestExpressions : Object.keys(EXPRESSION_LABELS_CN);
     selectEl.innerHTML = "";
-    names.forEach((name) => {
+    const values = [];
+    function appendOption(parent, value, text) {
       const option = document.createElement("option");
-      option.value = name;
+      option.value = value;
+      option.textContent = text;
+      parent.appendChild(option);
+      values.push(value);
+    }
+    if (expressionPresets.length) {
+      const group = document.createElement("optgroup");
+      group.label = "组合表情（眼睛 + LED）";
+      expressionPresets.forEach((preset) => {
+        const presetId = String(preset.preset_id || "").trim();
+        if (!presetId) return;
+        const pair = `${preset.eye_clip_id || "无眼睛"} + ${preset.led_effect_id || "无 LED"}`;
+        appendOption(group, `preset:${presetId}`, `${preset.label || presetId}（${presetId} · ${pair}）`);
+      });
+      if (group.children.length) selectEl.appendChild(group);
+    }
+    const ledGroup = document.createElement("optgroup");
+    ledGroup.label = "仅 LED 灯板";
+    names.forEach((name) => {
       const meta = expressionMeta(name);
       const modeText = meta && meta.mode !== null && meta.mode !== undefined ? ` · m${meta.mode}` : "";
-      option.textContent = `${expressionLabel(name)}（${name}${modeText}）`;
-      selectEl.appendChild(option);
+      appendOption(ledGroup, `led:${name}`, `${expressionLabel(name)}（${name}${modeText}）`);
     });
-    if (names.includes(selected)) {
+    if (ledGroup.children.length) selectEl.appendChild(ledGroup);
+    if (selected && !values.includes(selected)) {
+      const id = selected.split(":", 2)[1] || selected;
+      const prefix = selected.startsWith("preset:") ? "组合" : "LED";
+      appendOption(selectEl, selected, `${prefix} ${id}`);
+    }
+    if (values.includes(selected)) {
       selectEl.value = selected;
-    } else if (names.includes("smiley")) {
-      selectEl.value = "smiley";
-    } else if (names.length) {
-      selectEl.value = names[0];
+    } else if (values.includes("led:smiley")) {
+      selectEl.value = "led:smiley";
+    } else if (values.length) {
+      selectEl.value = values[0];
     }
   }
 
@@ -3149,14 +3218,15 @@
   function normalizeRecordingEntry(entry) {
     if (typeof entry === "string") {
       const name = entry.trim();
-      return { name, source: "builtin", description: "", expression: RECORDING_EXPRESSIONS[name] || "smiley" };
+      return { name, source: "builtin", description: "", expression: RECORDING_EXPRESSIONS[name] || "smiley", expression_preset: "" };
     }
-    if (!entry || typeof entry !== "object") return { name: "", source: "builtin", description: "", expression: "" };
+    if (!entry || typeof entry !== "object") return { name: "", source: "builtin", description: "", expression: "", expression_preset: "" };
     const name = String(entry.name || "").trim();
     const source = String(entry.source || "builtin").trim() || "builtin";
     const description = String(entry.description || "").trim();
     const expression = String(entry.expression || RECORDING_EXPRESSIONS[name] || "smiley").trim();
-    return { name, source, description, expression };
+    const expressionPreset = String(entry.expression_preset || entry.expressionPreset || "").trim();
+    return { name, source, description, expression, expression_preset: expressionPreset };
   }
 
   function renderSkills(skills) {
@@ -3361,8 +3431,10 @@
     if (Array.isArray(recordings)) {
       latestRecordings = recordings.map(normalizeRecordingEntry).filter((r) => r.name);
       recordingExpressionByName.clear();
+      recordingExpressionPresetByName.clear();
       latestRecordings.forEach((recording) => {
         recordingExpressionByName.set(recording.name, recording.expression || "smiley");
+        recordingExpressionPresetByName.set(recording.name, recording.expression_preset || "");
       });
     }
     recordingGrid.innerHTML = "";
@@ -3371,26 +3443,28 @@
       ? latestRecordings.filter((recording) => {
           const name = recording.name;
           const expr = getRecordingExpression(recording) || "";
+          const preset = getRecordingExpressionPreset(recording) || "";
           const labelCn = recordingLabel(name);
           const exprCn = expressionLabel(expr);
+          const presetCn = expressionPresetLabel(preset);
           const description = recording.description || "";
           return (
             name.toLowerCase().includes(q) ||
             expr.toLowerCase().includes(q) ||
+            preset.toLowerCase().includes(q) ||
             labelCn.toLowerCase().includes(q) ||
             exprCn.toLowerCase().includes(q) ||
+            presetCn.toLowerCase().includes(q) ||
             description.toLowerCase().includes(q)
           );
         })
       : latestRecordings;
     filtered.forEach((recording) => {
       const name = recording.name;
-      const expression = getRecordingExpression(recording);
       const labelCn = recordingLabel(name);
-      const exprCn = expressionLabel(expression);
       const isUserRecording = recording.source === "user";
       const sourceLabel = isUserRecording ? "我的录制" : "内置动作";
-      const expressionMeta = `表情 ${exprCn}`;
+      const expressionMeta = recordingExpressionChoiceLabel(recording);
       const description = recording.description || "";
       const card = makeSkillCard({
         title: labelCn,
@@ -3398,8 +3472,8 @@
           ? `${sourceLabel} · ${expressionMeta} · ${description}`
           : `${sourceLabel} · ${expressionMeta}`,
         tooltip: description
-          ? `播放录制动作：${labelCn}（${name}） · 推荐表情：${exprCn} · ${description}`
-          : `播放录制动作：${labelCn}（${name}） · 推荐表情：${exprCn}`,
+          ? `播放录制动作：${labelCn}（${name}） · 配套表情：${expressionMeta} · ${description}`
+          : `播放录制动作：${labelCn}（${name}） · 配套表情：${expressionMeta}`,
         onClick: () => invokeRecording(name),
       });
       if (isUserRecording) {
@@ -3407,7 +3481,7 @@
         const edit = document.createElement("button");
         edit.className = "skill-card-action skill-card-action--edit";
         edit.type = "button";
-        edit.title = "编辑推荐表情和动作说明";
+        edit.title = "编辑配套表情和动作说明";
         edit.textContent = "✎";
         edit.addEventListener("click", (ev) => {
           ev.stopPropagation();
@@ -3437,10 +3511,10 @@
     if (!recordEditDialog || !recording || !recording.name) return;
     recordEditDialog.dataset.recordingName = recording.name;
     if (recordEditDesc) {
-      recordEditDesc.textContent = `编辑 ${recordingLabel(recording.name)}（${recording.name}）的推荐表情和动作说明；不会改动录制动作轨迹。`;
+      recordEditDesc.textContent = `编辑 ${recordingLabel(recording.name)}（${recording.name}）的绑定表情和动作说明；不会改动录制动作轨迹。`;
     }
     if (recordEditDescriptionInput) recordEditDescriptionInput.value = recording.description || "";
-    populateExpressionSelect(recordEditExpressionSelect, getRecordingExpression(recording));
+    populateExpressionSelect(recordEditExpressionSelect, recordingExpressionChoiceValue(recording));
     if (recordEditError) recordEditError.textContent = "";
     recordEditDialog.showModal();
     if (recordEditDescriptionInput) recordEditDescriptionInput.focus();
@@ -3452,11 +3526,12 @@
     recordEditDialog.close();
   }
 
-  async function updateRecordingMetadata(name, description, expression) {
+  async function updateRecordingMetadata(name, description, expressionChoice) {
+    const pairing = splitRecordingExpressionChoice(expressionChoice);
     const resp = await fetch("/api/recordings/update", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ name, description, expression }),
+      body: JSON.stringify({ name, description, ...pairing }),
     });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok || !data.ok) {
@@ -3509,6 +3584,7 @@
     if (Array.isArray(result.led_effects)) expressionLedEffects = result.led_effects;
     if (Array.isArray(result.presets)) expressionPresets = result.presets;
     renderExpressionStudio();
+    renderRecordings();
   }
 
   function expressionResource(title, meta, actions = []) {
@@ -3627,6 +3703,7 @@
         mode: effect.mode,
         animated: effect.animated,
       })));
+      renderRecordings();
       const library = capacity.library;
       const device = capacity.device;
       if (expressionCapacityEl && library) {
@@ -4441,18 +4518,26 @@
     clearEmptyState();
     const requestId = nextId();
     const bubble = addAssistantBubble(requestId);
-    const expression = getRecordingExpression(name);
+    const recording = latestRecordings.find((entry) => entry.name === name) || { name };
+    const expressionPreset = getRecordingExpressionPreset(recording);
+    const expression = expressionPreset ? "" : getRecordingExpression(recording);
     const labelCn = recordingLabel(name);
-    const exprCn = expressionLabel(expression);
+    const pairingLabel = recordingExpressionChoiceLabel(recording);
+    const params = { name, playback_mode: playbackMode };
+    if (expressionPreset) {
+      params.expression_preset = expressionPreset;
+    } else {
+      params.expression = expression;
+    }
     addStep(
       getPreludeArea(ensureActivityLog(bubble)),
-      `播放录制动作 ${labelCn}（${name}） · 模式 ${playbackModeLabel(playbackMode)} · 表情 ${exprCn}`,
+      `播放录制动作 ${labelCn}（${name}） · 模式 ${playbackModeLabel(playbackMode)} · ${pairingLabel}`,
       "active"
     );
     send({
       type: "invoke",
       skill_id: "play_recording",
-      params: { name, expression, playback_mode: playbackMode },
+      params,
       wait: true,
       request_id: requestId,
     });
@@ -4529,7 +4614,7 @@
     recordNameError.textContent = "";
     recordNameInput.value = "";
     if (recordDescriptionInput) recordDescriptionInput.value = "";
-    populateRecordingExpressionSelect("smiley");
+    populateRecordingExpressionSelect();
     if (btnRecordSave) btnRecordSave.textContent = "保存";
     recordNameDialog.showModal();
     recordNameInput.focus();
@@ -4542,8 +4627,9 @@
     recordNameDialog.close();
   }
 
-  function saveMotionRecording(name, description, expression, overwrite = false) {
-    send({ type: "recording_save", name, description, expression, overwrite, request_id: nextId() });
+  function saveMotionRecording(name, description, expressionChoice, overwrite = false) {
+    const pairing = splitRecordingExpressionChoice(expressionChoice);
+    send({ type: "recording_save", name, description, ...pairing, overwrite, request_id: nextId() });
   }
 
   function discardMotionRecording() {
@@ -6815,14 +6901,14 @@
         if (recordDescriptionInput) recordDescriptionInput.focus();
         return;
       }
-      const expression = ((recordExpressionSelect && recordExpressionSelect.value) || "").trim();
-      if (!expression) {
-        recordNameError.textContent = "请选择推荐表情";
+      const expressionChoice = ((recordExpressionSelect && recordExpressionSelect.value) || "").trim();
+      if (!expressionChoice) {
+        recordNameError.textContent = "请选择配套表情";
         if (recordExpressionSelect) recordExpressionSelect.focus();
         return;
       }
       recordNameError.textContent = "";
-      saveMotionRecording(name, description, expression, pendingOverwriteSave);
+      saveMotionRecording(name, description, expressionChoice, pendingOverwriteSave);
     });
   }
 
@@ -6831,7 +6917,7 @@
       e.preventDefault();
       const name = (recordEditDialog && recordEditDialog.dataset.recordingName) || "";
       const description = ((recordEditDescriptionInput && recordEditDescriptionInput.value) || "").trim();
-      const expression = ((recordEditExpressionSelect && recordEditExpressionSelect.value) || "").trim();
+      const expressionChoice = ((recordEditExpressionSelect && recordEditExpressionSelect.value) || "").trim();
       if (!name) {
         if (recordEditError) recordEditError.textContent = "缺少动作名称";
         return;
@@ -6841,16 +6927,16 @@
         if (recordEditDescriptionInput) recordEditDescriptionInput.focus();
         return;
       }
-      if (!expression) {
-        if (recordEditError) recordEditError.textContent = "请选择推荐表情";
+      if (!expressionChoice) {
+        if (recordEditError) recordEditError.textContent = "请选择配套表情";
         if (recordEditExpressionSelect) recordEditExpressionSelect.focus();
         return;
       }
       if (recordEditError) recordEditError.textContent = "";
-      updateRecordingMetadata(name, description, expression)
+      updateRecordingMetadata(name, description, expressionChoice)
         .then(() => {
           closeEditRecordingDialog();
-          addSystemMessage(`录制动作已更新：${recordingLabel(name)}（${name}） · 表情 ${expressionLabel(expression)}`);
+          addSystemMessage(`录制动作已更新：${recordingLabel(name)}（${name}） · ${recordingExpressionChoiceLabel({ name, ...splitRecordingExpressionChoice(expressionChoice) })}`);
         })
         .catch((err) => {
           if (recordEditError) recordEditError.textContent = `保存失败：${err && err.message ? err.message : err}`;
@@ -6972,6 +7058,16 @@
   function nextId() {
     reqCounter += 1;
     return `r${reqCounter}_${Date.now().toString(36)}`;
+  }
+
+  function getRecordingExpressionPreset(recordingOrName) {
+    if (recordingOrName && typeof recordingOrName === "object") {
+      const expressionPreset = String(recordingOrName.expression_preset || recordingOrName.expressionPreset || "").trim();
+      if (expressionPreset) return expressionPreset;
+      return getRecordingExpressionPreset(recordingOrName.name);
+    }
+    const name = String(recordingOrName || "");
+    return recordingExpressionPresetByName.get(name) || "";
   }
 
   function getRecordingExpression(recordingOrName) {

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -27,6 +27,39 @@
   const skillSearchEl = document.getElementById("skill-search");
   const recordingSearchEl = document.getElementById("recording-search");
   const expressionSearchEl = document.getElementById("expression-search");
+  const expressionTabs = Array.from(document.querySelectorAll("[data-expression-tab]"));
+  const expressionPanels = Array.from(document.querySelectorAll("[data-expression-panel]"));
+  const expressionCapacityEl = document.getElementById("expression-capacity");
+  const eyeGrid = document.getElementById("eye-grid");
+  const eyeUploadFile = document.getElementById("eye-upload-file");
+  const eyeUploadId = document.getElementById("eye-upload-id");
+  const eyeUploadRows = document.getElementById("eye-upload-rows");
+  const eyeUploadCols = document.getElementById("eye-upload-cols");
+  const eyeUploadFps = document.getElementById("eye-upload-fps");
+  const btnEyeUpload = document.getElementById("btn-eye-upload");
+  const ledEffectForm = document.getElementById("led-effect-form");
+  const ledEffectId = document.getElementById("led-effect-id");
+  const ledEffectLabel = document.getElementById("led-effect-label");
+  const ledEffectRole = document.getElementById("led-effect-role");
+  const ledEffectTemplate = document.getElementById("led-effect-template");
+  const ledEffectColor = document.getElementById("led-effect-color");
+  const composerEye = document.getElementById("composer-eye");
+  const composerLed = document.getElementById("composer-led");
+  const composerColor = document.getElementById("composer-color");
+  const composerBrightness = document.getElementById("composer-brightness");
+  const composerIntensity = document.getElementById("composer-intensity");
+  const composerPresetId = document.getElementById("composer-preset-id");
+  const composerPresetLabel = document.getElementById("composer-preset-label");
+  const expressionEyePreview = document.getElementById("expression-eye-preview");
+  const expressionLedPreview = document.getElementById("expression-led-preview");
+  const expressionPreviewStatus = document.getElementById("expression-preview-status");
+  const expressionPresetGrid = document.getElementById("expression-preset-grid");
+  const btnExpressionPreview = document.getElementById("btn-expression-preview");
+  const btnExpressionSync = document.getElementById("btn-expression-sync");
+  const btnExpressionSetDefault = document.getElementById("btn-expression-set-default");
+  const btnExpressionPlay = document.getElementById("btn-expression-play");
+  const btnExpressionStop = document.getElementById("btn-expression-stop");
+  const btnExpressionSave = document.getElementById("btn-expression-save");
   const openclawTaskList = document.getElementById("openclaw-task-list");
   const chipJoint = document.getElementById("chip-joint");
   const chipJointDot = document.getElementById("chip-joint-dot");
@@ -187,6 +220,13 @@
 
   const expressionMetaByName = new Map();
   const recordingExpressionByName = new Map();
+  let expressionEyes = [];
+  let expressionLedEffects = [];
+  let expressionPresets = [];
+  let expressionDirection = "right";
+  let expressionPlayback = "once";
+  let expressionPreviewTimer = null;
+  let expressionPreviewImage = null;
   let latestStatusData = {};
 
   function expressionMeta(name) {
@@ -2464,6 +2504,7 @@
     }
 
     if (msg.ok && msg.result && (msg.result.expression_catalog || msg.result.expressions)) {
+      hydrateExpressionStudio(msg.result);
       renderExpressions(msg.result.expression_catalog || msg.result.expressions);
       return;
     }
@@ -3463,6 +3504,463 @@
     }
   }
 
+  function hydrateExpressionStudio(result) {
+    if (Array.isArray(result.eyes)) expressionEyes = result.eyes;
+    if (Array.isArray(result.led_effects)) expressionLedEffects = result.led_effects;
+    if (Array.isArray(result.presets)) expressionPresets = result.presets;
+    renderExpressionStudio();
+  }
+
+  function expressionResource(title, meta, actions = []) {
+    const row = document.createElement("div");
+    row.className = "expression-resource";
+    const copy = document.createElement("div");
+    const heading = document.createElement("div");
+    heading.className = "expression-resource-title";
+    heading.textContent = title;
+    const detail = document.createElement("div");
+    detail.className = "expression-resource-meta";
+    detail.textContent = meta;
+    copy.append(heading, detail);
+    const controls = document.createElement("div");
+    controls.className = "expression-resource-actions";
+    actions.forEach((action) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = action.primary ? "primary-button" : "ghost-button";
+      button.textContent = action.label;
+      button.title = action.title || action.label;
+      button.addEventListener("click", action.run);
+      controls.appendChild(button);
+    });
+    row.append(copy, controls);
+    return row;
+  }
+
+  function formatBytes(value) {
+    const bytes = Math.max(0, Number(value || 0));
+    if (bytes < 1024) return `${bytes} B`;
+    return `${(bytes / 1024).toFixed(bytes >= 102400 ? 0 : 1)} KiB`;
+  }
+
+  function populateExpressionComposer() {
+    if (composerEye) {
+      const selected = composerEye.value;
+      composerEye.innerHTML = '<option value="">无眼睛</option>';
+      expressionEyes.forEach((eye) => {
+        const option = document.createElement("option");
+        option.value = eye.eye_clip_id;
+        option.textContent = `${eye.label || eye.eye_clip_id} (${eye.eye_clip_id})`;
+        composerEye.appendChild(option);
+      });
+      composerEye.value = expressionEyes.some((item) => item.eye_clip_id === selected) ? selected : "";
+    }
+    if (composerLed) {
+      const selected = composerLed.value;
+      composerLed.innerHTML = '<option value="">无 LED</option>';
+      expressionLedEffects.forEach((effect) => {
+        const option = document.createElement("option");
+        option.value = effect.effect_id;
+        option.textContent = `${effect.label || effect.effect_id} · ${effect.role || "accent"}`;
+        composerLed.appendChild(option);
+      });
+      composerLed.value = expressionLedEffects.some((item) => item.effect_id === selected) ? selected : "";
+    }
+  }
+
+  function renderExpressionEyes() {
+    if (!eyeGrid) return;
+    eyeGrid.innerHTML = "";
+    expressionEyes.forEach((eye) => {
+      const lcd = eye.lcd || {};
+      const sync = eye.sync || {};
+      eyeGrid.appendChild(expressionResource(
+        eye.label || eye.eye_clip_id,
+        `${eye.eye_clip_id} · ${eye.frame_count || 0} 帧 · ${eye.fps || 0} FPS · ${formatBytes(lcd.bytes)} · ${sync.status || "unsynced"}`,
+        [
+          { label: "同步", run: () => syncExpressionEye(eye.eye_clip_id) },
+          { label: "选用", run: () => selectExpressionResource(eye.eye_clip_id, null), primary: true },
+        ],
+      ));
+    });
+    if (!expressionEyes.length) renderEmptyCell(eyeGrid, "暂无眼睛素材");
+  }
+
+  function renderExpressionPresets() {
+    if (!expressionPresetGrid) return;
+    expressionPresetGrid.innerHTML = "";
+    expressionPresets.forEach((preset) => {
+      const pair = `${preset.eye_clip_id || "无眼睛"} + ${preset.led_effect_id || "无 LED"}`;
+      expressionPresetGrid.appendChild(expressionResource(
+        preset.label || preset.preset_id,
+        `${preset.preset_id} · ${pair} · ${preset.playback === "loop" ? "循环" : "单次"}`,
+        [
+          { label: "载入", run: () => loadExpressionPreset(preset) },
+          { label: "▶", title: "播放", run: () => playExpression({ preset_id: preset.preset_id }), primary: true },
+        ],
+      ));
+    });
+    if (!expressionPresets.length) renderEmptyCell(expressionPresetGrid, "暂无组合表情");
+  }
+
+  function renderExpressionStudio() {
+    populateExpressionComposer();
+    renderExpressionEyes();
+    renderExpressionPresets();
+  }
+
+  async function refreshExpressionStudio() {
+    try {
+      const [eyes, effects, presets, capacity] = await Promise.all([
+        fetchJson("/api/eyes"),
+        fetchJson("/api/led-effects"),
+        fetchJson("/api/expression-presets"),
+        fetchJson("/api/device/expression-capabilities"),
+      ]);
+      expressionEyes = eyes.eyes || [];
+      expressionLedEffects = effects.led_effects || [];
+      expressionPresets = presets.presets || [];
+      renderExpressionStudio();
+      renderExpressions(expressionLedEffects.map((effect) => ({
+        name: effect.effect_id,
+        label: effect.label,
+        mode: effect.mode,
+        animated: effect.animated,
+      })));
+      const library = capacity.library;
+      const device = capacity.device;
+      if (expressionCapacityEl && library) {
+        const deviceEyeCount = device && Number(device.c6_eye_max_count || 0) > 0
+          ? `${device.c6_eye_installed_count}/${device.c6_eye_max_count}`
+          : `${library.eyes.installed}/${library.eyes.max_count}`;
+        const deviceEyeBytes = device && Number(device.c6_eye_budget_bytes || 0) > 0
+          ? `${formatBytes(device.c6_eye_installed_bytes)}/${formatBytes(device.c6_eye_budget_bytes)}`
+          : `${formatBytes(library.eyes.used_bytes)}/${formatBytes(library.eyes.budget_bytes)}`;
+        expressionCapacityEl.textContent = [
+          `C6 眼睛 ${deviceEyeCount} · ${deviceEyeBytes}`,
+          `用户 LED ${library.led_effects.installed_custom}/${library.led_effects.max_custom_count} · ${formatBytes(library.led_effects.used_bytes)}/${formatBytes(library.led_effects.budget_bytes)}`,
+          `组合 ${library.presets.installed}/${library.presets.max_count}`,
+          device ? `S3 可用 ${formatBytes(device.spiffs_free_bytes)}` : "设备未连接",
+        ].join("  |  ");
+      }
+    } catch (error) {
+      if (expressionCapacityEl) expressionCapacityEl.textContent = `表情库加载失败：${error.message || error}`;
+    }
+  }
+
+  function selectExpressionResource(eyeId, ledId) {
+    expressionTabs.find((tab) => tab.dataset.expressionTab === "compose")?.click();
+    if (eyeId !== null && composerEye) composerEye.value = eyeId || "";
+    if (ledId !== null && composerLed) composerLed.value = ledId || "";
+  }
+
+  function loadExpressionPreset(preset) {
+    selectExpressionResource(preset.eye_clip_id || "", preset.led_effect_id || "");
+    if (composerPresetId) composerPresetId.value = preset.preset_id || "";
+    if (composerPresetLabel) composerPresetLabel.value = preset.label || "";
+    expressionPlayback = preset.playback === "loop" ? "loop" : "once";
+    document.querySelectorAll("[data-playback]").forEach((button) => {
+      button.classList.toggle("is-active", button.dataset.playback === expressionPlayback);
+    });
+    const params = preset.led_params || {};
+    if (params.color && composerColor) composerColor.value = params.color;
+    if (params.brightness && composerBrightness) composerBrightness.value = String(params.brightness);
+    if (params.intensity && composerIntensity) composerIntensity.value = String(Math.round(params.intensity * 100));
+    if (params.direction) setExpressionDirection(params.direction);
+  }
+
+  function setExpressionDirection(direction) {
+    expressionDirection = direction;
+    document.querySelectorAll("[data-direction]").forEach((button) => {
+      button.classList.toggle("is-active", button.dataset.direction === direction);
+    });
+  }
+
+  function currentExpressionBody() {
+    return {
+      eye_clip_id: (composerEye && composerEye.value) || null,
+      led_effect_id: (composerLed && composerLed.value) || null,
+      led_params: {
+        color: (composerColor && composerColor.value) || "#ffffff",
+        brightness: Number((composerBrightness && composerBrightness.value) || 64),
+        intensity: Number((composerIntensity && composerIntensity.value) || 100) / 100,
+        direction: expressionDirection,
+      },
+      playback: expressionPlayback,
+      duration_ms: 3000,
+    };
+  }
+
+  function ensureLedPreviewCells() {
+    if (!expressionLedPreview || expressionLedPreview.childElementCount === 459) return;
+    expressionLedPreview.innerHTML = "";
+    for (let index = 0; index < 459; index += 1) {
+      const cell = document.createElement("span");
+      cell.className = "expression-led-cell";
+      expressionLedPreview.appendChild(cell);
+    }
+  }
+
+  function ledCellActive(effect, row, col, phase) {
+    if (!effect) return false;
+    const program = effect.program || {};
+    const template = program.template || (effect.role === "mouth" ? "mouth" : "");
+    const effectId = effect.effect_id || "";
+    if (template === "arrow" || ["left", "right", "up", "down"].includes(effectId)) {
+      const direction = effectId === "arrow" ? expressionDirection : effectId;
+      const x = col - 25;
+      const y = row - 4;
+      if (direction === "left" || direction === "right") {
+        const signedX = direction === "left" ? -x : x;
+        return (Math.abs(y) <= 1 && signedX >= -18 && signedX <= 10) ||
+          (signedX >= 6 && signedX <= 18 && Math.abs(y) === Math.floor((18 - signedX) / 2));
+      }
+      const signedY = direction === "up" ? -y : y;
+      return (Math.abs(x) <= 2 && signedY >= -3 && signedY <= 2) ||
+        (signedY >= 0 && signedY <= 4 && Math.abs(x) === (4 - signedY) * 2);
+    }
+    if (template === "heart" || effectId === "heart") {
+      const x = (col - 25) / 2.4;
+      const y = (4 - row) * 1.6;
+      const q = x * x + y * y - 30;
+      return q * q * q - x * x * y * y * y < 0;
+    }
+    if (template === "pulse" || effect.role === "accent") {
+      const radius = 5 + Math.sin(phase * Math.PI * 2) * 3;
+      const distance = Math.hypot((col - 25) / 3.2, row - 4);
+      return Math.abs(distance - radius) < 0.8;
+    }
+    const wave = 0.65 + 0.35 * Math.sin(phase * Math.PI * 2);
+    const dx = (col - 25) / (18 + wave * 6);
+    const dy = (row - 4) / (2.2 + wave * 1.5);
+    return dx * dx + dy * dy <= 1 && dx * dx + dy * dy >= 0.42;
+  }
+
+  function renderLedPreview(effect, phase) {
+    ensureLedPreviewCells();
+    if (!expressionLedPreview) return;
+    const color = (composerColor && composerColor.value) || "#ffffff";
+    const intensity = Number((composerIntensity && composerIntensity.value) || 100) / 100;
+    Array.from(expressionLedPreview.children).forEach((cell, index) => {
+      const row = Math.floor(index / 51);
+      const col = index % 51;
+      const active = ledCellActive(effect, row, col, phase);
+      cell.style.background = active ? color : "#30353a";
+      cell.style.opacity = active ? String(0.35 + intensity * 0.65) : "1";
+      cell.style.boxShadow = active ? `0 0 5px ${color}` : "none";
+    });
+  }
+
+  async function loadEyePreviewImage(eye) {
+    expressionPreviewImage = null;
+    if (!eye) return;
+    await new Promise((resolve) => {
+      const image = new Image();
+      image.onload = () => { expressionPreviewImage = image; resolve(); };
+      image.onerror = () => resolve();
+      image.src = `/api/eyes/${encodeURIComponent(eye.eye_clip_id)}/source?ts=${Date.now()}`;
+    });
+  }
+
+  function renderEyePreview(eye, phase) {
+    if (!expressionEyePreview) return;
+    const context = expressionEyePreview.getContext("2d");
+    context.fillStyle = "#000";
+    context.fillRect(0, 0, 320, 172);
+    if (!eye) return;
+    if (expressionPreviewImage) {
+      const frameCount = Math.max(1, Number(eye.frame_count || 1));
+      const source = eye.source || {};
+      const rows = Math.max(1, Number(source.grid_rows || (frameCount === 30 ? 5 : 1)));
+      const cols = Math.max(1, Number(source.grid_cols || Math.ceil(frameCount / rows)));
+      const frame = Math.min(frameCount - 1, Math.floor(phase * frameCount));
+      const sourceWidth = expressionPreviewImage.naturalWidth / cols;
+      const sourceHeight = expressionPreviewImage.naturalHeight / rows;
+      context.drawImage(
+        expressionPreviewImage,
+        (frame % cols) * sourceWidth,
+        Math.floor(frame / cols) * sourceHeight,
+        sourceWidth,
+        sourceHeight,
+        0,
+        0,
+        320,
+        172,
+      );
+      return;
+    }
+    context.strokeStyle = "#fff";
+    context.lineWidth = 18;
+    context.beginPath(); context.arc(95, 86, 42, 0, Math.PI * 2); context.stroke();
+    context.beginPath(); context.arc(225, 86, 42, 0, Math.PI * 2); context.stroke();
+  }
+
+  async function previewExpression() {
+    const body = currentExpressionBody();
+    if (!body.eye_clip_id && !body.led_effect_id) {
+      window.alert("请至少选择眼睛或 LED 效果");
+      return;
+    }
+    try {
+      const result = await fetchJson("/api/expressions/preview", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const composition = result.composition;
+      const eye = expressionEyes.find((item) => item.eye_clip_id === composition.eye_clip_id);
+      const effect = expressionLedEffects.find((item) => item.effect_id === composition.led_effect_id);
+      await loadEyePreviewImage(eye);
+      if (expressionPreviewTimer) cancelAnimationFrame(expressionPreviewTimer);
+      const started = Date.now();
+      const tick = () => {
+        const elapsed = Date.now() - started;
+        const phase = (elapsed % 3000) / 3000;
+        renderEyePreview(eye, phase);
+        renderLedPreview(effect, phase);
+        if (expressionPreviewStatus) expressionPreviewStatus.textContent = `${Math.min(3, elapsed / 1000).toFixed(1)} / 3.0 秒`;
+        if (expressionPlayback === "loop" || elapsed < 3000) {
+          expressionPreviewTimer = requestAnimationFrame(tick);
+        } else if (expressionPreviewStatus) {
+          expressionPreviewStatus.textContent = "预览完成";
+        }
+      };
+      expressionPreviewTimer = requestAnimationFrame(tick);
+    } catch (error) {
+      window.alert(`预览失败：${error.message || error}`);
+    }
+  }
+
+  async function playExpression(body = null) {
+    try {
+      const result = await fetchJson("/api/expressions/play", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body || currentExpressionBody()),
+      });
+      if (expressionPreviewStatus) expressionPreviewStatus.textContent = result.device ? "设备播放中" : "播放已发送";
+      return result;
+    } catch (error) {
+      window.alert(`播放失败：${error.message || error}`);
+      return null;
+    }
+  }
+
+  async function playLedEffect(name) {
+    await playExpression({
+      eye_clip_id: null,
+      led_effect_id: name,
+      playback: "loop",
+      duration_ms: 3000,
+    });
+  }
+
+  async function syncExpressionEye(eyeId = null) {
+    const selected = eyeId || (composerEye && composerEye.value);
+    if (!selected) {
+      window.alert("请选择眼睛素材");
+      return;
+    }
+    if (expressionPreviewStatus) expressionPreviewStatus.textContent = "同步中…";
+    try {
+      await fetchJson(`/api/eyes/${encodeURIComponent(selected)}/sync`, { method: "POST" });
+      if (expressionPreviewStatus) expressionPreviewStatus.textContent = "同步完成";
+      await refreshExpressionStudio();
+    } catch (error) {
+      if (expressionPreviewStatus) expressionPreviewStatus.textContent = "同步失败";
+      window.alert(`同步失败：${error.message || error}`);
+    }
+  }
+
+  async function setDefaultLedForEye() {
+    const eyeId = (composerEye && composerEye.value) || "";
+    if (!eyeId) {
+      window.alert("请选择眼睛素材");
+      return;
+    }
+    try {
+      await fetchJson(`/api/eyes/${encodeURIComponent(eyeId)}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ default_led_effect_id: (composerLed && composerLed.value) || null }),
+      });
+      if (expressionPreviewStatus) expressionPreviewStatus.textContent = "默认搭配已更新";
+      await refreshExpressionStudio();
+    } catch (error) {
+      window.alert(`更新失败：${error.message || error}`);
+    }
+  }
+
+  async function stopExpression() {
+    try {
+      await fetchJson("/api/expressions/stop", { method: "POST" });
+      if (expressionPreviewTimer) cancelAnimationFrame(expressionPreviewTimer);
+      if (expressionPreviewStatus) expressionPreviewStatus.textContent = "已停止";
+    } catch (error) {
+      window.alert(`停止失败：${error.message || error}`);
+    }
+  }
+
+  async function saveExpressionPresetFromComposer() {
+    const presetId = String((composerPresetId && composerPresetId.value) || "").trim();
+    if (!presetId) {
+      window.alert("请输入组合 ID");
+      return;
+    }
+    if (!window.confirm(`确认保存组合「${presetId}」？`)) return;
+    try {
+      const body = currentExpressionBody();
+      body.preset_id = presetId;
+      body.label = String((composerPresetLabel && composerPresetLabel.value) || presetId).trim();
+      body.confirmed = true;
+      await fetchJson("/api/expression-presets", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      await refreshExpressionStudio();
+    } catch (error) {
+      window.alert(`保存失败：${error.message || error}`);
+    }
+  }
+
+  async function uploadExpressionEye() {
+    const file = eyeUploadFile && eyeUploadFile.files && eyeUploadFile.files[0];
+    const clipId = String((eyeUploadId && eyeUploadId.value) || "").trim();
+    if (!file || !clipId) {
+      window.alert("请选择素材并填写素材 ID");
+      return;
+    }
+    btnEyeUpload.disabled = true;
+    try {
+      const dataUrl = await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(String(reader.result || ""));
+        reader.onerror = () => reject(reader.error || new Error("读取失败"));
+        reader.readAsDataURL(file);
+      });
+      await fetchJson("/api/expression-clips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          clip_id: clipId,
+          expression: clipId,
+          filename: file.name,
+          content_type: file.type,
+          content_base64: dataUrl.split(",", 2)[1] || "",
+          fps: Number((eyeUploadFps && eyeUploadFps.value) || 10),
+          grid_rows: Number((eyeUploadRows && eyeUploadRows.value) || 0) || null,
+          grid_cols: Number((eyeUploadCols && eyeUploadCols.value) || 0) || null,
+        }),
+      });
+      await refreshExpressionStudio();
+    } catch (error) {
+      window.alert(`上传失败：${error.message || error}`);
+    } finally {
+      btnEyeUpload.disabled = false;
+    }
+  }
+
   function renderExpressions(expressions) {
     if (Array.isArray(expressions)) latestExpressions = normalizeExpressionEntries(expressions);
     populateRecordingExpressionSelect();
@@ -3480,15 +3978,18 @@
       : latestExpressions;
     filtered.forEach((name) => {
       const meta = expressionMeta(name);
+      const effect = expressionLedEffects.find((item) => item.effect_id === name);
       const labelCn = expressionLabel(name);
-      const metaParts = ["LED 表情"];
+      const metaParts = [effect ? (effect.role || "LED") : "LED 表情"];
       if (meta && meta.mode !== null && meta.mode !== undefined) metaParts.push(`m${meta.mode}`);
       if (meta) metaParts.push(meta.animated ? "动态" : "静态");
+      if (effect) metaParts.push(effect.source || "builtin");
+      metaParts.push("眼睛保持当前");
       const card = makeSkillCard({
         title: labelCn,
         meta: metaParts.join(" · "),
-        tooltip: `切换灯光表情：${labelCn}（${name}）`,
-        onClick: () => invokeExpression(name),
+        tooltip: `单独播放 LED 效果：${labelCn}（${name}），眼睛保持当前画面`,
+        onClick: () => { void playLedEffect(name); },
       });
       expressionGrid.appendChild(card);
     });
@@ -3509,6 +4010,62 @@
   wireSkillSearch(userSkillSearchEl, (v) => { userSkillQuery = v; renderUserSkills(); });
   wireSkillSearch(recordingSearchEl, (v) => { recordingQuery = v; renderRecordings(); });
   wireSkillSearch(expressionSearchEl, (v) => { expressionQuery = v; renderExpressions(); });
+  expressionTabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      const target = tab.dataset.expressionTab;
+      expressionTabs.forEach((item) => item.classList.toggle("is-active", item === tab));
+      expressionPanels.forEach((panel) => panel.classList.toggle("hidden", panel.dataset.expressionPanel !== target));
+    });
+  });
+  document.querySelectorAll("[data-direction]").forEach((button) => {
+    button.addEventListener("click", () => setExpressionDirection(button.dataset.direction || "right"));
+  });
+  document.querySelectorAll("[data-playback]").forEach((button) => {
+    button.addEventListener("click", () => {
+      expressionPlayback = button.dataset.playback === "loop" ? "loop" : "once";
+      document.querySelectorAll("[data-playback]").forEach((item) => {
+        item.classList.toggle("is-active", item.dataset.playback === expressionPlayback);
+      });
+    });
+  });
+  if (btnExpressionPreview) btnExpressionPreview.addEventListener("click", () => { void previewExpression(); });
+  if (btnExpressionSync) btnExpressionSync.addEventListener("click", () => { void syncExpressionEye(); });
+  if (btnExpressionSetDefault) {
+    btnExpressionSetDefault.addEventListener("click", () => { void setDefaultLedForEye(); });
+  }
+  if (btnExpressionPlay) btnExpressionPlay.addEventListener("click", () => { void playExpression(); });
+  if (btnExpressionStop) btnExpressionStop.addEventListener("click", () => { void stopExpression(); });
+  if (btnExpressionSave) btnExpressionSave.addEventListener("click", () => { void saveExpressionPresetFromComposer(); });
+  if (btnEyeUpload) btnEyeUpload.addEventListener("click", () => { void uploadExpressionEye(); });
+  if (ledEffectForm) {
+    ledEffectForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      try {
+        await fetchJson("/api/led-effects", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            effect_id: String(ledEffectId.value || "").trim(),
+            label: String(ledEffectLabel.value || "").trim(),
+            role: ledEffectRole.value,
+            program: {
+              version: 1,
+              template: ledEffectTemplate.value,
+              defaults: { color: ledEffectColor.value, intensity: 1.0 },
+            },
+          }),
+        });
+        ledEffectForm.reset();
+        ledEffectColor.value = "#ffffff";
+        await refreshExpressionStudio();
+      } catch (error) {
+        window.alert(`保存失败：${error.message || error}`);
+      }
+    });
+  }
+  ensureLedPreviewCells();
+  void refreshSkillsAndRecordings();
+  void refreshExpressionStudio();
   if (btnUserSkillsReload) {
     btnUserSkillsReload.addEventListener("click", () => { void reloadUserSkills(); });
   }
@@ -5035,37 +5592,6 @@
   let hangupPending = false;
   let hangupCancelled = false;
 
-  const ESP32_WORKLET_CODE = `
-class Esp32PcmProcessor extends AudioWorkletProcessor {
-  constructor() {
-    super();
-    this._buffer = new Float32Array(0);
-    this.port.onmessage = (e) => {
-      const incoming = e.data;
-      const merged = new Float32Array(this._buffer.length + incoming.length);
-      merged.set(this._buffer);
-      merged.set(incoming, this._buffer.length);
-      this._buffer = merged;
-    };
-  }
-  process(inputs, outputs) {
-    const out = outputs[0][0];
-    if (!out) return true;
-    const needed = out.length;
-    if (this._buffer.length >= needed) {
-      out.set(this._buffer.subarray(0, needed));
-      this._buffer = this._buffer.subarray(needed);
-    } else {
-      out.set(this._buffer);
-      out.fill(0, this._buffer.length);
-      this._buffer = new Float32Array(0);
-    }
-    return true;
-  }
-}
-registerProcessor("esp32-pcm-processor", Esp32PcmProcessor);
-`;
-
   function setBrowserCallState(state) {
     updateCallViewState(state);
   }
@@ -5593,10 +6119,7 @@ registerProcessor("esp32-pcm-processor", Esp32PcmProcessor);
     if (esp32AudioCtx.state === "suspended") {
       try { await esp32AudioCtx.resume(); } catch (_) { /* ignore */ }
     }
-    const blob = new Blob([ESP32_WORKLET_CODE], { type: "application/javascript" });
-    const url = URL.createObjectURL(blob);
-    await esp32AudioCtx.audioWorklet.addModule(url);
-    URL.revokeObjectURL(url);
+    await esp32AudioCtx.audioWorklet.addModule("/esp32-pcm-worklet.js?v=20260709");
 
     esp32WorkletNode = new AudioWorkletNode(esp32AudioCtx, "esp32-pcm-processor");
     const dest = esp32AudioCtx.createMediaStreamDestination();

--- a/lampgo/web/static/esp32-pcm-worklet.js
+++ b/lampgo/web/static/esp32-pcm-worklet.js
@@ -1,0 +1,30 @@
+class Esp32PcmProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._buffer = new Float32Array(0);
+    this.port.onmessage = (event) => {
+      const incoming = event.data;
+      const merged = new Float32Array(this._buffer.length + incoming.length);
+      merged.set(this._buffer);
+      merged.set(incoming, this._buffer.length);
+      this._buffer = merged;
+    };
+  }
+
+  process(inputs, outputs) {
+    const out = outputs[0][0];
+    if (!out) return true;
+    const needed = out.length;
+    if (this._buffer.length >= needed) {
+      out.set(this._buffer.subarray(0, needed));
+      this._buffer = this._buffer.subarray(needed);
+    } else {
+      out.set(this._buffer);
+      out.fill(0, this._buffer.length);
+      this._buffer = new Float32Array(0);
+    }
+    return true;
+  }
+}
+
+registerProcessor("esp32-pcm-processor", Esp32PcmProcessor);

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>YareLampGo 控制台</title>
   <link rel="icon" href="/%E5%8F%B0%E7%81%AF%E8%99%BE%E5%A4%B4%E5%83%8F.jpeg">
-  <link rel="stylesheet" href="/style.css?v=brand-yarelampgo-20260604b">
+  <link rel="stylesheet" href="/style.css?v=recording-expression-presets-20260710">
   <link rel="stylesheet" href="/setup.css?v=secret-inputs-20260602">
 </head>
 <body>
@@ -1218,7 +1218,7 @@
   <dialog id="record-name-dialog" class="record-dialog">
     <form id="record-name-form" method="dialog" class="record-dialog-card">
       <div class="record-dialog-title">保存录制动作</div>
-      <div class="record-dialog-desc">请输入动作名称、动作说明和推荐表情，AI 会把它们作为选择和播放这个动作时的参考。</div>
+      <div class="record-dialog-desc">请输入动作名称、动作说明，并绑定播放时要同步触发的表情。</div>
       <input
         id="record-name-input"
         class="record-dialog-input"
@@ -1234,8 +1234,9 @@
         placeholder="例如：开心打招呼、看见用户靠近时挥动灯头，适合回应问候或活跃气氛。"
       ></textarea>
       <label class="record-dialog-field">
-        <span class="record-dialog-label">推荐表情</span>
+        <span class="record-dialog-label">绑定组合表情（眼睛 + LED）</span>
         <select id="record-expression-select" class="record-dialog-input record-dialog-select"></select>
+        <span class="record-dialog-hint">组合表情会在整个动作期间循环播放 C6 眼睛与 S3 LED；也可在下拉框中选择仅 LED 效果。</span>
       </label>
       <div id="record-name-error" class="record-dialog-error"></div>
       <div class="record-dialog-actions">
@@ -1249,7 +1250,7 @@
   <dialog id="record-edit-dialog" class="record-dialog">
     <form id="record-edit-form" method="dialog" class="record-dialog-card">
       <div class="record-dialog-title">编辑录制动作</div>
-      <div id="record-edit-desc" class="record-dialog-desc">只会修改推荐表情和动作说明，不会改动录制动作轨迹。</div>
+      <div id="record-edit-desc" class="record-dialog-desc">只会修改绑定表情和动作说明，不会改动录制动作轨迹。</div>
       <textarea
         id="record-edit-description-input"
         class="record-dialog-input record-dialog-textarea"
@@ -1257,8 +1258,9 @@
         placeholder="例如：开心打招呼、看见用户靠近时挥动灯头，适合回应问候或活跃气氛。"
       ></textarea>
       <label class="record-dialog-field">
-        <span class="record-dialog-label">推荐表情</span>
+        <span class="record-dialog-label">绑定组合表情（眼睛 + LED）</span>
         <select id="record-edit-expression-select" class="record-dialog-input record-dialog-select"></select>
+        <span class="record-dialog-hint">组合表情会在整个动作期间循环播放；“仅 LED 灯板”分组不会改变当前眼睛画面。</span>
       </label>
       <div id="record-edit-error" class="record-dialog-error"></div>
       <div class="record-dialog-actions">
@@ -1425,7 +1427,7 @@
     </div>
   </dialog>
 
-  <script src="/app.js?v=expression-led-only-20260710"></script>
+  <script src="/app.js?v=recording-expression-presets-20260710"></script>
   <script type="module" src="/pet.js?v=19"></script>
   <script src="/setup.js?v=secret-inputs-20260602"></script>
 </body>

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -343,16 +343,95 @@
           <div class="skill-section">
             <div class="skill-section-head">
               <div>
-                <div class="skill-section-title">灯光表情</div>
-                <div class="skill-section-desc">通过 LED 灯阵呈现的情绪表达。</div>
+                <div class="skill-section-title">表情工作台</div>
+                <div class="skill-section-desc">组合 C6 眼睛动画与 S3 LED 嘴巴、符号和方向效果。</div>
               </div>
               <div class="skill-section-count" id="expression-count">0</div>
             </div>
-            <div class="skill-section-search">
-              <input id="expression-search" type="search" class="skill-search-input" placeholder="搜索灯光表情" autocomplete="off" />
-              <button type="button" class="skill-search-clear" data-target="expression-search" aria-label="清空搜索">×</button>
+            <div class="expression-tabs" role="tablist" aria-label="表情工作区">
+              <button type="button" class="expression-tab is-active" data-expression-tab="eyes" role="tab">眼睛素材</button>
+              <button type="button" class="expression-tab" data-expression-tab="led" role="tab">LED 效果</button>
+              <button type="button" class="expression-tab" data-expression-tab="compose" role="tab">组合表情</button>
             </div>
-            <div id="expression-grid" class="skill-card-grid"></div>
+            <div id="expression-capacity" class="expression-capacity" aria-live="polite"></div>
+
+            <div class="expression-panel" data-expression-panel="eyes">
+              <div class="expression-toolbar">
+                <input id="eye-upload-file" type="file" accept="image/png,image/gif,image/jpeg,video/mp4,application/zip" />
+                <input id="eye-upload-id" type="text" placeholder="素材 ID" maxlength="32" />
+                <label>行 <input id="eye-upload-rows" type="number" min="1" max="30" value="5" /></label>
+                <label>列 <input id="eye-upload-cols" type="number" min="1" max="30" value="6" /></label>
+                <label>FPS <input id="eye-upload-fps" type="number" min="8" max="12" value="10" /></label>
+                <button id="btn-eye-upload" class="primary-button" type="button">上传眼睛</button>
+              </div>
+              <div id="eye-grid" class="expression-resource-list"></div>
+            </div>
+
+            <div class="expression-panel hidden" data-expression-panel="led">
+              <div class="skill-section-search">
+                <input id="expression-search" type="search" class="skill-search-input" placeholder="搜索 LED 效果" autocomplete="off" />
+                <button type="button" class="skill-search-clear" data-target="expression-search" aria-label="清空搜索">×</button>
+              </div>
+              <div id="expression-grid" class="skill-card-grid"></div>
+              <form id="led-effect-form" class="expression-editor-row">
+                <input id="led-effect-id" type="text" maxlength="32" placeholder="效果 ID" required />
+                <input id="led-effect-label" type="text" maxlength="64" placeholder="显示名称" required />
+                <select id="led-effect-role" aria-label="LED 用途">
+                  <option value="mouth">嘴巴</option>
+                  <option value="symbol">符号</option>
+                  <option value="direction">方向</option>
+                  <option value="accent">气氛</option>
+                </select>
+                <select id="led-effect-template" aria-label="程序模板">
+                  <option value="mouth">嘴巴</option>
+                  <option value="arrow">箭头</option>
+                  <option value="heart">爱心</option>
+                  <option value="pulse">脉冲</option>
+                </select>
+                <input id="led-effect-color" type="color" value="#ffffff" title="默认颜色" />
+                <button class="primary-button" type="submit">保存 LED 效果</button>
+              </form>
+            </div>
+
+            <div class="expression-panel hidden" data-expression-panel="compose">
+              <div class="expression-composer">
+                <div class="expression-preview" aria-label="三秒同步预览">
+                  <canvas id="expression-eye-preview" width="320" height="172"></canvas>
+                  <div id="expression-led-preview" class="expression-led-matrix"></div>
+                  <div id="expression-preview-status" class="expression-preview-status">等待预览</div>
+                </div>
+                <div class="expression-controls">
+                  <label>眼睛<select id="composer-eye"><option value="">无眼睛</option></select></label>
+                  <label>LED<select id="composer-led"><option value="">无 LED</option></select></label>
+                  <label>颜色<input id="composer-color" type="color" value="#ffffff" /></label>
+                  <label>亮度<input id="composer-brightness" type="range" min="1" max="96" value="64" /></label>
+                  <label>强度<input id="composer-intensity" type="range" min="10" max="100" value="100" /></label>
+                  <div class="expression-direction" role="group" aria-label="方向">
+                    <button type="button" data-direction="left" title="向左">←</button>
+                    <button type="button" data-direction="up" title="向上">↑</button>
+                    <button type="button" data-direction="down" title="向下">↓</button>
+                    <button type="button" class="is-active" data-direction="right" title="向右">→</button>
+                  </div>
+                  <div class="expression-playback" role="group" aria-label="播放方式">
+                    <button type="button" class="is-active" data-playback="once">单次</button>
+                    <button type="button" data-playback="loop">循环</button>
+                  </div>
+                  <div class="expression-command-row">
+                    <button id="btn-expression-preview" class="ghost-button" type="button" title="本地预览">▶ 预览</button>
+                    <button id="btn-expression-sync" class="ghost-button" type="button">同步眼睛</button>
+                    <button id="btn-expression-set-default" class="ghost-button" type="button">设为默认搭配</button>
+                    <button id="btn-expression-play" class="primary-button" type="button">▶ 播放</button>
+                    <button id="btn-expression-stop" class="ghost-button" type="button" title="停止播放">■</button>
+                  </div>
+                  <div class="expression-save-row">
+                    <input id="composer-preset-id" type="text" maxlength="32" placeholder="组合 ID" />
+                    <input id="composer-preset-label" type="text" maxlength="64" placeholder="组合名称" />
+                    <button id="btn-expression-save" class="ghost-button" type="button">保存组合</button>
+                  </div>
+                </div>
+              </div>
+              <div id="expression-preset-grid" class="expression-resource-list"></div>
+            </div>
           </div>
         </div>
       </section>
@@ -1346,7 +1425,7 @@
     </div>
   </dialog>
 
-  <script src="/app.js?v=livekit-audio-output-20260602"></script>
+  <script src="/app.js?v=expression-led-only-20260710"></script>
   <script type="module" src="/pet.js?v=19"></script>
   <script src="/setup.js?v=secret-inputs-20260602"></script>
 </body>

--- a/lampgo/web/static/style.css
+++ b/lampgo/web/static/style.css
@@ -3514,6 +3514,12 @@ button.device-chip.is-active {
   color: var(--text-soft);
 }
 
+.record-dialog-hint {
+  color: var(--text-muted, #a08b80);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+
 .record-dialog-select {
   width: 100%;
 }

--- a/lampgo/web/static/style.css
+++ b/lampgo/web/static/style.css
@@ -2544,6 +2544,225 @@ button.device-chip.is-active {
   box-shadow: 0 8px 20px rgba(221, 147, 136, 0.14);
 }
 
+/* ============= Expression studio ============= */
+
+.primary-button {
+  min-height: 32px;
+  padding: 7px 14px;
+  border: 1px solid #227c75;
+  border-radius: 7px;
+  background: #227c75;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.primary-button:hover { background: #19665f; }
+
+.expression-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 10px;
+}
+
+.expression-tab {
+  min-height: 36px;
+  padding: 7px 12px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--text-soft);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.expression-tab.is-active {
+  border-bottom-color: #227c75;
+  color: #155f59;
+}
+
+.expression-capacity {
+  min-height: 28px;
+  margin-bottom: 12px;
+  padding: 6px 10px;
+  border-left: 3px solid #d14f73;
+  background: #f8f9fa;
+  color: #596169;
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+
+.expression-panel.hidden { display: none; }
+
+.expression-toolbar,
+.expression-editor-row,
+.expression-save-row,
+.expression-command-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.expression-toolbar,
+.expression-editor-row {
+  margin-bottom: 12px;
+  padding: 10px;
+  border: 1px solid #dce1e5;
+  background: #f8f9fa;
+}
+
+.expression-toolbar input[type="text"],
+.expression-toolbar input[type="number"],
+.expression-editor-row input[type="text"],
+.expression-editor-row select,
+.expression-controls input[type="text"],
+.expression-controls select {
+  min-height: 32px;
+  border: 1px solid #ccd3d8;
+  border-radius: 6px;
+  background: #fff;
+  color: #30363b;
+  padding: 5px 8px;
+}
+
+.expression-toolbar input[type="number"] { width: 64px; }
+.expression-toolbar label { color: #596169; font-size: 12px; }
+
+.expression-resource-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 8px;
+}
+
+.expression-resource {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 58px;
+  padding: 9px 10px;
+  border: 1px solid #dce1e5;
+  border-radius: 7px;
+  background: #fff;
+}
+
+.expression-resource-title {
+  overflow: hidden;
+  color: #30363b;
+  font-size: 13px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.expression-resource-meta {
+  margin-top: 3px;
+  color: #717a82;
+  font-size: 11px;
+}
+
+.expression-resource-actions { display: flex; gap: 5px; }
+.expression-resource-actions button { min-width: 32px; padding: 5px 8px; }
+
+.expression-composer {
+  display: grid;
+  grid-template-columns: minmax(360px, 1.4fr) minmax(250px, 0.8fr);
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.expression-preview {
+  position: relative;
+  min-width: 0;
+  padding: 12px;
+  background: #181b1f;
+  border: 1px solid #30363d;
+  border-radius: 7px;
+}
+
+#expression-eye-preview {
+  display: block;
+  width: 100%;
+  aspect-ratio: 320 / 172;
+  background: #000;
+  image-rendering: auto;
+}
+
+.expression-led-matrix {
+  display: grid;
+  grid-template-columns: repeat(51, minmax(0, 1fr));
+  gap: 1px;
+  width: 100%;
+  aspect-ratio: 51 / 9;
+  margin-top: 10px;
+}
+
+.expression-led-cell {
+  min-width: 0;
+  aspect-ratio: 1;
+  border-radius: 1px;
+  background: #30353a;
+}
+
+.expression-preview-status {
+  min-height: 19px;
+  margin-top: 8px;
+  color: #cdd5dc;
+  font-size: 11.5px;
+  text-align: center;
+}
+
+.expression-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  min-width: 0;
+}
+
+.expression-controls > label {
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  color: #596169;
+  font-size: 12px;
+}
+
+.expression-direction,
+.expression-playback {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: 4px;
+}
+
+.expression-direction button,
+.expression-playback button {
+  min-height: 32px;
+  border: 1px solid #ccd3d8;
+  border-radius: 6px;
+  background: #fff;
+  color: #596169;
+}
+
+.expression-direction button.is-active,
+.expression-playback button.is-active {
+  border-color: #227c75;
+  background: #e4f3f1;
+  color: #155f59;
+}
+
+.expression-save-row input { flex: 1 1 110px; min-width: 0; }
+
+@media (max-width: 860px) {
+  .expression-composer { grid-template-columns: 1fr; }
+  .expression-toolbar input[type="file"] { width: 100%; }
+  .expression-resource-list { grid-template-columns: 1fr; }
+}
+
 /* User-authored composed skills carry a subtle left-border tint so users
    can tell at a glance which skills they (or OpenClaw) can safely delete /
    modify, and which ones are factory-locked.  The accent colour matches

--- a/openclaw-plugin-lampgo/index.ts
+++ b/openclaw-plugin-lampgo/index.ts
@@ -111,8 +111,9 @@ const plugin: OpenClawPluginModule = {
 
     api.registerTool({
       name: "lampgo_expression",
-      label: "Set lampgo LED expression",
-      description: "Set lampgo LED expression.",
+      label: "Play lampgo expression",
+      description:
+        "Play a saved expression preset, C6 eye clip, or S3 LED effect. Query lampgo_expression_catalog before choosing dynamic ids.",
       parameters: Type.Object({
         mode: Type.String({ description: "LED expression mode key, e.g. smiley/heart/focused/wink/myu7gt." }),
         wait: Type.Optional(Type.Boolean({ description: "Wait for completion (default true)." })),
@@ -126,6 +127,98 @@ const plugin: OpenClawPluginModule = {
         });
         if (!result.ok) throw new Error(result.error || "lampgo invoke failed");
         return toolOk("ok");
+      },
+    });
+
+    api.registerTool({
+      name: "lampgo_expression_catalog",
+      label: "List lampgo expressions",
+      description: "List currently available eye clips, LED effects, presets, and device capacity.",
+      parameters: Type.Object({}),
+      async execute() {
+        const base = getBase();
+        const [catalog, capacity] = await Promise.all([
+          getJson<unknown>(`${base}/api/expressions`),
+          getJson<unknown>(`${base}/api/device/expression-capabilities`),
+        ]);
+        return toolOk(JSON.stringify({ catalog, capacity }, null, 2));
+      },
+    });
+
+    api.registerTool({
+      name: "lampgo_compose_expression",
+      label: "Play transient lampgo composition",
+      description:
+        "Temporarily combine a discovered C6 eye clip and S3 LED effect. This does not save a preset.",
+      parameters: Type.Object({
+        eyeClipId: Type.Optional(Type.String({ description: "Eye id from lampgo_expression_catalog." })),
+        ledEffectId: Type.Optional(Type.String({ description: "LED effect id from lampgo_expression_catalog." })),
+        color: Type.Optional(Type.String({ description: "LED #RRGGBB color override." })),
+        brightness: Type.Optional(Type.Integer({ minimum: 1, maximum: 96 })),
+        intensity: Type.Optional(Type.Number({ minimum: 0.1, maximum: 1.0 })),
+        direction: Type.Optional(Type.Union([
+          Type.Literal("left"), Type.Literal("right"), Type.Literal("up"), Type.Literal("down"),
+        ])),
+        playback: Type.Optional(Type.Union([Type.Literal("once"), Type.Literal("loop")])),
+      }),
+      async execute(_toolCallId, params) {
+        const base = getBase();
+        const result = await postJson<{ ok: boolean; error?: string }>(`${base}/api/expressions/play`, {
+          eye_clip_id: params.eyeClipId ?? null,
+          led_effect_id: params.ledEffectId ?? null,
+          led_params: {
+            color: params.color ?? "#ffffff",
+            brightness: params.brightness ?? 64,
+            intensity: params.intensity ?? 1.0,
+            direction: params.direction ?? "right",
+          },
+          playback: params.playback ?? "once",
+          duration_ms: 3000,
+        });
+        if (!result.ok) throw new Error(result.error || "lampgo expression play failed");
+        return toolOk("ok (transient; not saved)");
+      },
+    });
+
+    api.registerTool({
+      name: "lampgo_save_expression_preset",
+      label: "Save lampgo expression preset",
+      description:
+        "Save a confirmed eye + LED composition. Set confirmed=true only after the user explicitly asks to save it.",
+      parameters: Type.Object({
+        presetId: Type.String({ description: "Stable lowercase preset id." }),
+        label: Type.String({ description: "User-facing preset name." }),
+        eyeClipId: Type.Optional(Type.String()),
+        ledEffectId: Type.Optional(Type.String()),
+        color: Type.Optional(Type.String()),
+        brightness: Type.Optional(Type.Integer({ minimum: 1, maximum: 96 })),
+        intensity: Type.Optional(Type.Number({ minimum: 0.1, maximum: 1.0 })),
+        direction: Type.Optional(Type.Union([
+          Type.Literal("left"), Type.Literal("right"), Type.Literal("up"), Type.Literal("down"),
+        ])),
+        playback: Type.Optional(Type.Union([Type.Literal("once"), Type.Literal("loop")])),
+        confirmed: Type.Boolean({ description: "Must be true only after explicit user confirmation." }),
+      }),
+      async execute(_toolCallId, params) {
+        const base = getBase();
+        const result = await postJson<{ ok: boolean; error?: string }>(`${base}/api/expression-presets`, {
+          preset_id: params.presetId,
+          label: params.label,
+          eye_clip_id: params.eyeClipId ?? null,
+          led_effect_id: params.ledEffectId ?? null,
+          led_params: {
+            color: params.color ?? "#ffffff",
+            brightness: params.brightness ?? 64,
+            intensity: params.intensity ?? 1.0,
+            direction: params.direction ?? "right",
+          },
+          playback: params.playback ?? "once",
+          duration_ms: 3000,
+          confirmed: params.confirmed,
+          source: "openclaw",
+        });
+        if (!result.ok) throw new Error(result.error || "lampgo preset save failed");
+        return toolOk("saved");
       },
     });
 

--- a/openclaw-skills/lampgo/SKILL.md
+++ b/openclaw-skills/lampgo/SKILL.md
@@ -23,13 +23,18 @@ metadata:
 
 # lampgo — Intelligent Desk Lamp Robot
 
-Control a 5-DOF desk lamp robot: 37 pre-recorded actions + 34 LED expressions + smooth joint control + teach recording + camera vision + visual servoing.
+Control a 5-DOF desk lamp robot with dynamic C6 eye clips, reusable S3 LED
+effects, saved expression presets, smooth joint control, teach recording,
+camera vision, and visual servoing.
 
 Use the OpenClaw plugin tools (preferred, keeps all interactions inside OpenClaw):
 
 - `lampgo_move` (joint move via `move_to`)
 - `lampgo_play` (play recording via `play_recording`)
-- `lampgo_expression` (LED expression via `set_expression`)
+- `lampgo_expression_catalog` (live eyes, LED effects, presets, and capacity)
+- `lampgo_expression` (play a discovered expression id via `set_expression`)
+- `lampgo_compose_expression` (play an unsaved eye + LED combination)
+- `lampgo_save_expression_preset` (save only after explicit user confirmation)
 - `lampgo_camera_snap` (take a photo)
 - `lampgo_ask_user` (ask the user a question with TTS)
 - `lampgo_save_recording` (save a new CSV recording)

--- a/openclaw-skills/lampgo/references/api.md
+++ b/openclaw-skills/lampgo/references/api.md
@@ -42,7 +42,18 @@ Connect to Unix socket `/tmp/lampgo.sock`, send one JSON line, receive one JSON 
 - `fps` (int, optional): playback FPS override
 
 ### set_expression
-- `mode` (str): exact LED mode key (see led-modes.md in lampgo skill), e.g. `smiley`, `heart`, `focused`, `wink`, `myu7gt`
+- `mode` (str): a live expression preset, eye clip, LED effect id, or built-in
+  mode. Query `GET /api/expressions` before choosing dynamic ids.
+
+### Expression HTTP API
+
+- `GET /api/eyes`
+- `GET /api/led-effects`
+- `GET /api/expression-presets`
+- `GET /api/device/expression-capabilities`
+- `POST /api/expressions/play` — saved preset or transient composition
+- `POST /api/expressions/stop`
+- `POST /api/expression-presets` — requires explicit `confirmed: true`
 
 ### nod / headshake
 - `count` (int): number of repetitions

--- a/openclaw-skills/lampgo/references/led-modes.md
+++ b/openclaw-skills/lampgo/references/led-modes.md
@@ -1,4 +1,13 @@
-# LED Expression Keys (34 modes)
+# LED Expression Keys (34 built-in modes)
+
+This table is only the firmware built-in set. Call
+`lampgo_expression_catalog` before selecting a dynamic C6 eye clip, S3 LED
+effect, or saved preset, then pass the discovered id to `lampgo_expression`.
+
+The C6 renders eyes only. The S3 LED board renders mouths, symbols, directions,
+and accents. An LLM may play a transient combination, but must not save a new
+preset until the user explicitly confirms it. See
+`docs/guides/expression-authoring.md` for the authoring and capacity contract.
 
 Use the exact `Name` column in OpenClaw tool calls.
 

--- a/tests/test_esp32_pairing.py
+++ b/tests/test_esp32_pairing.py
@@ -89,6 +89,31 @@ def test_preferred_fallback_keeps_pairing_probe_status(monkeypatch, tmp_path) ->
     assert [d["host"] for d in status["all_devices"]] == ["lampgo-cam-0834.local"]
 
 
+async def test_bulk_transfer_stays_online_and_skips_health_probe(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    manager = Esp32DeviceManager(DeviceEsp32Config(enabled=True))
+    device = _device("self.local", owner_id=manager.owner_id, paired=True)
+    device.last_health_ok = False
+    manager._devices = {"self": device}
+    manager._active_transfers = 1
+    probes = 0
+
+    async def fake_probe(_device):
+        nonlocal probes
+        probes += 1
+        return False
+
+    monkeypatch.setattr(manager, "_probe", fake_probe)
+
+    await manager._probe_all()
+    status = manager.get_status()
+
+    assert probes == 0
+    assert status["online"] is True
+    assert status["transfer_active"] is True
+    assert device.last_health_ok is True
+
+
 async def test_claim_owner_is_non_preemptive_and_sends_auth(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
     manager = Esp32DeviceManager(DeviceEsp32Config(enabled=True))

--- a/tests/test_expression_clips.py
+++ b/tests/test_expression_clips.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import numpy as np
+import pytest
+from starlette.testclient import TestClient
+
+from lampgo.core.config import DeviceConfig, LampgoConfig
+from lampgo.expression_clips import create_expression_clip, list_expression_clips
+from lampgo.server import LampgoServer
+from lampgo.web.gateway import WebGateway
+
+
+def _png_sprite_sheet(*, rows: int = 3, cols: int = 10, cell_w: int = 32, cell_h: int = 18) -> bytes:
+    cv2 = pytest.importorskip("cv2")
+    sheet = np.zeros((rows * cell_h, cols * cell_w, 3), dtype=np.uint8)
+    for index in range(rows * cols):
+        row = index // cols
+        col = index % cols
+        x0 = col * cell_w
+        y0 = row * cell_h
+        color = np.array([(index * 7) % 255, 210, 255 - ((index * 5) % 180)], dtype=np.uint8)
+        sheet[y0 + 3 : y0 + cell_h - 3, x0 + 4 : x0 + cell_w - 4] = color
+    ok, encoded = cv2.imencode(".png", cv2.cvtColor(sheet, cv2.COLOR_RGB2BGR))
+    assert ok
+    return bytes(encoded)
+
+
+def _make_gateway(monkeypatch, tmp_path: Path) -> WebGateway:
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    server = LampgoServer(LampgoConfig(device=DeviceConfig(motor_port="/dev/null")))
+    return WebGateway(server)
+
+
+def test_create_expression_clip_from_sprite_sheet(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+
+    manifest = create_expression_clip(
+        clip_id="smiley",
+        expression="smiley",
+        source_bytes=_png_sprite_sheet(),
+        filename="smiley.png",
+        content_type="image/png",
+        fps=10,
+        grid_rows=3,
+        grid_cols=10,
+    )
+
+    assert manifest["clip_id"] == "smiley"
+    assert manifest["duration_ms"] == 3000
+    assert manifest["frame_count"] == 30
+    assert manifest["lcd"]["bytes"] > 0
+    assert manifest["led"] == {"type": "procedural", "effect": "smiley"}
+    assert (tmp_path / "expression_clips" / "smiley" / "lcd.bin").exists()
+    assert not (tmp_path / "expression_clips" / "smiley" / "led.bin").exists()
+    assert list_expression_clips()[0]["expression"] == "smiley"
+
+
+def test_expression_clip_rejects_short_duration(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+
+    with pytest.raises(ValueError, match="duration"):
+        create_expression_clip(
+            clip_id="too-short",
+            expression="smiley",
+            source_bytes=_png_sprite_sheet(rows=1, cols=5),
+            filename="short.png",
+            fps=10,
+            grid_rows=1,
+            grid_cols=5,
+        )
+
+
+def test_expression_clip_api_upload_and_sync(monkeypatch, tmp_path):
+    gateway = _make_gateway(monkeypatch, tmp_path)
+    sent: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_proxy_post(path: str, payload: dict[str, object]):
+        sent.append((path, payload))
+        return 200, {"ok": True}, "application/json"
+
+    monkeypatch.setattr(gateway.server.esp32, "proxy_post", fake_proxy_post)
+
+    upload = {
+        "clip_id": "focused",
+        "expression": "focused",
+        "filename": "focused.png",
+        "content_type": "image/png",
+        "content_base64": base64.b64encode(_png_sprite_sheet()).decode("ascii"),
+        "fps": 10,
+        "grid_rows": 3,
+        "grid_cols": 10,
+    }
+    with TestClient(gateway.app) as client:
+        response = client.post("/api/expression-clips", json=upload)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        assert body["result"]["clip"]["clip_id"] == "focused"
+
+        listed = client.get("/api/expression-clips").json()
+        assert listed["result"]["clips"][0]["clip_id"] == "focused"
+
+        sync = client.post("/api/device/expression-clips/sync", json={"clip_id": "focused"})
+        assert sync.status_code == 200
+        assert sync.json()["result"]["sent_chunks"] == len(sent)
+
+    assert sent[0][0] == "/device/expression-clips/sync"
+    assert sent[0][1]["action"] == "begin"
+    assert sent[0][1]["led_effect"] == "focused"
+    assert not any(payload["action"] == "chunk" and payload["target"] == "led" for _path, payload in sent)
+    assert any(payload["action"] == "chunk" and payload["target"] == "lcd" for _path, payload in sent)
+    assert sent[-1][1]["action"] == "commit"

--- a/tests/test_expression_clips.py
+++ b/tests/test_expression_clips.py
@@ -75,13 +75,19 @@ def test_expression_clip_rejects_short_duration(monkeypatch, tmp_path):
 
 def test_expression_clip_api_upload_and_sync(monkeypatch, tmp_path):
     gateway = _make_gateway(monkeypatch, tmp_path)
-    sent: list[tuple[str, dict[str, object]]] = []
+    sent: list[tuple[str, bytes, dict[str, object]]] = []
 
-    async def fake_proxy_post(path: str, payload: dict[str, object]):
-        sent.append((path, payload))
-        return 200, {"ok": True}, "application/json"
+    async def fake_proxy_post_bytes(
+        path: str,
+        payload: bytes,
+        *,
+        params: dict[str, object] | None = None,
+        content_type: str = "application/octet-stream",
+    ):
+        sent.append((path, payload, params or {}))
+        return 200, {"ok": True, "action": "upload", "c6_confirmed": True}, "application/json"
 
-    monkeypatch.setattr(gateway.server.esp32, "proxy_post", fake_proxy_post)
+    monkeypatch.setattr(gateway.server.esp32, "proxy_post_bytes", fake_proxy_post_bytes)
 
     upload = {
         "clip_id": "focused",
@@ -105,11 +111,39 @@ def test_expression_clip_api_upload_and_sync(monkeypatch, tmp_path):
 
         sync = client.post("/api/device/expression-clips/sync", json={"clip_id": "focused"})
         assert sync.status_code == 200
-        assert sync.json()["result"]["sent_chunks"] == len(sent)
+        result = sync.json()["result"]
+        assert result["transfer_mode"] == "bulk"
+        assert result["sent_chunks"] == 1
+        assert result["device_body"]["c6_confirmed"] is True
 
-    assert sent[0][0] == "/device/expression-clips/sync"
-    assert sent[0][1]["action"] == "begin"
-    assert sent[0][1]["led_effect"] == "focused"
-    assert not any(payload["action"] == "chunk" and payload["target"] == "led" for _path, payload in sent)
-    assert any(payload["action"] == "chunk" and payload["target"] == "lcd" for _path, payload in sent)
-    assert sent[-1][1]["action"] == "commit"
+    assert len(sent) == 1
+    assert sent[0][0] == "/device/expression-clips/upload"
+    assert sent[0][1]
+    assert sent[0][2]["clip_id"] == "focused"
+    assert sent[0][2]["led_effect"] == "focused"
+    assert sent[0][2]["owner_id"] == gateway.server.esp32.owner_id
+
+
+def test_expression_clip_sync_rejects_missing_c6_confirmation(monkeypatch, tmp_path):
+    gateway = _make_gateway(monkeypatch, tmp_path)
+    create_expression_clip(
+        clip_id="focused",
+        expression="focused",
+        source_bytes=_png_sprite_sheet(),
+        filename="focused.png",
+        content_type="image/png",
+        fps=10,
+        grid_rows=3,
+        grid_cols=10,
+    )
+
+    async def fake_proxy_post_bytes(*_args, **_kwargs):
+        return 200, {"ok": True, "action": "upload"}, "application/json"
+
+    monkeypatch.setattr(gateway.server.esp32, "proxy_post_bytes", fake_proxy_post_bytes)
+
+    with TestClient(gateway.app) as client:
+        response = client.post("/api/device/expression-clips/sync", json={"clip_id": "focused"})
+
+    assert response.status_code == 502
+    assert response.json()["error"] == "C6 did not confirm clip sync"

--- a/tests/test_expression_library.py
+++ b/tests/test_expression_library.py
@@ -109,6 +109,30 @@ def test_many_to_many_presets_reuse_assets(monkeypatch, tmp_path):
     assert [item["effect_id"] for item in list_led_effects()].count("soft_mouth") == 1
 
 
+def test_codex_led_effect_is_available_without_an_eye(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+
+    effect = next(item for item in list_led_effects() if item["effect_id"] == "codex")
+    resolved = resolve_expression({"led_effect_id": "codex", "playback": "loop"})
+
+    assert effect["label"] == "CODEX 闪烁字标"
+    assert effect["animated"] is True
+    assert effect["program"] == {
+        "version": 1,
+        "template": "codex",
+        "defaults": {
+            "color": "#f4f4f4",
+            "secondary_color": "#00d8ff",
+            "brightness": 64,
+            "intensity": 1.0,
+        },
+    }
+    assert resolved["eye_clip_id"] is None
+    assert resolved["led_effect_id"] == "codex"
+    assert resolved["led_effect"]["program"]["template"] == "codex"
+    assert resolved["playback"] == "loop"
+
+
 def test_dizzy_legacy_asset_migrates_without_copy(monkeypatch, tmp_path):
     monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
     _create_eye("dizzy")

--- a/tests/test_expression_library.py
+++ b/tests/test_expression_library.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from starlette.testclient import TestClient
+
+from lampgo.core.config import DeviceConfig, LampgoConfig
+from lampgo.expression_clips import create_expression_clip
+from lampgo.expression_library import (
+    ExpressionLibraryError,
+    expression_capabilities,
+    list_expression_presets,
+    list_led_effects,
+    resolve_expression,
+    save_expression_preset,
+    save_led_effect,
+)
+from lampgo.server import LampgoServer
+from lampgo.web.gateway import WebGateway
+
+
+def _sprite_sheet(*, rows: int = 3, cols: int = 10) -> bytes:
+    cv2 = pytest.importorskip("cv2")
+    sheet = np.zeros((rows * 12, cols * 20, 3), dtype=np.uint8)
+    for index in range(rows * cols):
+        row = index // cols
+        col = index % cols
+        sheet[row * 12 + 2 : row * 12 + 10, col * 20 + 3 : col * 20 + 17] = (index * 5, 220, 255)
+    ok, encoded = cv2.imencode(".png", cv2.cvtColor(sheet, cv2.COLOR_RGB2BGR))
+    assert ok
+    return bytes(encoded)
+
+
+def _create_eye(clip_id: str, *, default_led_effect_id: str | None = None) -> dict:
+    return create_expression_clip(
+        clip_id=clip_id,
+        expression=clip_id,
+        source_bytes=_sprite_sheet(),
+        filename=f"{clip_id}.png",
+        content_type="image/png",
+        fps=10,
+        grid_rows=3,
+        grid_cols=10,
+        default_led_effect_id=default_led_effect_id,
+    )
+
+
+def _custom_effect(effect_id: str) -> dict:
+    return save_led_effect(
+        {
+            "effect_id": effect_id,
+            "label": effect_id,
+            "role": "mouth",
+            "program": {
+                "version": 1,
+                "template": "mouth",
+                "variant": "smile",
+                "defaults": {"color": "#ffffff", "intensity": 0.8},
+            },
+        }
+    )
+
+
+def _gateway(monkeypatch, tmp_path: Path) -> WebGateway:
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    return WebGateway(LampgoServer(LampgoConfig(device=DeviceConfig(motor_port="/dev/null"))))
+
+
+def test_eye_default_led_and_explicit_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    _create_eye("focused_eyes", default_led_effect_id="heart")
+
+    inherited = resolve_expression({"eye_clip_id": "focused_eyes"})
+    assert inherited["led_effect_id"] == "heart"
+
+    eye_only = resolve_expression({"eye_clip_id": "focused_eyes", "led_effect_id": None})
+    assert eye_only["led_effect_id"] is None
+    assert eye_only["eye_storage_clip_id"] == "focused_eyes"
+
+
+def test_many_to_many_presets_reuse_assets(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    _create_eye("calm_eyes")
+    _create_eye("happy_eyes")
+    _custom_effect("soft_mouth")
+
+    save_expression_preset(
+        {
+            "preset_id": "calm_smile",
+            "eye_clip_id": "calm_eyes",
+            "led_effect_id": "soft_mouth",
+            "playback": "once",
+        }
+    )
+    save_expression_preset(
+        {
+            "preset_id": "happy_smile",
+            "eye_clip_id": "happy_eyes",
+            "led_effect_id": "soft_mouth",
+            "playback": "once",
+        }
+    )
+
+    presets = list_expression_presets()
+    assert {item["preset_id"] for item in presets} == {"calm_smile", "happy_smile"}
+    assert {item["led_effect_id"] for item in presets} == {"soft_mouth"}
+    assert [item["effect_id"] for item in list_led_effects()].count("soft_mouth") == 1
+
+
+def test_dizzy_legacy_asset_migrates_without_copy(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    _create_eye("dizzy")
+
+    resolved = resolve_expression({"preset_id": "dizzy"})
+    assert resolved["eye_clip_id"] == "dizzy_eyes"
+    assert resolved["eye_storage_clip_id"] == "dizzy"
+    assert resolved["led_effect_id"] == "dizzy_mouth"
+    assert resolved["playback"] == "once"
+
+
+def test_preset_api_requires_confirmation_and_transient_play_does_not_save(monkeypatch, tmp_path):
+    gateway = _gateway(monkeypatch, tmp_path)
+    _create_eye("focused_eyes")
+    _custom_effect("soft_mouth")
+    sent: list[tuple[str, dict]] = []
+
+    async def fake_proxy_post(path: str, payload: dict):
+        sent.append((path, payload))
+        return 200, {"ok": True}, "application/json"
+
+    monkeypatch.setattr(gateway.server.esp32, "proxy_post", fake_proxy_post)
+    composition = {
+        "eye_clip_id": "focused_eyes",
+        "led_effect_id": "soft_mouth",
+        "led_params": {"color": "#ff00aa", "brightness": 64, "intensity": 0.8},
+        "playback": "once",
+    }
+
+    with TestClient(gateway.app) as client:
+        played = client.post("/api/expressions/play", json=composition)
+        assert played.status_code == 200
+        assert list_expression_presets() == []
+
+        rejected = client.post("/api/expression-presets", json={"preset_id": "focus", **composition})
+        assert rejected.status_code == 400
+        assert "confirmed=true" in rejected.json()["error"]
+
+        saved = client.post(
+            "/api/expression-presets",
+            json={"preset_id": "focus", "label": "Focus", "confirmed": True, **composition},
+        )
+        assert saved.status_code == 200
+
+    assert sent[0][0] == "/device/expressions/play"
+    assert sent[0][1]["eye_clip_id"] == "focused_eyes"
+    assert sent[0][1]["led_effect_id"] == "soft_mouth"
+    assert sent[0][1]["led_program"]["template"] == "mouth"
+    assert [item["preset_id"] for item in list_expression_presets()] == ["focus"]
+
+
+def test_led_only_play_keeps_eye_channel_untouched(monkeypatch, tmp_path):
+    gateway = _gateway(monkeypatch, tmp_path)
+    sent: list[tuple[str, dict]] = []
+
+    async def fake_proxy_post(path: str, payload: dict):
+        sent.append((path, payload))
+        return 200, {"ok": True}, "application/json"
+
+    monkeypatch.setattr(gateway.server.esp32, "proxy_post", fake_proxy_post)
+
+    with TestClient(gateway.app) as client:
+        played = client.post(
+            "/api/expressions/play",
+            json={
+                "eye_clip_id": None,
+                "led_effect_id": "heart",
+                "playback": "loop",
+                "duration_ms": 3000,
+            },
+        )
+
+    assert played.status_code == 200
+    assert sent[0][0] == "/device/expressions/play"
+    assert sent[0][1]["eye_clip_id"] is None
+    assert sent[0][1]["led_effect_id"] == "heart"
+    assert sent[0][1]["playback"] == "loop"
+
+
+def test_eye_default_led_api(monkeypatch, tmp_path):
+    gateway = _gateway(monkeypatch, tmp_path)
+    _create_eye("focused_eyes")
+    _custom_effect("soft_mouth")
+
+    with TestClient(gateway.app) as client:
+        updated = client.post(
+            "/api/eyes/focused_eyes",
+            json={"default_led_effect_id": "soft_mouth"},
+        )
+        assert updated.status_code == 200
+        assert updated.json()["result"]["eye"]["default_led_effect_id"] == "soft_mouth"
+
+    resolved = resolve_expression({"eye_clip_id": "focused_eyes"})
+    assert resolved["led_effect_id"] == "soft_mouth"
+
+
+def test_led_dsl_and_capacity_guards(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    with pytest.raises(ExpressionLibraryError, match="program.template"):
+        save_led_effect(
+            {
+                "effect_id": "unsafe",
+                "role": "accent",
+                "program": {"version": 1, "template": "python", "defaults": {}},
+            }
+        )
+
+    _custom_effect("safe_mouth")
+    with pytest.raises(ExpressionLibraryError, match="brightness"):
+        resolve_expression({"led_effect_id": "safe_mouth", "led_params": {"brightness": 97}})
+    capacity = expression_capabilities()
+    assert capacity["led_effects"]["installed_custom"] == 1
+    assert capacity["led_effects"]["single_max_bytes"] == 8 * 1024
+    assert capacity["presets"]["max_count"] == 64

--- a/tests/test_recording_expressions.py
+++ b/tests/test_recording_expressions.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+from lampgo.recordings import (
+    build_recording_actions_prompt,
+    list_recording_catalog,
+    read_recording_metadata,
+    write_recording_description,
+)
+from lampgo.skills.builtin.playback_skills import PlayRecordingSkill
+
+
+def _write_recording_csv(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "timestamp,base_yaw.pos,base_pitch.pos,elbow_pitch.pos,wrist_roll.pos,wrist_pitch.pos\n"
+        "0.0,0,0,0,0,0\n"
+        "0.1,1,2,3,4,5\n",
+        encoding="utf-8",
+    )
+
+
+def test_recording_metadata_supports_expression_preset(tmp_path: Path) -> None:
+    csv_path = tmp_path / "user" / "happy_wave.csv"
+    _write_recording_csv(csv_path)
+
+    write_recording_description(csv_path, "开心挥手，适合打招呼", expression="heart", expression_preset="happy")
+
+    metadata = read_recording_metadata(csv_path)
+    assert metadata == {
+        "description": "开心挥手，适合打招呼",
+        "expression": "heart",
+        "expression_preset": "happy",
+    }
+
+    catalog = list_recording_catalog(tmp_path)
+    assert catalog == [
+        {
+            "name": "happy_wave",
+            "source": "user",
+            "path": str(csv_path),
+            "description": "开心挥手，适合打招呼",
+            "expression": "heart",
+            "expression_preset": "happy",
+        }
+    ]
+
+    prompt = build_recording_actions_prompt(tmp_path)
+    assert "expression_preset=happy | expression=heart" in prompt
+    assert "pass it to `play_recording` so C6 eyes" in prompt
+
+
+class _FakeMotion:
+    def __init__(self) -> None:
+        self.stream_calls: list[dict] = []
+        self.return_targets = []
+        self.stop_calls = 0
+
+    def stream_frames(self, frames, *, fps: int, playback_mode: str):
+        self.stream_calls.append({"frames": frames, "fps": fps, "playback_mode": playback_mode})
+        done = threading.Event()
+        done.set()
+        return done
+
+    def move_to(self, target):
+        self.return_targets.append(target)
+        done = threading.Event()
+        done.set()
+        return done
+
+    def stop_immediate(self) -> None:
+        self.stop_calls += 1
+
+
+class _FakeLed:
+    is_connected = True
+
+    def __init__(self) -> None:
+        self.preset_calls: list[tuple[str, dict]] = []
+        self.mode_calls: list[str] = []
+        self.stop_calls = 0
+
+    def play_expression(self, expression_id: str, **overrides):
+        self.preset_calls.append((expression_id, overrides))
+        return True, {"preset_id": expression_id}
+
+    def set_mode(self, expression: str) -> bool:
+        self.mode_calls.append(expression)
+        return True
+
+    def stop_expression(self) -> bool:
+        self.stop_calls += 1
+        return True
+
+
+def test_play_recording_uses_expression_preset_before_legacy_led(tmp_path: Path) -> None:
+    _write_recording_csv(tmp_path / "wave.csv")
+    motion = _FakeMotion()
+    led = _FakeLed()
+    skill = PlayRecordingSkill(tmp_path)
+
+    result = asyncio.run(
+        skill.execute(
+            SimpleNamespace(motion=motion, led=led),
+            name="wave",
+            expression="heart",
+            expression_preset="happy",
+            playback_mode="cleaned",
+        )
+    )
+
+    assert result.status == "ok"
+    assert result.data["expression_preset"] == "happy"
+    assert result.data["expression"] == "heart"
+    assert led.preset_calls == [("happy", {"playback": "loop"})]
+    assert led.stop_calls == 1
+    assert led.mode_calls == []
+    assert motion.stream_calls[0]["playback_mode"] == "cleaned"
+    assert motion.return_targets
+
+
+def test_play_recording_keeps_legacy_led_expression(tmp_path: Path) -> None:
+    _write_recording_csv(tmp_path / "wave.csv")
+    motion = _FakeMotion()
+    led = _FakeLed()
+    skill = PlayRecordingSkill(tmp_path)
+
+    result = asyncio.run(
+        skill.execute(
+            SimpleNamespace(motion=motion, led=led),
+            name="wave",
+            expression="heart",
+            playback_mode="cleaned",
+        )
+    )
+
+    assert result.status == "ok"
+    assert result.data["expression_preset"] is None
+    assert led.preset_calls == []
+    assert led.stop_calls == 0
+    assert led.mode_calls == ["heart"]
+
+
+def test_play_recording_cancel_stops_motion_and_looping_expression(tmp_path: Path) -> None:
+    motion = _FakeMotion()
+    led = _FakeLed()
+    skill = PlayRecordingSkill(tmp_path)
+    skill._motion = motion
+    skill._expression_controller = led
+
+    asyncio.run(skill.cancel())
+
+    assert motion.stop_calls == 1
+    assert led.stop_calls == 1
+    assert skill._expression_controller is None


### PR DESCRIPTION
## What changed
- Add reusable eye clips, LED effects, and expression presets to the LampGo backend.
- Let recorded actions bind an eye + LED preset from the console.
- Loop bound expressions for the full motion and stop them on completion, timeout, or cancellation.
- Add the CODEX LED effect and update AL03 calibration.

## Why
Recorded actions previously sent a one-shot expression, so eyes and LED could return to their defaults while a longer motion was still running.

## Validation
- `uv run pytest -q tests/test_recording_expressions.py tests/test_expression_library.py tests/test_motion_skills.py`
- 15 passed
- Verified an AL03 recorded action sends `playback=loop` and stops the expression after the return-to-safe phase.