### PR TITLE
Add user-authored LED expression library

### DIFF
--- a/docs/guides/expression-authoring.md
+++ b/docs/guides/expression-authoring.md
@@ -3,28 +3,67 @@
 LampGo expressions are reusable compositions, not a single animation file:
 
 - `EyeClip` is a 320x172 C6 LCD asset containing eyes only.
-- `LedEffect` is an S3 program for a mouth, symbol, direction, or accent.
+- `LedEffect` is either an immutable firmware effect or a safe color pixel clip
+  uploaded to the S3 for a mouth, symbol, direction, or accent.
 - `ExpressionPreset` references one optional eye and one optional LED effect.
 
 At least one channel must be present. The two channels start at `t=0` and use
-the same 0-1 phase over a default three-second duration. Micro-expressions play
-once unless the caller explicitly selects `loop`.
+the same 0-1 phase over a default three-second duration. Expressions loop by
+default and keep looping for the full action; callers must explicitly request
+`once` when they want a one-shot micro-expression.
 
 ## Design Rules
 
 1. Keep the C6 image black except for the eyes. Do not draw a mouth, product
    shell, LED board, text, or status UI into an eye sprite.
-2. Use the 51x9 LED board for mouths, arrows, hearts, symbols, and broad color
-   accents. LED effects are programs, never image sprite sheets.
-3. Reuse parameterized effects. One `arrow` effect with a `direction` parameter
-   is preferred over four copied programs.
+2. Use the front-facing 51x9 LED grid for mouths, arrows, hearts, symbols, and
+   broad color accents. Twelve corner cells are outside the physical 447-pixel
+   topology and are ignored by the compiler.
+3. User effects use LED program version 2 (`pixel_clip`): exactly 30 ticks at
+   10fps, up to 16 RGB colors including the off color, and no executable code.
 4. Use 30 eye frames at 10fps and target 3.0 seconds. The accepted range is
    8-12fps and 2.5-3.5 seconds.
 5. A transient composition may be previewed or played without being saved.
    An LLM must receive explicit user confirmation before saving a preset.
-6. Do not emit arbitrary code, unbounded loops, dynamic allocation, or custom
-   frame buffers. LED DSL version 1 only accepts `mouth`, `arrow`, `heart`, and
-   `pulse` templates.
+6. Do not emit arbitrary code, jumps, unbounded loops, or device allocations.
+   Repeated frames use `ticks`; their sum must be exactly 30. Firmware v1
+   templates remain available only for official and backward-compatible assets.
+
+## Pixel Clip Format
+
+```json
+{
+  "effect_id": "rainbow_smile",
+  "label": "Rainbow smile",
+  "role": "mouth",
+  "program": {
+    "version": 2,
+    "type": "pixel_clip",
+    "fps": 10,
+    "palette": {".": "#000000", "1": "#ff3366", "2": "#00d8ff"},
+    "roles": {"primary": "1", "secondary": "2"},
+    "frames": [{
+      "rows": [
+        "...................................................",
+        "...................................................",
+        "...................................................",
+        "...................................................",
+        "..........1111111111111111111111111111111..........",
+        "...................................................",
+        "...................................................",
+        "...................................................",
+        "..................................................."
+      ],
+      "ticks": 30
+    }]
+  }
+}
+```
+
+Palette symbols are `.123456789ABCDEF`; `.` is always off. The backend maps
+the logical grid to physical wiring, deduplicates frames, compiles LEF1, and
+rejects packages over 8KiB. `primary`, `secondary`, and `accent` palette roles
+may be recolored by a preset without copying the animation.
 
 ## Capacity Contract
 
@@ -50,7 +89,13 @@ GET /api/eyes
 GET /api/led-effects
 GET /api/expression-presets
 GET /api/device/expression-capabilities
+GET /api/expression-catalog
 ```
+
+The same catalog is atomically written to
+`~/.lampgo/expression_library/llm-catalog.json` for local agents that cannot
+call the HTTP API. It is a generated read-only projection, not a second source
+of truth.
 
 Play a saved preset:
 
@@ -72,7 +117,7 @@ POST /api/expressions/play
     "brightness": 64,
     "intensity": 0.8
   },
-  "playback": "once",
+  "playback": "loop",
   "duration_ms": 3000
 }
 ```
@@ -82,16 +127,29 @@ Save only after the user confirms:
 ```json
 POST /api/expression-presets
 {
-  "preset_id": "dizzy_right",
-  "label": "Dizzy right",
+  "name": "Dizzy right",
   "eye_clip_id": "dizzy_eyes",
   "led_effect_id": "arrow",
   "led_params": {"direction":"right","color":"#00ff88"},
-  "playback": "once",
+  "playback": "loop",
   "duration_ms": 3000,
   "confirmed": true
 }
 ```
+
+The backend generates a stable `preset_id` when it is omitted. Renaming a
+preset changes its display name, not the stable ids referenced by recordings.
+
+Create and upload a user LED effect through the backend:
+
+```text
+POST /api/led-effects
+POST /api/led-effects/{effect_id}/sync
+```
+
+Playback automatically compares the installed S3 SHA and performs the small
+LEF1 upload when the selected user effect is missing or stale. Official effects
+remain in firmware and cannot be overwritten or deleted.
 
 The legacy `dizzy` cache is exposed without copying binary data as
 `dizzy_eyes + dizzy_mouth -> dizzy preset`. Existing `clip_id=dizzy` callers

--- a/docs/schemas/expression-preset.schema.json
+++ b/docs/schemas/expression-preset.schema.json
@@ -4,19 +4,26 @@
   "title": "LampGo Expression Preset",
   "type": "object",
   "additionalProperties": false,
-  "required": ["preset_id", "playback", "duration_ms"],
+  "required": ["confirmed"],
   "anyOf": [
-    {"required": ["eye_clip_id"]},
-    {"required": ["led_effect_id"]}
+    {
+      "required": ["eye_clip_id"],
+      "properties": {"eye_clip_id": {"type": "string", "minLength": 1}}
+    },
+    {
+      "required": ["led_effect_id"],
+      "properties": {"led_effect_id": {"type": "string", "minLength": 1}}
+    }
   ],
   "properties": {
     "preset_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]{0,31}$"},
+    "name": {"type": "string", "minLength": 1, "maxLength": 64},
     "label": {"type": "string", "maxLength": 64},
     "description": {"type": "string", "maxLength": 240},
     "eye_clip_id": {"type": ["string", "null"]},
     "led_effect_id": {"type": ["string", "null"]},
     "led_params": {"type": "object"},
-    "playback": {"enum": ["once", "loop"]},
+    "playback": {"enum": ["once", "loop"], "default": "loop"},
     "duration_ms": {"type": "integer", "minimum": 2500, "maximum": 3500},
     "confirmed": {"const": true}
   }

--- a/docs/schemas/led-effect.schema.json
+++ b/docs/schemas/led-effect.schema.json
@@ -4,31 +4,69 @@
   "title": "LampGo LED Effect",
   "type": "object",
   "additionalProperties": false,
-  "required": ["effect_id", "role", "program"],
+  "required": ["effect_id", "label", "role", "program"],
   "properties": {
     "effect_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]{0,31}$"},
-    "label": {"type": "string", "maxLength": 64},
+    "label": {"type": "string", "minLength": 1, "maxLength": 64},
     "role": {"enum": ["mouth", "symbol", "direction", "accent"]},
     "program": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["version", "template"],
-      "properties": {
-        "version": {"const": 1},
-        "template": {"enum": ["mouth", "arrow", "heart", "pulse"]},
-        "variant": {"enum": ["smile", "open", "flat", "dizzy"]},
-        "defaults": {
+      "oneOf": [
+        {
+          "title": "User pixel clip",
           "type": "object",
           "additionalProperties": false,
+          "required": ["version", "type", "fps", "palette", "frames"],
           "properties": {
-            "color": {"type": "string", "pattern": "^#[0-9a-fA-F]{6}$"},
-            "secondary_color": {"type": "string", "pattern": "^#[0-9a-fA-F]{6}$"},
-            "brightness": {"type": "integer", "minimum": 1, "maximum": 96},
-            "intensity": {"type": "number", "minimum": 0.1, "maximum": 1.0},
-            "direction": {"enum": ["left", "right", "up", "down"]}
+            "version": {"const": 2},
+            "type": {"const": "pixel_clip"},
+            "fps": {"const": 10},
+            "palette": {
+              "type": "object",
+              "minProperties": 1,
+              "maxProperties": 16,
+              "propertyNames": {"pattern": "^[.1-9A-F]$"},
+              "additionalProperties": {"type": "string", "pattern": "^#[0-9a-fA-F]{6}$"}
+            },
+            "roles": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "primary": {"type": "string"},
+                "secondary": {"type": "string"},
+                "accent": {"type": "string"}
+              }
+            },
+            "frames": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 30,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["rows", "ticks"],
+                "properties": {
+                  "rows": {
+                    "type": "array",
+                    "minItems": 9,
+                    "maxItems": 9,
+                    "items": {"type": "string", "minLength": 51, "maxLength": 51}
+                  },
+                  "ticks": {"type": "integer", "minimum": 1, "maximum": 30}
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Legacy safe template",
+          "type": "object",
+          "required": ["version", "template"],
+          "properties": {
+            "version": {"const": 1},
+            "template": {"enum": ["mouth", "arrow", "heart", "pulse", "codex"]}
           }
         }
-      }
+      ]
     }
   }
 }

--- a/lampgo/core/led.py
+++ b/lampgo/core/led.py
@@ -227,14 +227,14 @@ class LEDController:
             "eye_clip_id": composition.get("eye_storage_clip_id"),
             "led_effect_id": composition.get("led_effect_id"),
             "led_params": composition.get("led_params") or {},
-            "playback": composition.get("playback") or "once",
+            "playback": composition.get("playback") or "loop",
             "duration_ms": int(composition.get("duration_ms") or 3000),
         }
         if composition.get("preset_id"):
             payload["preset_id"] = composition["preset_id"]
         if effect.get("mode") is not None:
             payload["led_mode"] = int(effect["mode"])
-        if isinstance(effect.get("program"), dict):
+        if isinstance(effect.get("program"), dict) and effect["program"].get("type") != "pixel_clip":
             payload["led_program"] = effect["program"]
         return self._send_remote_path("/device/expressions/play", payload, reason="expression_play"), composition
 

--- a/lampgo/expression_library.py
+++ b/lampgo/expression_library.py
@@ -9,12 +9,23 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
+import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from lampgo import personastore
 from lampgo.core.led import led_expression_catalog
 from lampgo.expression_clips import list_expression_clips, load_expression_clip
+from lampgo.led_effects import (
+    LED_EFFECT_BUDGET_BYTES,
+    MAX_CUSTOM_LED_EFFECTS,
+    MAX_LED_EFFECT_BYTES,
+    LedEffectError,
+    list_pixel_led_effects,
+    save_pixel_led_effect,
+)
 
 MAX_EYES_CURRENT = 5
 MAX_EYE_BYTES = 256 * 1024
@@ -22,9 +33,6 @@ C6_INSTALLED_BUDGET_BYTES = 896 * 1024
 C6_RESERVED_BYTES = 256 * 1024
 C6_STAGING_BYTES = 256 * 1024
 
-MAX_CUSTOM_LED_EFFECTS = 24
-MAX_LED_EFFECT_BYTES = 8 * 1024
-LED_EFFECT_BUDGET_BYTES = 192 * 1024
 MAX_PRESETS = 64
 MAX_PRESET_BYTES = 1024
 PRESET_BUDGET_BYTES = 64 * 1024
@@ -163,7 +171,9 @@ def set_eye_default_led(eye_clip_id: str, led_effect_id: str | None) -> dict[str
     manifest["default_led_effect_id"] = normalized_effect
     path = personastore.lampgo_home() / "expression_clips" / storage_id / "manifest.json"
     _atomic_write_json(path, manifest)
-    return load_eye(eye_clip_id)
+    eye = load_eye(eye_clip_id)
+    refresh_llm_expression_catalog()
+    return eye
 
 
 def _builtin_role(name: str) -> str:
@@ -309,7 +319,7 @@ def _validate_program(raw: Any) -> dict[str, Any]:
 
 
 def list_led_effects() -> list[dict[str, Any]]:
-    custom = _read_json_objects(_led_effect_dir())
+    custom = [*_read_json_objects(_led_effect_dir()), *list_pixel_led_effects()]
     by_id = {str(item["effect_id"]): item for item in _virtual_effects()}
     for item in custom:
         effect_id = str(item.get("effect_id") or "")
@@ -335,8 +345,36 @@ def save_led_effect(raw: dict[str, Any]) -> dict[str, Any]:
     role = str(raw.get("role") or "accent").strip().lower()
     if role not in ALLOWED_ROLES:
         raise ExpressionLibraryError(f"role must be one of: {', '.join(sorted(ALLOWED_ROLES))}")
-    label = str(raw.get("label") or effect_id).strip()[:64]
-    program = _validate_program(raw.get("program"))
+    label = str(raw.get("label") or effect_id).strip()[:64] or effect_id
+    legacy_effects = _read_json_objects(_led_effect_dir())
+    pixel_effects = list_pixel_led_effects()
+    legacy_other = [item for item in legacy_effects if str(item.get("effect_id") or "") != effect_id]
+    pixel_other = [item for item in pixel_effects if str(item.get("effect_id") or "") != effect_id]
+    current_exists = len(legacy_other) != len(legacy_effects) or len(pixel_other) != len(pixel_effects)
+    if not current_exists and len(legacy_other) + len(pixel_other) >= MAX_CUSTOM_LED_EFFECTS:
+        raise ExpressionLibraryError(f"maximum custom LED effects reached: {MAX_CUSTOM_LED_EFFECTS}")
+    used_without_current = sum(len(_encoded_json(item)) for item in legacy_other) + sum(
+        int((item.get("package") or {}).get("bytes") or 0) for item in pixel_other
+    )
+    raw_program = raw.get("program")
+    if isinstance(raw_program, dict) and int(raw_program.get("version") or 0) == 2:
+        try:
+            item = save_pixel_led_effect(
+                raw,
+                effect_id=effect_id,
+                label=label,
+                role=role,
+                external_count=len(legacy_other),
+                external_used_bytes=sum(len(_encoded_json(item)) for item in legacy_other),
+            )
+        except LedEffectError as exc:
+            raise ExpressionLibraryError(str(exc)) from exc
+        legacy_path = _led_effect_dir() / f"{effect_id}.json"
+        if legacy_path.exists():
+            legacy_path.unlink()
+        refresh_llm_expression_catalog()
+        return item
+    program = _validate_program(raw_program)
     item = {
         "effect_id": effect_id,
         "label": label,
@@ -349,18 +387,37 @@ def save_led_effect(raw: dict[str, Any]) -> dict[str, Any]:
     encoded = _encoded_json(item)
     if len(encoded) > MAX_LED_EFFECT_BYTES:
         raise ExpressionLibraryError(f"LED effect exceeds {MAX_LED_EFFECT_BYTES} byte limit")
-    directory = _led_effect_dir()
-    path = directory / f"{effect_id}.json"
-    existing = _read_json_objects(directory)
-    if not path.exists() and len(existing) >= MAX_CUSTOM_LED_EFFECTS:
-        raise ExpressionLibraryError(f"maximum custom LED effects reached: {MAX_CUSTOM_LED_EFFECTS}")
-    used_without_current = sum(
-        len(_encoded_json(item)) for item in existing if str(item.get("effect_id") or "") != effect_id
-    )
     if used_without_current + len(encoded) > LED_EFFECT_BUDGET_BYTES:
         raise ExpressionLibraryError("custom LED effect storage budget exceeded")
+    directory = _led_effect_dir()
+    path = directory / f"{effect_id}.json"
     _atomic_write_json(path, item)
+    pixel_directory = directory / effect_id
+    if pixel_directory.is_dir():
+        shutil.rmtree(pixel_directory)
+    refresh_llm_expression_catalog()
     return item
+
+
+def delete_led_effect(effect_id: str) -> None:
+    effect_id = sanitize_library_id(effect_id, field="effect_id")
+    effect = load_led_effect(effect_id)
+    if effect.get("source") != "custom":
+        raise ExpressionLibraryError("official LED effects cannot be deleted")
+    used_by = [
+        str(item.get("label") or item.get("preset_id"))
+        for item in _stored_presets()
+        if item.get("led_effect_id") == effect_id
+    ]
+    if used_by:
+        raise ExpressionLibraryError(f"LED effect is used by presets: {', '.join(used_by)}")
+    legacy_path = _led_effect_dir() / f"{effect_id}.json"
+    if legacy_path.exists():
+        legacy_path.unlink()
+    directory = _led_effect_dir() / effect_id
+    if directory.is_dir():
+        shutil.rmtree(directory)
+    refresh_llm_expression_catalog()
 
 
 def _normalize_led_params(raw: Any, effect: dict[str, Any] | None) -> dict[str, Any]:
@@ -373,6 +430,8 @@ def _normalize_led_params(raw: Any, effect: dict[str, Any] | None) -> dict[str, 
         params["color"] = _normalize_color(raw["color"], field="led_params.color")
     if "secondary_color" in raw:
         params["secondary_color"] = _normalize_color(raw["secondary_color"], field="led_params.secondary_color")
+    if "accent_color" in raw:
+        params["accent_color"] = _normalize_color(raw["accent_color"], field="led_params.accent_color")
     if "brightness" in raw:
         brightness = int(raw["brightness"])
         if not 1 <= brightness <= 96:
@@ -388,7 +447,7 @@ def _normalize_led_params(raw: Any, effect: dict[str, Any] | None) -> dict[str, 
         if direction not in ALLOWED_DIRECTIONS:
             raise ExpressionLibraryError("led_params.direction is invalid")
         params["direction"] = direction
-    allowed = {"color", "secondary_color", "brightness", "intensity", "direction"}
+    allowed = {"color", "secondary_color", "accent_color", "brightness", "intensity", "direction"}
     unknown = sorted(set(raw) - allowed)
     if unknown:
         raise ExpressionLibraryError(f"unsupported led_params: {', '.join(unknown)}")
@@ -413,7 +472,7 @@ def _virtual_dizzy_preset() -> dict[str, Any] | None:
         "eye_clip_id": "dizzy_eyes",
         "led_effect_id": "dizzy_mouth",
         "led_params": {},
-        "playback": "once",
+        "playback": "loop",
         "duration_ms": 3000,
         "source": "migration",
     }
@@ -442,29 +501,33 @@ def load_expression_preset(preset_id: str) -> dict[str, Any]:
 def save_expression_preset(raw: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(raw, dict):
         raise ExpressionLibraryError("preset must be an object")
-    preset_id = sanitize_library_id(str(raw.get("preset_id") or ""), field="preset_id")
+    requested_id = str(raw.get("preset_id") or "").strip().lower()
+    preset_id = sanitize_library_id(requested_id or f"usr_{uuid.uuid4().hex[:12]}", field="preset_id")
+    if preset_id == "dizzy" and _virtual_dizzy_preset():
+        raise ExpressionLibraryError("migration expression presets cannot be overwritten")
     eye_id = str(raw.get("eye_clip_id") or "").strip().lower() or None
     led_id = str(raw.get("led_effect_id") or "").strip().lower() or None
     if not eye_id and not led_id:
         raise ExpressionLibraryError("preset requires an eye_clip_id or led_effect_id")
     eye = load_eye(eye_id) if eye_id else None
     effect = load_led_effect(led_id) if led_id else None
-    playback = str(raw.get("playback") or "once").strip().lower()
+    playback = str(raw.get("playback") or "loop").strip().lower()
     if playback not in ALLOWED_PLAYBACK:
         raise ExpressionLibraryError("playback must be once or loop")
     duration_ms = int(raw.get("duration_ms") or (eye or {}).get("duration_ms") or 3000)
     if not 2500 <= duration_ms <= 3500:
         raise ExpressionLibraryError("duration_ms must be 2500-3500")
+    label = str(raw.get("name") or raw.get("label") or preset_id).strip()[:64] or preset_id
     item = {
         "preset_id": preset_id,
-        "label": str(raw.get("label") or preset_id).strip()[:64],
+        "label": label,
         "description": str(raw.get("description") or "").strip()[:240],
         "eye_clip_id": eye_id,
         "led_effect_id": led_id,
         "led_params": _normalize_led_params(raw.get("led_params"), effect),
         "playback": playback,
         "duration_ms": duration_ms,
-        "source": str(raw.get("source") or "user").strip()[:32],
+        "source": "user",
     }
     encoded = _encoded_json(item)
     if len(encoded) > MAX_PRESET_BYTES:
@@ -480,7 +543,17 @@ def save_expression_preset(raw: dict[str, Any]) -> dict[str, Any]:
     if used_without_current + len(encoded) > PRESET_BUDGET_BYTES:
         raise ExpressionLibraryError("expression preset storage budget exceeded")
     _atomic_write_json(path, item)
+    refresh_llm_expression_catalog()
     return item
+
+
+def delete_expression_preset(preset_id: str) -> None:
+    preset_id = sanitize_library_id(preset_id, field="preset_id")
+    path = _preset_dir() / f"{preset_id}.json"
+    if not path.exists():
+        raise ExpressionLibraryError(f"expression preset not found: {preset_id}")
+    path.unlink()
+    refresh_llm_expression_catalog()
 
 
 def resolve_expression(raw: dict[str, Any]) -> dict[str, Any]:
@@ -519,7 +592,7 @@ def resolve_expression(raw: dict[str, Any]) -> dict[str, Any]:
 
     merged_params = dict((preset or {}).get("led_params") or {})
     merged_params.update(raw.get("led_params") or {})
-    playback = str(raw.get("playback") or (preset or {}).get("playback") or "once").strip().lower()
+    playback = str(raw.get("playback") or (preset or {}).get("playback") or "loop").strip().lower()
     if playback not in ALLOWED_PLAYBACK:
         raise ExpressionLibraryError("playback must be once or loop")
     duration_ms = int(
@@ -542,10 +615,14 @@ def resolve_expression(raw: dict[str, Any]) -> dict[str, Any]:
 
 def expression_capabilities() -> dict[str, Any]:
     eyes = list_eyes()
-    custom_effects = [item for item in _read_json_objects(_led_effect_dir())]
+    legacy_effects = [item for item in _read_json_objects(_led_effect_dir())]
+    pixel_effects = list_pixel_led_effects()
+    custom_effects = [*legacy_effects, *pixel_effects]
     presets = _stored_presets()
     eye_used = sum(int((item.get("lcd") or {}).get("bytes") or 0) for item in eyes)
-    led_used = sum(len(_encoded_json(item)) for item in custom_effects)
+    led_used = sum(len(_encoded_json(item)) for item in legacy_effects) + sum(
+        int((item.get("package") or {}).get("bytes") or 0) for item in pixel_effects
+    )
     preset_used = sum(len(_encoded_json(item)) for item in presets)
     return {
         "eyes": {
@@ -589,6 +666,33 @@ def build_expression_prompt() -> str:
     )
 
 
+def expression_catalog_snapshot() -> dict[str, Any]:
+    """Return the machine-readable expression catalog shared with LLM clients."""
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "eyes": list_eyes(),
+        "led_effects": list_led_effects(),
+        "expression_presets": list_expression_presets(),
+        "capacity": expression_capabilities(),
+    }
+
+
+def refresh_llm_expression_catalog() -> Path:
+    """Atomically refresh the derived, read-only catalog for external LLMs."""
+    path = expression_library_root() / "llm-catalog.json"
+    revision = 1
+    if path.exists():
+        try:
+            revision = max(1, int(json.loads(path.read_text(encoding="utf-8")).get("revision") or 0) + 1)
+        except Exception:
+            revision = 1
+    snapshot = expression_catalog_snapshot()
+    snapshot["revision"] = revision
+    _atomic_write_json(path, snapshot)
+    return path
+
+
 def expression_schemas() -> dict[str, Any]:
     return {
         "eye_clip": {
@@ -609,7 +713,23 @@ def expression_schemas() -> dict[str, Any]:
                 "role": {"enum": sorted(ALLOWED_ROLES)},
                 "program": {
                     "type": "object",
-                    "properties": {"version": {"const": 1}, "template": {"enum": sorted(ALLOWED_TEMPLATES)}},
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "version": {"const": 1},
+                                "template": {"enum": sorted(ALLOWED_TEMPLATES)},
+                            }
+                        },
+                        {
+                            "properties": {
+                                "version": {"const": 2},
+                                "type": {"const": "pixel_clip"},
+                                "fps": {"const": 10},
+                                "palette": {"type": "object", "maxProperties": 16},
+                                "frames": {"type": "array", "minItems": 1, "maxItems": 30},
+                            }
+                        },
+                    ],
                 },
             },
         },
@@ -620,7 +740,7 @@ def expression_schemas() -> dict[str, Any]:
                 "preset_id": {"type": "string", "pattern": _SAFE_ID_RE.pattern},
                 "eye_clip_id": {"type": ["string", "null"]},
                 "led_effect_id": {"type": ["string", "null"]},
-                "playback": {"enum": sorted(ALLOWED_PLAYBACK)},
+                "playback": {"enum": sorted(ALLOWED_PLAYBACK), "default": "loop"},
                 "duration_ms": {"type": "integer", "minimum": 2500, "maximum": 3500},
             },
         },

--- a/lampgo/led_effects.py
+++ b/lampgo/led_effects.py
@@ -1,0 +1,389 @@
+"""Safe, deterministic LED pixel-clip assets for the S3 matrix.
+
+The authoring format is JSON so browsers and LLMs can create it.  Devices only
+receive the compact LEF1 binary compiled here; no user-authored code is ever
+executed on the S3.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import struct
+import zlib
+from pathlib import Path
+from typing import Any
+
+from lampgo import personastore
+
+LED_WIDTH = 51
+LED_HEIGHT = 9
+LED_PIXEL_COUNT = 447
+LED_FPS = 10
+LED_TICK_COUNT = 30
+LED_FRAME_BYTES = (LED_PIXEL_COUNT + 1) // 2
+LED_PALETTE_SIZE = 16
+MAX_LED_EFFECT_BYTES = 8 * 1024
+MAX_CUSTOM_LED_EFFECTS = 24
+LED_EFFECT_BUDGET_BYTES = 192 * 1024
+
+LEF_MAGIC = b"LEF1"
+LEF_VERSION = 1
+LEF_HEADER = struct.Struct("<4s8BHHII8B")
+LEF_HEADER_BYTES = LEF_HEADER.size
+
+_ROW_LENGTHS = (47, 49, 51, 51, 51, 51, 51, 49, 47)
+_ROW_STARTS = (0, 47, 96, 147, 198, 249, 300, 351, 400)
+_ROLE_NAMES = ("primary", "secondary", "accent")
+_SAFE_SYMBOLS = frozenset(".123456789ABCDEF")
+_SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+
+
+class LedEffectError(ValueError):
+    """Raised when an LED authoring document or package is invalid."""
+
+
+def _safe_effect_id(effect_id: str) -> str:
+    normalized = str(effect_id or "").strip().lower()
+    if not _SAFE_ID_RE.fullmatch(normalized):
+        raise LedEffectError("effect_id must be 1-32 lowercase letters, numbers, dash, or underscore")
+    return normalized
+
+
+def led_effect_root() -> Path:
+    path = personastore.lampgo_home() / "expression_library" / "led_effects"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _encoded_json(value: dict[str, Any]) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _atomic_write(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_bytes(payload)
+    temporary.replace(path)
+
+
+def _normalize_hex_color(value: Any, *, field: str) -> str:
+    color = str(value or "").strip().lower()
+    if len(color) != 7 or color[0] != "#":
+        raise LedEffectError(f"{field} must be a #RRGGBB color")
+    try:
+        int(color[1:], 16)
+    except ValueError as exc:
+        raise LedEffectError(f"{field} must be a #RRGGBB color") from exc
+    return color
+
+
+def _rgb_bytes(color: str) -> bytes:
+    return bytes((int(color[1:3], 16), int(color[3:5], 16), int(color[5:7], 16)))
+
+
+def _physical_index(row: int, col: int) -> int | None:
+    """Map the editor's front-facing 51x9 grid to the wired pixel order."""
+    wired_row = LED_HEIGHT - 1 - row
+    wired_col = LED_WIDTH - 1 - col
+    row_length = _ROW_LENGTHS[wired_row]
+    left_pad = (LED_WIDTH - row_length) // 2
+    local_col = wired_col - left_pad
+    if local_col < 0 or local_col >= row_length:
+        return None
+    return _ROW_STARTS[wired_row] + local_col
+
+
+def _pack_frame(rows: list[str], symbol_indexes: dict[str, int]) -> bytes:
+    if len(rows) != LED_HEIGHT:
+        raise LedEffectError(f"each LED frame must contain {LED_HEIGHT} rows")
+    pixels = bytearray(LED_PIXEL_COUNT)
+    for row_index, raw_row in enumerate(rows):
+        row = str(raw_row)
+        if len(row) != LED_WIDTH:
+            raise LedEffectError(f"frame row {row_index} must contain exactly {LED_WIDTH} cells")
+        for col_index, symbol in enumerate(row):
+            if symbol not in symbol_indexes:
+                raise LedEffectError(f"frame uses undefined palette symbol: {symbol}")
+            physical = _physical_index(row_index, col_index)
+            if physical is not None:
+                pixels[physical] = symbol_indexes[symbol]
+    packed = bytearray(LED_FRAME_BYTES)
+    for index, palette_index in enumerate(pixels):
+        if index & 1:
+            packed[index // 2] |= palette_index & 0x0F
+        else:
+            packed[index // 2] = (palette_index & 0x0F) << 4
+    return bytes(packed)
+
+
+def compile_led_program(program: dict[str, Any]) -> tuple[dict[str, Any], bytes]:
+    """Validate a v2 pixel-clip program and compile it to LEF1."""
+    if not isinstance(program, dict):
+        raise LedEffectError("program must be an object")
+    if int(program.get("version") or 0) != 2 or program.get("type") != "pixel_clip":
+        raise LedEffectError("program must use version=2 and type=pixel_clip")
+    if int(program.get("fps") or LED_FPS) != LED_FPS:
+        raise LedEffectError(f"pixel clips must use {LED_FPS} fps")
+
+    raw_palette = program.get("palette")
+    if not isinstance(raw_palette, dict) or not raw_palette:
+        raise LedEffectError("program.palette must be a non-empty object")
+    palette: dict[str, str] = {".": "#000000"}
+    for raw_symbol, raw_color in raw_palette.items():
+        symbol = str(raw_symbol)
+        if symbol not in _SAFE_SYMBOLS:
+            raise LedEffectError("palette symbols must be one of .123456789ABCDEF")
+        color = _normalize_hex_color(raw_color, field=f"program.palette.{symbol}")
+        if symbol == "." and color != "#000000":
+            raise LedEffectError("palette symbol . is reserved for #000000")
+        palette[symbol] = color
+    ordered_symbols = ["."] + sorted(symbol for symbol in palette if symbol != ".")
+    if len(ordered_symbols) > LED_PALETTE_SIZE:
+        raise LedEffectError(f"pixel clips support at most {LED_PALETTE_SIZE} colors")
+    symbol_indexes = {symbol: index for index, symbol in enumerate(ordered_symbols)}
+
+    raw_roles = program.get("roles") or {}
+    if not isinstance(raw_roles, dict):
+        raise LedEffectError("program.roles must be an object")
+    roles: dict[str, str] = {}
+    role_indexes = [255, 255, 255]
+    for role_index, role in enumerate(_ROLE_NAMES):
+        if role not in raw_roles:
+            continue
+        symbol = str(raw_roles[role])
+        if symbol == "." or symbol not in symbol_indexes:
+            raise LedEffectError(f"program.roles.{role} must reference a visible palette symbol")
+        roles[role] = symbol
+        role_indexes[role_index] = symbol_indexes[symbol]
+    unknown_roles = sorted(set(raw_roles) - set(_ROLE_NAMES))
+    if unknown_roles:
+        raise LedEffectError(f"unsupported palette roles: {', '.join(unknown_roles)}")
+
+    raw_frames = program.get("frames")
+    if not isinstance(raw_frames, list) or not raw_frames:
+        raise LedEffectError("program.frames must be a non-empty array")
+    unique_frames: list[bytes] = []
+    frame_indexes: dict[bytes, int] = {}
+    timeline: list[int] = []
+    normalized_frames: list[dict[str, Any]] = []
+    for frame_number, raw_frame in enumerate(raw_frames):
+        if not isinstance(raw_frame, dict):
+            raise LedEffectError(f"program.frames[{frame_number}] must be an object")
+        raw_rows = raw_frame.get("rows")
+        if not isinstance(raw_rows, list):
+            raise LedEffectError(f"program.frames[{frame_number}].rows must be an array")
+        rows = [str(row) for row in raw_rows]
+        ticks = int(raw_frame.get("ticks") or 1)
+        if ticks < 1 or ticks > LED_TICK_COUNT:
+            raise LedEffectError(f"program.frames[{frame_number}].ticks must be 1-{LED_TICK_COUNT}")
+        packed = _pack_frame(rows, symbol_indexes)
+        unique_index = frame_indexes.get(packed)
+        if unique_index is None:
+            unique_index = len(unique_frames)
+            if unique_index >= LED_TICK_COUNT:
+                raise LedEffectError(f"pixel clips support at most {LED_TICK_COUNT} unique frames")
+            frame_indexes[packed] = unique_index
+            unique_frames.append(packed)
+        timeline.extend([unique_index] * ticks)
+        normalized_frames.append({"rows": rows, "ticks": ticks})
+    if len(timeline) != LED_TICK_COUNT:
+        raise LedEffectError(f"pixel clip timeline must contain exactly {LED_TICK_COUNT} ticks")
+
+    palette_bytes = b"".join(_rgb_bytes(palette[symbol]) for symbol in ordered_symbols)
+    payload = palette_bytes + bytes(timeline) + b"".join(unique_frames)
+    crc32 = zlib.crc32(payload) & 0xFFFFFFFF
+    header = LEF_HEADER.pack(
+        LEF_MAGIC,
+        LEF_VERSION,
+        LED_WIDTH,
+        LED_HEIGHT,
+        LED_FPS,
+        LED_TICK_COUNT,
+        len(unique_frames),
+        len(ordered_symbols),
+        0,
+        LED_FRAME_BYTES,
+        LEF_HEADER_BYTES,
+        len(payload),
+        crc32,
+        *role_indexes,
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+    package = header + payload
+    if len(package) > MAX_LED_EFFECT_BYTES:
+        raise LedEffectError(f"compiled LED effect exceeds {MAX_LED_EFFECT_BYTES} byte limit")
+    normalized = {
+        "version": 2,
+        "type": "pixel_clip",
+        "fps": LED_FPS,
+        "palette": {symbol: palette[symbol] for symbol in ordered_symbols},
+        "roles": roles,
+        "frames": normalized_frames,
+    }
+    return normalized, package
+
+
+def inspect_led_package(package: bytes) -> dict[str, Any]:
+    """Parse and checksum a LEF1 package, primarily for tests and diagnostics."""
+    if len(package) < LEF_HEADER_BYTES:
+        raise LedEffectError("LEF1 package is truncated")
+    unpacked = LEF_HEADER.unpack_from(package)
+    magic = unpacked[0]
+    version, width, height, fps, ticks, frames, colors, flags = unpacked[1:9]
+    frame_bytes, header_bytes, payload_bytes, expected_crc = unpacked[9:13]
+    primary, secondary, accent = unpacked[13:16]
+    if magic != LEF_MAGIC or version != LEF_VERSION:
+        raise LedEffectError("unsupported LED package")
+    if (width, height, fps, ticks, frame_bytes, header_bytes) != (
+        LED_WIDTH,
+        LED_HEIGHT,
+        LED_FPS,
+        LED_TICK_COUNT,
+        LED_FRAME_BYTES,
+        LEF_HEADER_BYTES,
+    ):
+        raise LedEffectError("LED package topology does not match this product")
+    if not 1 <= frames <= LED_TICK_COUNT or not 1 <= colors <= LED_PALETTE_SIZE or flags != 0:
+        raise LedEffectError("LED package header is invalid")
+    payload = package[header_bytes:]
+    if len(payload) != payload_bytes or zlib.crc32(payload) & 0xFFFFFFFF != expected_crc:
+        raise LedEffectError("LED package checksum mismatch")
+    expected_payload = colors * 3 + ticks + frames * frame_bytes
+    if payload_bytes != expected_payload:
+        raise LedEffectError("LED package payload size is invalid")
+    return {
+        "width": width,
+        "height": height,
+        "fps": fps,
+        "frame_count": ticks,
+        "unique_frame_count": frames,
+        "palette_count": colors,
+        "bytes": len(package),
+        "crc32": f"{expected_crc:08x}",
+        "sha256": hashlib.sha256(package).hexdigest(),
+        "roles": {"primary": primary, "secondary": secondary, "accent": accent},
+    }
+
+
+def list_pixel_led_effects() -> list[dict[str, Any]]:
+    effects: list[dict[str, Any]] = []
+    for path in sorted(led_effect_root().glob("*/manifest.json")):
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if isinstance(value, dict) and value.get("effect_id"):
+            effects.append(value)
+    return effects
+
+
+def load_pixel_led_effect(effect_id: str) -> dict[str, Any]:
+    effect_id = _safe_effect_id(effect_id)
+    path = led_effect_root() / effect_id / "manifest.json"
+    if not path.is_file():
+        raise LedEffectError(f"pixel LED effect not found: {effect_id}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise LedEffectError(f"pixel LED effect manifest is invalid: {effect_id}")
+    return value
+
+
+def load_pixel_led_source(effect_id: str) -> dict[str, Any]:
+    effect_id = _safe_effect_id(effect_id)
+    path = led_effect_root() / effect_id / "source.json"
+    if not path.is_file():
+        raise LedEffectError(f"pixel LED effect source not found: {effect_id}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise LedEffectError(f"pixel LED effect source is invalid: {effect_id}")
+    return value
+
+
+def load_pixel_led_package(effect_id: str) -> bytes:
+    effect_id = _safe_effect_id(effect_id)
+    path = led_effect_root() / effect_id / "effect.lef"
+    if not path.is_file():
+        raise LedEffectError(f"pixel LED effect package not found: {effect_id}")
+    payload = path.read_bytes()
+    inspect_led_package(payload)
+    return payload
+
+
+def save_pixel_led_effect(
+    raw: dict[str, Any],
+    *,
+    effect_id: str,
+    label: str,
+    role: str,
+    external_count: int = 0,
+    external_used_bytes: int = 0,
+) -> dict[str, Any]:
+    effect_id = _safe_effect_id(effect_id)
+    normalized_program, package = compile_led_program(raw.get("program"))
+    existing = list_pixel_led_effects()
+    current = next((item for item in existing if item.get("effect_id") == effect_id), None)
+    if current is None and len(existing) + external_count >= MAX_CUSTOM_LED_EFFECTS:
+        raise LedEffectError(f"maximum custom LED effects reached: {MAX_CUSTOM_LED_EFFECTS}")
+    used_without_current = external_used_bytes + sum(
+        int((item.get("package") or {}).get("bytes") or 0)
+        for item in existing
+        if item.get("effect_id") != effect_id
+    )
+    if used_without_current + len(package) > LED_EFFECT_BUDGET_BYTES:
+        raise LedEffectError("custom LED effect storage budget exceeded")
+    package_info = inspect_led_package(package)
+    source = {
+        "effect_id": effect_id,
+        "label": label,
+        "role": role,
+        "program": normalized_program,
+    }
+    manifest = {
+        "effect_id": effect_id,
+        "label": label,
+        "role": role,
+        "source": "custom",
+        "kind": "pixel_clip",
+        "animated": True,
+        "default_playback": "loop",
+        "duration_ms": 3000,
+        "program": {
+            "version": 2,
+            "type": "pixel_clip",
+            "fps": LED_FPS,
+            "frame_count": LED_TICK_COUNT,
+            "palette": normalized_program["palette"],
+            "roles": normalized_program["roles"],
+        },
+        "package": {**package_info, "filename": "effect.lef"},
+        "sync": dict((current or {}).get("sync") or {"status": "not_synced"}),
+        "parameter_schema": {
+            "color": {"type": "string", "format": "color"},
+            "secondary_color": {"type": "string", "format": "color"},
+            "accent_color": {"type": "string", "format": "color"},
+            "brightness": {"type": "integer", "minimum": 1, "maximum": 96, "default": 64},
+            "intensity": {"type": "number", "minimum": 0.1, "maximum": 1.0, "default": 1.0},
+        },
+    }
+    if current and (current.get("package") or {}).get("sha256") != package_info["sha256"]:
+        manifest["sync"] = {"status": "not_synced"}
+    directory = led_effect_root() / effect_id
+    directory.mkdir(parents=True, exist_ok=True)
+    _atomic_write(directory / "source.json", _encoded_json(source))
+    _atomic_write(directory / "effect.lef", package)
+    _atomic_write(directory / "manifest.json", _encoded_json(manifest))
+    return manifest
+
+
+def update_pixel_led_sync(effect_id: str, *, status: str, device: Any = None) -> dict[str, Any]:
+    effect_id = _safe_effect_id(effect_id)
+    manifest = load_pixel_led_effect(effect_id)
+    manifest["sync"] = {"status": status, "device": device}
+    _atomic_write(led_effect_root() / effect_id / "manifest.json", _encoded_json(manifest))
+    return manifest

--- a/lampgo/web/gateway.py
+++ b/lampgo/web/gateway.py
@@ -41,17 +41,28 @@ from lampgo.expression_clips import (
 )
 from lampgo.expression_library import (
     ExpressionLibraryError,
+    delete_expression_preset,
+    delete_led_effect,
     expression_capabilities,
+    expression_catalog_snapshot,
     expression_schemas,
     eye_source_path,
     eye_storage_id,
     list_expression_presets,
     list_eyes,
     list_led_effects,
+    refresh_llm_expression_catalog,
     resolve_expression,
     save_expression_preset,
     save_led_effect,
     set_eye_default_led,
+)
+from lampgo.led_effects import (
+    LedEffectError,
+    load_pixel_led_effect,
+    load_pixel_led_package,
+    load_pixel_led_source,
+    update_pixel_led_sync,
 )
 from lampgo.perception.camera import CameraCapture
 from lampgo.recordings import (
@@ -202,6 +213,10 @@ class WebGateway:
         self._livekit_active_rooms: dict[str, dict[str, Any]] = {}
         self._rate_limit_buckets: dict[str, list[float]] = {}
         self.app = self._build_app()
+        try:
+            refresh_llm_expression_catalog()
+        except Exception:
+            logger.exception("expression_catalog.initial_refresh_failed")
 
     def _build_app(self) -> Starlette:
         routes = [
@@ -224,7 +239,16 @@ class WebGateway:
             Route("/api/eyes/{eye_id:str}/source", self.api_eye_source, methods=["GET"]),
             Route("/api/eyes/{eye_id:str}/sync", self.api_eye_sync, methods=["POST"]),
             Route("/api/led-effects", self.api_led_effects, methods=["GET", "POST"]),
+            Route("/api/led-effects/{effect_id:str}", self.api_led_effect_item, methods=["PUT", "DELETE"]),
+            Route("/api/led-effects/{effect_id:str}/source", self.api_led_effect_source, methods=["GET"]),
+            Route("/api/led-effects/{effect_id:str}/sync", self.api_led_effect_sync, methods=["POST"]),
             Route("/api/expression-presets", self.api_expression_presets, methods=["GET", "POST"]),
+            Route(
+                "/api/expression-presets/{preset_id:str}",
+                self.api_expression_preset_item,
+                methods=["PUT", "DELETE"],
+            ),
+            Route("/api/expression-catalog", self.api_expression_catalog, methods=["GET"]),
             Route("/api/expressions/preview", self.api_expression_preview, methods=["POST"]),
             Route("/api/expressions/play", self.api_expression_play, methods=["POST"]),
             Route("/api/expressions/stop", self.api_expression_stop, methods=["POST"]),
@@ -902,6 +926,86 @@ class WebGateway:
             return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
         return JSONResponse({"ok": True, "result": {"led_effect": effect}})
 
+    async def api_led_effect_item(self, request: Request) -> JSONResponse:
+        effect_id = str(request.path_params.get("effect_id") or "")
+        try:
+            if request.method == "DELETE":
+                delete_led_effect(effect_id)
+                device: Any = None
+                if self.server.esp32:
+                    payload = self.server.esp32.with_owner_auth(
+                        {"led_effect_id": effect_id}, reason="led_effect_delete"
+                    )
+                    status, device, _ = await self.server.esp32.proxy_post("/device/led-effects/delete", payload)
+                    if status >= 400 and isinstance(device, dict) and device.get("error") != "LED effect not found":
+                        logger.warning("led_effect.device_delete_failed", effect_id=effect_id, response=device)
+                return JSONResponse({"ok": True, "result": {"effect_id": effect_id, "device": device}})
+            body = await request.json()
+            if not isinstance(body, dict):
+                raise ExpressionLibraryError("LED effect body must be an object")
+            body["effect_id"] = effect_id
+            effect = save_led_effect(body)
+            return JSONResponse({"ok": True, "result": {"led_effect": effect}})
+        except (ExpressionLibraryError, LedEffectError, ValueError, TypeError) as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+
+    async def api_led_effect_source(self, request: Request) -> JSONResponse:
+        effect_id = str(request.path_params.get("effect_id") or "")
+        try:
+            source = load_pixel_led_source(effect_id)
+        except (LedEffectError, ValueError, TypeError) as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=404)
+        return JSONResponse({"ok": True, "result": {"led_effect": source}})
+
+    async def _sync_led_effect_to_device(
+        self,
+        effect_id: str,
+        *,
+        force: bool = False,
+    ) -> tuple[int, Any, dict[str, Any]]:
+        if not self.server.esp32:
+            return 503, {"ok": False, "error": "no_device"}, {}
+        manifest = load_pixel_led_effect(effect_id)
+        package = load_pixel_led_package(effect_id)
+        package_info = manifest.get("package") or {}
+        expected_sha = str(package_info.get("sha256") or "")
+        if not force:
+            status, body, _ = await self.server.esp32.proxy_get("/device/led-effects")
+            installed = ((body.get("result") or {}).get("led_effects") or []) if isinstance(body, dict) else []
+            if status < 400 and any(
+                item.get("effect_id") == effect_id and item.get("sha256") == expected_sha for item in installed
+            ):
+                manifest = update_pixel_led_sync(effect_id, status="synced", device=body.get("result"))
+                refresh_llm_expression_catalog()
+                return 200, {"ok": True, "action": "already_synced"}, manifest
+        query = self.server.esp32.with_owner_auth(
+            {"effect_id": effect_id, "bytes": len(package), "sha256": expected_sha},
+            reason="led_effect_sync",
+        )
+        status, body, _ = await self.server.esp32.proxy_post_bytes(
+            "/device/led-effects/upload", package, params=query
+        )
+        ok = status < 400 and isinstance(body, dict) and body.get("ok") is not False
+        manifest = update_pixel_led_sync(
+            effect_id,
+            status="synced" if ok else "sync_failed",
+            device=body,
+        )
+        refresh_llm_expression_catalog()
+        return status, body, manifest
+
+    async def api_led_effect_sync(self, request: Request) -> JSONResponse:
+        effect_id = str(request.path_params.get("effect_id") or "")
+        try:
+            status, device, manifest = await self._sync_led_effect_to_device(effect_id, force=True)
+        except (LedEffectError, ExpressionLibraryError, ValueError, TypeError) as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+        ok = status < 400 and not (isinstance(device, dict) and device.get("ok") is False)
+        return JSONResponse(
+            {"ok": ok, "result": {"led_effect": manifest, "device": device}},
+            status_code=status,
+        )
+
     async def api_expression_presets(self, request: Request) -> JSONResponse:
         if request.method == "GET":
             return JSONResponse(
@@ -924,6 +1028,26 @@ class WebGateway:
         except (ExpressionLibraryError, ValueError, TypeError) as exc:
             return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
         return JSONResponse({"ok": True, "result": {"preset": preset}})
+
+    async def api_expression_preset_item(self, request: Request) -> JSONResponse:
+        preset_id = str(request.path_params.get("preset_id") or "")
+        try:
+            if request.method == "DELETE":
+                delete_expression_preset(preset_id)
+                return JSONResponse({"ok": True, "result": {"preset_id": preset_id}})
+            body = await request.json()
+            if not isinstance(body, dict):
+                raise ExpressionLibraryError("preset body must be an object")
+            if body.get("confirmed") is not True:
+                raise ExpressionLibraryError("saving a preset requires confirmed=true")
+            body["preset_id"] = preset_id
+            preset = save_expression_preset(body)
+            return JSONResponse({"ok": True, "result": {"preset": preset}})
+        except (ExpressionLibraryError, ValueError, TypeError) as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+
+    async def api_expression_catalog(self, request: Request) -> JSONResponse:
+        return JSONResponse({"ok": True, "result": expression_catalog_snapshot()})
 
     async def api_expression_preview(self, request: Request) -> JSONResponse:
         try:
@@ -951,18 +1075,25 @@ class WebGateway:
         if not self.server.esp32:
             return 503, {"ok": False, "error": "no_device"}
         effect = composition.get("led_effect") or {}
+        if effect.get("kind") == "pixel_clip" and composition.get("led_effect_id"):
+            sync_status, sync_body, _ = await self._sync_led_effect_to_device(
+                str(composition["led_effect_id"])
+            )
+            if sync_status >= 400 or (isinstance(sync_body, dict) and sync_body.get("ok") is False):
+                return sync_status, sync_body
         payload: dict[str, Any] = {
             "eye_clip_id": composition.get("eye_storage_clip_id"),
             "led_effect_id": composition.get("led_effect_id"),
             "led_params": composition.get("led_params") or {},
-            "playback": composition.get("playback") or "once",
+            "playback": composition.get("playback") or "loop",
             "duration_ms": int(composition.get("duration_ms") or 3000),
         }
         if composition.get("preset_id"):
             payload["preset_id"] = composition["preset_id"]
         if effect.get("mode") is not None:
             payload["led_mode"] = int(effect["mode"])
-        if isinstance(effect.get("program"), dict):
+        program = effect.get("program")
+        if isinstance(program, dict) and program.get("type") != "pixel_clip":
             payload["led_program"] = effect["program"]
         payload = self.server.esp32.with_owner_auth(payload, reason="expression_play")
         status, response, _ = await self.server.esp32.proxy_post("/device/expressions/play", payload)
@@ -1007,6 +1138,7 @@ class WebGateway:
         try:
             payload = await self._read_expression_clip_upload(request)
             manifest = create_expression_clip(**payload)
+            refresh_llm_expression_catalog()
         except ExpressionClipError as exc:
             return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
         except Exception as exc:

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -41,11 +41,20 @@
   const ledEffectId = document.getElementById("led-effect-id");
   const ledEffectLabel = document.getElementById("led-effect-label");
   const ledEffectRole = document.getElementById("led-effect-role");
-  const ledEffectTemplate = document.getElementById("led-effect-template");
-  const ledEffectColor = document.getElementById("led-effect-color");
+  const ledEditorCanvas = document.getElementById("led-editor-canvas");
+  const ledFrameTimeline = document.getElementById("led-frame-timeline");
+  const ledEditorPalette = document.getElementById("led-editor-palette");
+  const ledEditorStatus = document.getElementById("led-editor-status");
+  const btnLedCopyFrame = document.getElementById("btn-led-copy-frame");
+  const btnLedPasteFrame = document.getElementById("btn-led-paste-frame");
+  const btnLedMirrorFrame = document.getElementById("btn-led-mirror-frame");
+  const btnLedClearFrame = document.getElementById("btn-led-clear-frame");
+  const btnLedEditorPreview = document.getElementById("btn-led-editor-preview");
+  const btnLedEditorSave = document.getElementById("btn-led-editor-save");
   const composerEye = document.getElementById("composer-eye");
   const composerLed = document.getElementById("composer-led");
   const composerColor = document.getElementById("composer-color");
+  const composerColorOverride = document.getElementById("composer-color-override");
   const composerBrightness = document.getElementById("composer-brightness");
   const composerIntensity = document.getElementById("composer-intensity");
   const composerPresetId = document.getElementById("composer-preset-id");
@@ -225,9 +234,27 @@
   let expressionLedEffects = [];
   let expressionPresets = [];
   let expressionDirection = "right";
-  let expressionPlayback = "once";
+  let expressionPlayback = "loop";
   let expressionPreviewTimer = null;
   let expressionPreviewImage = null;
+  const ledEffectSourceCache = new Map();
+  const LED_EDITOR_WIDTH = 51;
+  const LED_EDITOR_HEIGHT = 9;
+  const LED_EDITOR_FRAMES = 30;
+  const LED_EDITOR_SYMBOLS = "123456789ABCDEF".split("");
+  const ledEditorColors = [
+    "#ff3b6b", "#00d8ff", "#ffd43b", "#44e38b", "#ffffff",
+    "#8b5cf6", "#ff8a34", "#2878ff", "#f472b6", "#9aff32",
+    "#00a6a6", "#ff1744", "#c8d0d8", "#7a4cff", "#f7ff00",
+  ];
+  let ledEditorFrames = Array.from({ length: LED_EDITOR_FRAMES }, () => new Uint8Array(LED_EDITOR_WIDTH * LED_EDITOR_HEIGHT));
+  let ledEditorFrame = 0;
+  let ledEditorSymbol = 1;
+  let ledEditorTool = "paint";
+  let ledEditorDrawing = false;
+  let ledEditorPreviewTimer = null;
+  let ledEditorClipboard = null;
+  let ledEditorClipboardSource = -1;
   let latestStatusData = {};
 
   function expressionMeta(name) {
@@ -3394,6 +3421,294 @@
     return `${(bytes / 1024).toFixed(bytes >= 102400 ? 0 : 1)} KiB`;
   }
 
+  function ledEditorCellExists(row, col) {
+    const lengths = [47, 49, 51, 51, 51, 51, 51, 49, 47];
+    const pad = Math.floor((LED_EDITOR_WIDTH - lengths[row]) / 2);
+    return col >= pad && col < pad + lengths[row];
+  }
+
+  function drawLedEditor() {
+    if (!ledEditorCanvas) return;
+    const context = ledEditorCanvas.getContext("2d");
+    const cellWidth = ledEditorCanvas.width / LED_EDITOR_WIDTH;
+    const cellHeight = ledEditorCanvas.height / LED_EDITOR_HEIGHT;
+    context.fillStyle = "#15191c";
+    context.fillRect(0, 0, ledEditorCanvas.width, ledEditorCanvas.height);
+    const frame = ledEditorFrames[ledEditorFrame];
+    for (let row = 0; row < LED_EDITOR_HEIGHT; row += 1) {
+      for (let col = 0; col < LED_EDITOR_WIDTH; col += 1) {
+        const exists = ledEditorCellExists(row, col);
+        const value = frame[row * LED_EDITOR_WIDTH + col];
+        const x = col * cellWidth + cellWidth / 2;
+        const y = row * cellHeight + cellHeight / 2;
+        const radius = Math.max(2, Math.min(cellWidth, cellHeight) * 0.31);
+        context.beginPath();
+        context.arc(x, y, radius, 0, Math.PI * 2);
+        context.fillStyle = !exists ? "#15191c" : value ? ledEditorColors[value - 1] : "#343a3f";
+        context.shadowColor = value ? ledEditorColors[value - 1] : "transparent";
+        context.shadowBlur = value ? 8 : 0;
+        context.fill();
+      }
+    }
+    context.shadowBlur = 0;
+    if (ledEditorStatus) {
+      const copied = ledEditorClipboard ? ` · 已复制第 ${ledEditorClipboardSource + 1} 帧` : "";
+      ledEditorStatus.textContent = `第 ${ledEditorFrame + 1} / ${LED_EDITOR_FRAMES} 帧 · 10 FPS${copied}`;
+    }
+    if (btnLedPasteFrame) {
+      btnLedPasteFrame.disabled = !ledEditorClipboard;
+      btnLedPasteFrame.title = ledEditorClipboard
+        ? `将第 ${ledEditorClipboardSource + 1} 帧粘贴到当前帧`
+        : "请先复制一个帧";
+    }
+    if (ledFrameTimeline) {
+      Array.from(ledFrameTimeline.children).forEach((button, index) => {
+        button.classList.toggle("is-active", index === ledEditorFrame);
+        button.classList.toggle("has-pixels", ledEditorFrames[index].some((value) => value > 0));
+      });
+    }
+  }
+
+  function setLedEditorFrame(index) {
+    ledEditorFrame = Math.max(0, Math.min(LED_EDITOR_FRAMES - 1, Number(index) || 0));
+    drawLedEditor();
+  }
+
+  function renderLedEditorTimeline() {
+    if (!ledFrameTimeline) return;
+    ledFrameTimeline.innerHTML = "";
+    for (let index = 0; index < LED_EDITOR_FRAMES; index += 1) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = String(index + 1);
+      button.title = `第 ${index + 1} 帧`;
+      button.addEventListener("click", () => setLedEditorFrame(index));
+      ledFrameTimeline.appendChild(button);
+    }
+  }
+
+  function renderLedEditorPalette() {
+    if (!ledEditorPalette) return;
+    ledEditorPalette.innerHTML = "";
+    LED_EDITOR_SYMBOLS.forEach((symbol, index) => {
+      const wrapper = document.createElement("label");
+      wrapper.className = "led-palette-swatch";
+      wrapper.title = `${symbol} 色`;
+      const radio = document.createElement("input");
+      radio.type = "radio";
+      radio.name = "led-editor-palette-choice";
+      radio.checked = index === ledEditorSymbol - 1;
+      radio.addEventListener("change", () => { ledEditorSymbol = index + 1; });
+      const color = document.createElement("input");
+      color.type = "color";
+      color.value = ledEditorColors[index];
+      color.addEventListener("input", () => {
+        ledEditorColors[index] = color.value;
+        ledEditorSymbol = index + 1;
+        radio.checked = true;
+        drawLedEditor();
+      });
+      wrapper.append(radio, color);
+      ledEditorPalette.appendChild(wrapper);
+    });
+  }
+
+  function ledEditorPointerCell(event) {
+    const rect = ledEditorCanvas.getBoundingClientRect();
+    const col = Math.floor(((event.clientX - rect.left) / rect.width) * LED_EDITOR_WIDTH);
+    const row = Math.floor(((event.clientY - rect.top) / rect.height) * LED_EDITOR_HEIGHT);
+    if (row < 0 || row >= LED_EDITOR_HEIGHT || col < 0 || col >= LED_EDITOR_WIDTH || !ledEditorCellExists(row, col)) {
+      return null;
+    }
+    return { row, col };
+  }
+
+  function paintLedEditorCell(event) {
+    const cell = ledEditorPointerCell(event);
+    if (!cell) return;
+    ledEditorFrames[ledEditorFrame][cell.row * LED_EDITOR_WIDTH + cell.col] =
+      ledEditorTool === "erase" ? 0 : ledEditorSymbol;
+    drawLedEditor();
+  }
+
+  function mirrorLedEditorFrame() {
+    const source = ledEditorFrames[ledEditorFrame];
+    const mirrored = new Uint8Array(source.length);
+    for (let row = 0; row < LED_EDITOR_HEIGHT; row += 1) {
+      for (let col = 0; col < LED_EDITOR_WIDTH; col += 1) {
+        mirrored[row * LED_EDITOR_WIDTH + col] = source[row * LED_EDITOR_WIDTH + (LED_EDITOR_WIDTH - 1 - col)];
+      }
+    }
+    ledEditorFrames[ledEditorFrame] = mirrored;
+    drawLedEditor();
+  }
+
+  function copyLedEditorFrame() {
+    ledEditorClipboard = new Uint8Array(ledEditorFrames[ledEditorFrame]);
+    ledEditorClipboardSource = ledEditorFrame;
+    drawLedEditor();
+  }
+
+  function pasteLedEditorFrame() {
+    if (!ledEditorClipboard) return;
+    ledEditorFrames[ledEditorFrame] = new Uint8Array(ledEditorClipboard);
+    drawLedEditor();
+  }
+
+  function toggleLedEditorPreview() {
+    if (ledEditorPreviewTimer) {
+      clearInterval(ledEditorPreviewTimer);
+      ledEditorPreviewTimer = null;
+      if (btnLedEditorPreview) btnLedEditorPreview.textContent = "播放预览";
+      return;
+    }
+    if (btnLedEditorPreview) btnLedEditorPreview.textContent = "暂停预览";
+    ledEditorPreviewTimer = setInterval(() => setLedEditorFrame((ledEditorFrame + 1) % LED_EDITOR_FRAMES), 100);
+  }
+
+  function ledEditorRows(frame) {
+    const rows = [];
+    for (let row = 0; row < LED_EDITOR_HEIGHT; row += 1) {
+      let line = "";
+      for (let col = 0; col < LED_EDITOR_WIDTH; col += 1) {
+        const value = ledEditorCellExists(row, col) ? frame[row * LED_EDITOR_WIDTH + col] : 0;
+        line += value ? LED_EDITOR_SYMBOLS[value - 1] : ".";
+      }
+      rows.push(line);
+    }
+    return rows;
+  }
+
+  function currentLedEditorDocument() {
+    const compressed = [];
+    ledEditorFrames.forEach((frame) => {
+      const rows = ledEditorRows(frame);
+      const previous = compressed[compressed.length - 1];
+      if (previous && previous.rows.every((row, index) => row === rows[index])) previous.ticks += 1;
+      else compressed.push({ rows, ticks: 1 });
+    });
+    const palette = { ".": "#000000" };
+    LED_EDITOR_SYMBOLS.forEach((symbol, index) => { palette[symbol] = ledEditorColors[index]; });
+    return {
+      effect_id: String((ledEffectId && ledEffectId.value) || "").trim(),
+      label: String((ledEffectLabel && ledEffectLabel.value) || "").trim(),
+      role: (ledEffectRole && ledEffectRole.value) || "mouth",
+      program: {
+        version: 2,
+        type: "pixel_clip",
+        fps: 10,
+        palette,
+        roles: { primary: "1", secondary: "2", accent: "3" },
+        frames: compressed,
+      },
+    };
+  }
+
+  async function saveLedEditor({ sync = false } = {}) {
+    const body = currentLedEditorDocument();
+    if (!body.effect_id || !body.label) {
+      window.alert("请填写效果 ID 和显示名称");
+      return;
+    }
+    try {
+      if (ledEditorStatus) ledEditorStatus.textContent = "正在编译…";
+      const saved = await fetchJson("/api/led-effects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (sync) {
+        if (ledEditorStatus) ledEditorStatus.textContent = "正在同步 S3…";
+        await fetchJson(`/api/led-effects/${encodeURIComponent(body.effect_id)}/sync`, { method: "POST" });
+      }
+      ledEffectSourceCache.set(body.effect_id, body);
+      const packageInfo = (saved.led_effect && saved.led_effect.package) || {};
+      if (ledEditorStatus) {
+        ledEditorStatus.textContent = `${sync ? "已同步" : "已保存"} · ${formatBytes(packageInfo.bytes)}`;
+      }
+      await refreshExpressionStudio();
+    } catch (error) {
+      if (ledEditorStatus) ledEditorStatus.textContent = "保存失败";
+      window.alert(`LED 动画保存失败：${error.message || error}`);
+    }
+  }
+
+  function loadLedEditorDocument(source) {
+    const program = source && source.program;
+    if (!program || program.type !== "pixel_clip") return;
+    if (ledEffectId) ledEffectId.value = source.effect_id || "";
+    if (ledEffectLabel) ledEffectLabel.value = source.label || "";
+    if (ledEffectRole) ledEffectRole.value = source.role || "mouth";
+    LED_EDITOR_SYMBOLS.forEach((symbol, index) => {
+      if (program.palette && program.palette[symbol]) ledEditorColors[index] = program.palette[symbol];
+    });
+    const expanded = [];
+    (program.frames || []).forEach((frame) => {
+      for (let tick = 0; tick < Number(frame.ticks || 1); tick += 1) expanded.push(frame.rows || []);
+    });
+    ledEditorFrames = Array.from({ length: LED_EDITOR_FRAMES }, (_, frameIndex) => {
+      const values = new Uint8Array(LED_EDITOR_WIDTH * LED_EDITOR_HEIGHT);
+      const rows = expanded[frameIndex] || [];
+      rows.forEach((row, rowIndex) => {
+        Array.from(String(row)).forEach((symbol, colIndex) => {
+          values[rowIndex * LED_EDITOR_WIDTH + colIndex] = Math.max(0, LED_EDITOR_SYMBOLS.indexOf(symbol) + 1);
+        });
+      });
+      return values;
+    });
+    renderLedEditorPalette();
+    setLedEditorFrame(0);
+  }
+
+  async function editLedEffect(effectId) {
+    try {
+      const result = await fetchJson(`/api/led-effects/${encodeURIComponent(effectId)}/source`);
+      const source = result.led_effect;
+      ledEffectSourceCache.set(effectId, source);
+      loadLedEditorDocument(source);
+      if (ledEditorStatus) ledEditorStatus.textContent = "已载入，可覆盖保存";
+    } catch (error) {
+      window.alert(`载入失败：${error.message || error}`);
+    }
+  }
+
+  async function syncLedEffect(effectId) {
+    try {
+      await fetchJson(`/api/led-effects/${encodeURIComponent(effectId)}/sync`, { method: "POST" });
+      await refreshExpressionStudio();
+    } catch (error) {
+      window.alert(`同步失败：${error.message || error}`);
+    }
+  }
+
+  async function deleteLedEffectFromLibrary(effect) {
+    if (!window.confirm(`确认删除用户 LED 动画「${effect.label || effect.effect_id}」？`)) return;
+    try {
+      await fetchJson(`/api/led-effects/${encodeURIComponent(effect.effect_id)}`, { method: "DELETE" });
+      ledEffectSourceCache.delete(effect.effect_id);
+      await refreshExpressionStudio();
+    } catch (error) {
+      window.alert(`删除失败：${error.message || error}`);
+    }
+  }
+
+  function initializeLedEditor() {
+    renderLedEditorTimeline();
+    renderLedEditorPalette();
+    drawLedEditor();
+    if (!ledEditorCanvas) return;
+    ledEditorCanvas.addEventListener("pointerdown", (event) => {
+      ledEditorDrawing = true;
+      ledEditorCanvas.setPointerCapture(event.pointerId);
+      paintLedEditorCell(event);
+    });
+    ledEditorCanvas.addEventListener("pointermove", (event) => {
+      if (ledEditorDrawing) paintLedEditorCell(event);
+    });
+    ledEditorCanvas.addEventListener("pointerup", () => { ledEditorDrawing = false; });
+    ledEditorCanvas.addEventListener("pointercancel", () => { ledEditorDrawing = false; });
+  }
+
   function populateExpressionComposer() {
     if (composerEye) {
       const selected = composerEye.value;
@@ -3429,7 +3744,7 @@
         eye.label || eye.eye_clip_id,
         `${eye.eye_clip_id} · ${eye.frame_count || 0} 帧 · ${eye.fps || 0} FPS · ${formatBytes(lcd.bytes)} · ${sync.status || "unsynced"}`,
         [
-          { label: "同步", run: () => syncExpressionEye(eye.eye_clip_id) },
+          { label: "同步", run: () => syncExpressionResources(eye.eye_clip_id) },
           { label: "选用", run: () => selectExpressionResource(eye.eye_clip_id, null), primary: true },
         ],
       ));
@@ -3448,6 +3763,7 @@
         [
           { label: "载入", run: () => loadExpressionPreset(preset) },
           { label: "▶", title: "播放", run: () => playExpression({ preset_id: preset.preset_id }), primary: true },
+          ...(preset.source === "user" ? [{ label: "删除", run: () => deleteExpressionPresetFromLibrary(preset) }] : []),
         ],
       ));
     });
@@ -3515,6 +3831,7 @@
       button.classList.toggle("is-active", button.dataset.playback === expressionPlayback);
     });
     const params = preset.led_params || {};
+    if (composerColorOverride) composerColorOverride.checked = Boolean(params.color);
     if (params.color && composerColor) composerColor.value = params.color;
     if (params.brightness && composerBrightness) composerBrightness.value = String(params.brightness);
     if (params.intensity && composerIntensity) composerIntensity.value = String(Math.round(params.intensity * 100));
@@ -3529,15 +3846,18 @@
   }
 
   function currentExpressionBody() {
+    const ledParams = {
+      brightness: Number((composerBrightness && composerBrightness.value) || 64),
+      intensity: Number((composerIntensity && composerIntensity.value) || 100) / 100,
+      direction: expressionDirection,
+    };
+    if (composerColorOverride && composerColorOverride.checked) {
+      ledParams.color = (composerColor && composerColor.value) || "#ffffff";
+    }
     return {
       eye_clip_id: (composerEye && composerEye.value) || null,
       led_effect_id: (composerLed && composerLed.value) || null,
-      led_params: {
-        color: (composerColor && composerColor.value) || "#ffffff",
-        brightness: Number((composerBrightness && composerBrightness.value) || 64),
-        intensity: Number((composerIntensity && composerIntensity.value) || 100) / 100,
-        direction: expressionDirection,
-      },
+      led_params: ledParams,
       playback: expressionPlayback,
       duration_ms: 3000,
     };
@@ -3588,18 +3908,56 @@
     return dx * dx + dy * dy <= 1 && dx * dx + dy * dy >= 0.42;
   }
 
+  async function loadLedPreviewSource(effect) {
+    if (!effect || effect.kind !== "pixel_clip") return null;
+    if (ledEffectSourceCache.has(effect.effect_id)) return ledEffectSourceCache.get(effect.effect_id);
+    try {
+      const result = await fetchJson(`/api/led-effects/${encodeURIComponent(effect.effect_id)}/source`);
+      ledEffectSourceCache.set(effect.effect_id, result.led_effect);
+      return result.led_effect;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function pixelClipCellColor(effect, row, col, phase) {
+    const source = ledEffectSourceCache.get(effect && effect.effect_id);
+    const program = source && source.program;
+    if (!program || program.type !== "pixel_clip") return null;
+    const targetTick = Math.min(29, Math.floor(phase * 30));
+    let elapsed = 0;
+    let rows = null;
+    for (const frame of program.frames || []) {
+      elapsed += Number(frame.ticks || 1);
+      if (targetTick < elapsed) {
+        rows = frame.rows;
+        break;
+      }
+    }
+    const symbol = rows && rows[row] ? rows[row][col] : ".";
+    if (!symbol || symbol === ".") return null;
+    const primarySymbol = program.roles && program.roles.primary;
+    if (composerColorOverride && composerColorOverride.checked && symbol === primarySymbol) {
+      return (composerColor && composerColor.value) || "#ffffff";
+    }
+    return (program.palette && program.palette[symbol]) || null;
+  }
+
   function renderLedPreview(effect, phase) {
     ensureLedPreviewCells();
     if (!expressionLedPreview) return;
     const color = (composerColor && composerColor.value) || "#ffffff";
     const intensity = Number((composerIntensity && composerIntensity.value) || 100) / 100;
+    const pixelClipReady = effect && effect.kind === "pixel_clip" && ledEffectSourceCache.has(effect.effect_id);
     Array.from(expressionLedPreview.children).forEach((cell, index) => {
       const row = Math.floor(index / 51);
       const col = index % 51;
-      const active = ledCellActive(effect, row, col, phase);
-      cell.style.background = active ? color : "#30353a";
+      const pixelColor = pixelClipReady ? pixelClipCellColor(effect, row, col, phase) : null;
+      const active = pixelClipReady ? Boolean(pixelColor) : ledCellActive(effect, row, col, phase);
+      const activeColor = pixelColor || color;
+      cell.style.background = active ? activeColor : "#30353a";
       cell.style.opacity = active ? String(0.35 + intensity * 0.65) : "1";
-      cell.style.boxShadow = active ? `0 0 5px ${color}` : "none";
+      cell.style.boxShadow = active ? `0 0 5px ${activeColor}` : "none";
     });
   }
 
@@ -3662,7 +4020,7 @@
       const composition = result.composition;
       const eye = expressionEyes.find((item) => item.eye_clip_id === composition.eye_clip_id);
       const effect = expressionLedEffects.find((item) => item.effect_id === composition.led_effect_id);
-      await loadEyePreviewImage(eye);
+      await Promise.all([loadEyePreviewImage(eye), loadLedPreviewSource(effect)]);
       if (expressionPreviewTimer) cancelAnimationFrame(expressionPreviewTimer);
       const started = Date.now();
       const tick = () => {
@@ -3707,15 +4065,20 @@
     });
   }
 
-  async function syncExpressionEye(eyeId = null) {
+  async function syncExpressionResources(eyeId = null) {
     const selected = eyeId || (composerEye && composerEye.value);
-    if (!selected) {
-      window.alert("请选择眼睛素材");
+    const selectedLed = eyeId ? "" : ((composerLed && composerLed.value) || "");
+    const effect = expressionLedEffects.find((item) => item.effect_id === selectedLed);
+    if (!selected && !(effect && effect.kind === "pixel_clip")) {
+      window.alert("所选资源无需同步，或尚未选择可同步资源");
       return;
     }
     if (expressionPreviewStatus) expressionPreviewStatus.textContent = "同步中…";
     try {
-      await fetchJson(`/api/eyes/${encodeURIComponent(selected)}/sync`, { method: "POST" });
+      if (selected) await fetchJson(`/api/eyes/${encodeURIComponent(selected)}/sync`, { method: "POST" });
+      if (effect && effect.kind === "pixel_clip") {
+        await fetchJson(`/api/led-effects/${encodeURIComponent(selectedLed)}/sync`, { method: "POST" });
+      }
       if (expressionPreviewStatus) expressionPreviewStatus.textContent = "同步完成";
       await refreshExpressionStudio();
     } catch (error) {
@@ -3755,15 +4118,16 @@
 
   async function saveExpressionPresetFromComposer() {
     const presetId = String((composerPresetId && composerPresetId.value) || "").trim();
-    if (!presetId) {
-      window.alert("请输入组合 ID");
+    const presetName = String((composerPresetLabel && composerPresetLabel.value) || "").trim();
+    if (!presetName) {
+      window.alert("请给组合取一个名称");
       return;
     }
-    if (!window.confirm(`确认保存组合「${presetId}」？`)) return;
+    if (!window.confirm(`确认暂存组合「${presetName}」？`)) return;
     try {
       const body = currentExpressionBody();
-      body.preset_id = presetId;
-      body.label = String((composerPresetLabel && composerPresetLabel.value) || presetId).trim();
+      if (presetId) body.preset_id = presetId;
+      body.name = presetName;
       body.confirmed = true;
       await fetchJson("/api/expression-presets", {
         method: "POST",
@@ -3773,6 +4137,17 @@
       await refreshExpressionStudio();
     } catch (error) {
       window.alert(`保存失败：${error.message || error}`);
+    }
+  }
+
+  async function deleteExpressionPresetFromLibrary(preset) {
+    if (!window.confirm(`确认删除组合「${preset.label || preset.preset_id}」？`)) return;
+    try {
+      await fetchJson(`/api/expression-presets/${encodeURIComponent(preset.preset_id)}`, { method: "DELETE" });
+      if (composerPresetId && composerPresetId.value === preset.preset_id) composerPresetId.value = "";
+      await refreshExpressionStudio();
+    } catch (error) {
+      window.alert(`删除失败：${error.message || error}`);
     }
   }
 
@@ -3836,6 +4211,10 @@
       if (meta && meta.mode !== null && meta.mode !== undefined) metaParts.push(`m${meta.mode}`);
       if (meta) metaParts.push(meta.animated ? "动态" : "静态");
       if (effect) metaParts.push(effect.source || "builtin");
+      if (effect && effect.kind === "pixel_clip") {
+        metaParts.push(formatBytes((effect.package || {}).bytes));
+        metaParts.push((effect.sync || {}).status || "not_synced");
+      }
       metaParts.push("眼睛保持当前");
       const card = makeSkillCard({
         title: labelCn,
@@ -3843,6 +4222,26 @@
         tooltip: `单独播放 LED 效果：${labelCn}（${name}），眼睛保持当前画面`,
         onClick: () => { void playLedEffect(name); },
       });
+      if (effect && effect.kind === "pixel_clip" && effect.source === "custom") {
+        const actions = document.createElement("div");
+        actions.className = "expression-card-actions";
+        [
+          ["编辑", () => editLedEffect(effect.effect_id)],
+          ["同步", () => syncLedEffect(effect.effect_id)],
+          ["删除", () => deleteLedEffectFromLibrary(effect)],
+        ].forEach(([label, run]) => {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.textContent = label;
+          button.addEventListener("click", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void run();
+          });
+          actions.appendChild(button);
+        });
+        card.appendChild(actions);
+      }
       expressionGrid.appendChild(card);
     });
     if (!filtered.length) renderEmptyCell(expressionGrid, q ? `无匹配「${q}」的灯光表情` : "暂无灯光表情");
@@ -3881,7 +4280,7 @@
     });
   });
   if (btnExpressionPreview) btnExpressionPreview.addEventListener("click", () => { void previewExpression(); });
-  if (btnExpressionSync) btnExpressionSync.addEventListener("click", () => { void syncExpressionEye(); });
+  if (btnExpressionSync) btnExpressionSync.addEventListener("click", () => { void syncExpressionResources(); });
   if (btnExpressionSetDefault) {
     btnExpressionSetDefault.addEventListener("click", () => { void setDefaultLedForEye(); });
   }
@@ -3890,31 +4289,29 @@
   if (btnExpressionSave) btnExpressionSave.addEventListener("click", () => { void saveExpressionPresetFromComposer(); });
   if (btnEyeUpload) btnEyeUpload.addEventListener("click", () => { void uploadExpressionEye(); });
   if (ledEffectForm) {
-    ledEffectForm.addEventListener("submit", async (event) => {
+    ledEffectForm.addEventListener("submit", (event) => {
       event.preventDefault();
-      try {
-        await fetchJson("/api/led-effects", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            effect_id: String(ledEffectId.value || "").trim(),
-            label: String(ledEffectLabel.value || "").trim(),
-            role: ledEffectRole.value,
-            program: {
-              version: 1,
-              template: ledEffectTemplate.value,
-              defaults: { color: ledEffectColor.value, intensity: 1.0 },
-            },
-          }),
-        });
-        ledEffectForm.reset();
-        ledEffectColor.value = "#ffffff";
-        await refreshExpressionStudio();
-      } catch (error) {
-        window.alert(`保存失败：${error.message || error}`);
-      }
+      void saveLedEditor({ sync: true });
     });
   }
+  document.querySelectorAll("[data-led-tool]").forEach((button) => {
+    button.addEventListener("click", () => {
+      ledEditorTool = button.dataset.ledTool === "erase" ? "erase" : "paint";
+      document.querySelectorAll("[data-led-tool]").forEach((item) => {
+        item.classList.toggle("is-active", item === button);
+      });
+    });
+  });
+  if (btnLedCopyFrame) btnLedCopyFrame.addEventListener("click", copyLedEditorFrame);
+  if (btnLedPasteFrame) btnLedPasteFrame.addEventListener("click", pasteLedEditorFrame);
+  if (btnLedMirrorFrame) btnLedMirrorFrame.addEventListener("click", mirrorLedEditorFrame);
+  if (btnLedClearFrame) btnLedClearFrame.addEventListener("click", () => {
+    ledEditorFrames[ledEditorFrame].fill(0);
+    drawLedEditor();
+  });
+  if (btnLedEditorPreview) btnLedEditorPreview.addEventListener("click", toggleLedEditorPreview);
+  if (btnLedEditorSave) btnLedEditorSave.addEventListener("click", () => { void saveLedEditor({ sync: false }); });
+  initializeLedEditor();
   ensureLedPreviewCells();
   void refreshSkillsAndRecordings();
   void refreshExpressionStudio();

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>YareLampGo 控制台</title>
   <link rel="icon" href="/%E5%8F%B0%E7%81%AF%E8%99%BE%E5%A4%B4%E5%83%8F.jpeg">
-  <link rel="stylesheet" href="/style.css?v=recording-expression-presets-20260710">
+  <link rel="stylesheet" href="/style.css?v=led-pixel-clips-20260715">
   <link rel="stylesheet" href="/setup.css?v=secret-inputs-20260602">
 </head>
 <body>
@@ -373,23 +373,40 @@
                 <button type="button" class="skill-search-clear" data-target="expression-search" aria-label="清空搜索">×</button>
               </div>
               <div id="expression-grid" class="skill-card-grid"></div>
-              <form id="led-effect-form" class="expression-editor-row">
-                <input id="led-effect-id" type="text" maxlength="32" placeholder="效果 ID" required />
-                <input id="led-effect-label" type="text" maxlength="64" placeholder="显示名称" required />
-                <select id="led-effect-role" aria-label="LED 用途">
-                  <option value="mouth">嘴巴</option>
-                  <option value="symbol">符号</option>
-                  <option value="direction">方向</option>
-                  <option value="accent">气氛</option>
-                </select>
-                <select id="led-effect-template" aria-label="程序模板">
-                  <option value="mouth">嘴巴</option>
-                  <option value="arrow">箭头</option>
-                  <option value="heart">爱心</option>
-                  <option value="pulse">脉冲</option>
-                </select>
-                <input id="led-effect-color" type="color" value="#ffffff" title="默认颜色" />
-                <button class="primary-button" type="submit">保存 LED 效果</button>
+              <form id="led-effect-form" class="led-animation-editor">
+                <div class="led-editor-head">
+                  <input id="led-effect-id" type="text" maxlength="32" placeholder="效果 ID" required />
+                  <input id="led-effect-label" type="text" maxlength="64" placeholder="显示名称" required />
+                  <select id="led-effect-role" aria-label="LED 用途">
+                    <option value="mouth">嘴巴</option>
+                    <option value="symbol">符号</option>
+                    <option value="direction">方向</option>
+                    <option value="accent">气氛</option>
+                  </select>
+                  <span id="led-editor-status" class="led-editor-status">新动画</span>
+                </div>
+                <div class="led-editor-workspace">
+                  <div class="led-editor-stage">
+                    <canvas id="led-editor-canvas" width="1020" height="180" aria-label="51 乘 9 LED 动画画布"></canvas>
+                    <div id="led-frame-timeline" class="led-frame-timeline" aria-label="30 帧时间轴"></div>
+                  </div>
+                  <div class="led-editor-tools">
+                    <div id="led-editor-palette" class="led-editor-palette" aria-label="LED 调色板"></div>
+                    <div class="led-editor-tool-row" role="group" aria-label="绘制工具">
+                      <button type="button" class="is-active" data-led-tool="paint" title="画笔">画笔</button>
+                      <button type="button" data-led-tool="erase" title="橡皮">橡皮</button>
+                      <button id="btn-led-copy-frame" type="button" title="复制当前帧，不修改画布">复制</button>
+                      <button id="btn-led-paste-frame" type="button" title="粘贴复制的帧到当前选中的时间轴帧" disabled>粘贴</button>
+                      <button id="btn-led-mirror-frame" type="button" title="左右镜像">镜像</button>
+                      <button id="btn-led-clear-frame" type="button" title="清空当前帧">清空</button>
+                    </div>
+                    <div class="led-editor-command-row">
+                      <button id="btn-led-editor-preview" class="ghost-button" type="button">播放预览</button>
+                      <button id="btn-led-editor-save" class="ghost-button" type="button">仅保存</button>
+                      <button id="btn-led-editor-sync" class="primary-button" type="submit">保存并同步</button>
+                    </div>
+                  </div>
+                </div>
               </form>
             </div>
 
@@ -403,7 +420,7 @@
                 <div class="expression-controls">
                   <label>眼睛<select id="composer-eye"><option value="">无眼睛</option></select></label>
                   <label>LED<select id="composer-led"><option value="">无 LED</option></select></label>
-                  <label>颜色<input id="composer-color" type="color" value="#ffffff" /></label>
+                  <label class="expression-color-control"><input id="composer-color-override" type="checkbox" />覆盖主色<input id="composer-color" type="color" value="#ffffff" /></label>
                   <label>亮度<input id="composer-brightness" type="range" min="1" max="96" value="64" /></label>
                   <label>强度<input id="composer-intensity" type="range" min="10" max="100" value="100" /></label>
                   <div class="expression-direction" role="group" aria-label="方向">
@@ -413,20 +430,20 @@
                     <button type="button" class="is-active" data-direction="right" title="向右">→</button>
                   </div>
                   <div class="expression-playback" role="group" aria-label="播放方式">
-                    <button type="button" class="is-active" data-playback="once">单次</button>
-                    <button type="button" data-playback="loop">循环</button>
+                    <button type="button" data-playback="once">单次</button>
+                    <button type="button" class="is-active" data-playback="loop">循环</button>
                   </div>
                   <div class="expression-command-row">
                     <button id="btn-expression-preview" class="ghost-button" type="button" title="本地预览">▶ 预览</button>
-                    <button id="btn-expression-sync" class="ghost-button" type="button">同步眼睛</button>
+                    <button id="btn-expression-sync" class="ghost-button" type="button">同步所选资源</button>
                     <button id="btn-expression-set-default" class="ghost-button" type="button">设为默认搭配</button>
                     <button id="btn-expression-play" class="primary-button" type="button">▶ 播放</button>
                     <button id="btn-expression-stop" class="ghost-button" type="button" title="停止播放">■</button>
                   </div>
                   <div class="expression-save-row">
-                    <input id="composer-preset-id" type="text" maxlength="32" placeholder="组合 ID" />
-                    <input id="composer-preset-label" type="text" maxlength="64" placeholder="组合名称" />
-                    <button id="btn-expression-save" class="ghost-button" type="button">保存组合</button>
+                    <input id="composer-preset-id" type="hidden" />
+                    <input id="composer-preset-label" type="text" maxlength="64" placeholder="给这个组合命名" />
+                    <button id="btn-expression-save" class="ghost-button" type="button">暂存组合</button>
                   </div>
                 </div>
               </div>
@@ -1421,7 +1438,7 @@
     </div>
   </dialog>
 
-  <script src="/app.js?v=recording-expression-presets-20260710"></script>
+  <script src="/app.js?v=led-frame-clipboard-20260715"></script>
   <script type="module" src="/pet.js?v=19"></script>
   <script src="/setup.js?v=secret-inputs-20260602"></script>
 </body>

--- a/lampgo/web/static/style.css
+++ b/lampgo/web/static/style.css
@@ -764,6 +764,7 @@ button {
 /* ============= Main ============= */
 
 .main {
+  grid-column: 3;
   min-width: 0;
   min-height: 0;
   display: flex;
@@ -2614,6 +2615,155 @@ button.device-chip.is-active {
   background: #f8f9fa;
 }
 
+.led-animation-editor {
+  margin-top: 14px;
+  padding: 12px 0;
+  border-top: 1px solid #dce1e5;
+  border-bottom: 1px solid #dce1e5;
+}
+
+.led-editor-head,
+.led-editor-command-row,
+.led-editor-tool-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.led-editor-head { margin-bottom: 10px; }
+.led-editor-head input,
+.led-editor-head select {
+  min-height: 34px;
+  border: 1px solid #ccd3d8;
+  border-radius: 6px;
+  padding: 5px 9px;
+  background: #fff;
+}
+.led-editor-head input { min-width: 150px; }
+.led-editor-status {
+  margin-left: auto;
+  color: #69747c;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.led-editor-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 190px;
+  gap: 14px;
+  align-items: start;
+}
+
+.led-editor-stage { min-width: 0; }
+#led-editor-canvas {
+  display: block;
+  width: 100%;
+  aspect-ratio: 51 / 9;
+  border: 1px solid #3d454b;
+  border-radius: 6px;
+  background: #15191c;
+  cursor: crosshair;
+  touch-action: none;
+}
+
+.led-frame-timeline {
+  display: grid;
+  grid-template-columns: repeat(30, minmax(26px, 1fr));
+  gap: 2px;
+  margin-top: 7px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+.led-frame-timeline button {
+  width: 100%;
+  min-width: 26px;
+  height: 25px;
+  padding: 0;
+  border: 1px solid #d5dce0;
+  border-radius: 4px;
+  background: #f4f6f7;
+  color: #78828a;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.led-frame-timeline button.has-pixels { border-bottom-color: #00a6a6; }
+.led-frame-timeline button.is-active {
+  border-color: #176d68;
+  background: #176d68;
+  color: #fff;
+}
+
+.led-editor-tools { display: flex; flex-direction: column; gap: 10px; }
+.led-editor-palette {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+}
+.led-palette-swatch {
+  position: relative;
+  width: 30px;
+  height: 30px;
+}
+.led-palette-swatch input[type="radio"] {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+.led-palette-swatch input[type="color"] {
+  width: 30px;
+  height: 30px;
+  padding: 2px;
+  border: 2px solid transparent;
+  border-radius: 6px;
+  background: #fff;
+}
+.led-palette-swatch input[type="radio"]:checked + input[type="color"] {
+  border-color: #1a282d;
+  box-shadow: 0 0 0 2px #7dd3c7;
+}
+.led-editor-tool-row button {
+  min-height: 30px;
+  border: 1px solid #ccd3d8;
+  border-radius: 5px;
+  background: #fff;
+  color: #4f5b63;
+}
+.led-editor-tool-row button.is-active {
+  border-color: #176d68;
+  background: #e3f3f0;
+  color: #125b57;
+}
+.led-editor-command-row { align-items: stretch; }
+.led-editor-command-row button { flex: 1 1 80px; }
+
+.expression-color-control {
+  display: grid !important;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+}
+.expression-color-control input[type="checkbox"] { width: 16px; height: 16px; }
+
+.expression-card-actions {
+  display: flex;
+  gap: 4px;
+  margin-top: 8px;
+}
+.expression-card-actions button {
+  min-height: 26px;
+  padding: 3px 7px;
+  border: 1px solid #d5dce0;
+  border-radius: 5px;
+  background: #fff;
+  color: #59656d;
+  font-size: 11px;
+}
+
 .expression-toolbar input[type="text"],
 .expression-toolbar input[type="number"],
 .expression-editor-row input[type="text"],
@@ -2761,6 +2911,29 @@ button.device-chip.is-active {
   .expression-composer { grid-template-columns: 1fr; }
   .expression-toolbar input[type="file"] { width: 100%; }
   .expression-resource-list { grid-template-columns: 1fr; }
+  .led-editor-workspace { grid-template-columns: 1fr; }
+  .led-editor-tools { display: grid; grid-template-columns: minmax(160px, 1fr) minmax(180px, 1fr); }
+  .led-editor-command-row { grid-column: 1 / -1; }
+}
+
+@media (max-width: 640px) {
+  .app-shell[data-view="skills"] .pet-panel { display: none; }
+  .view[data-view="skills"] .skill-section {
+    min-width: 0;
+    padding: 12px;
+  }
+  .led-animation-editor,
+  .led-editor-workspace,
+  .led-editor-stage { min-width: 0; max-width: 100%; }
+  .led-editor-tools {
+    display: flex;
+    flex-direction: column;
+  }
+  .led-editor-head input {
+    width: 100%;
+    min-width: 0;
+  }
+  .led-editor-status { margin-left: 0; }
 }
 
 /* User-authored composed skills carry a subtle left-border tint so users

--- a/tests/test_expression_library.py
+++ b/tests/test_expression_library.py
@@ -17,6 +17,7 @@ from lampgo.expression_library import (
     save_expression_preset,
     save_led_effect,
 )
+from lampgo.led_effects import LEF_MAGIC
 from lampgo.server import LampgoServer
 from lampgo.web.gateway import WebGateway
 
@@ -58,6 +59,26 @@ def _custom_effect(effect_id: str) -> dict:
                 "template": "mouth",
                 "variant": "smile",
                 "defaults": {"color": "#ffffff", "intensity": 0.8},
+            },
+        }
+    )
+
+
+def _pixel_effect(effect_id: str) -> dict:
+    rows = ["." * 51 for _ in range(9)]
+    rows[4] = "." * 10 + "1" * 31 + "." * 10
+    return save_led_effect(
+        {
+            "effect_id": effect_id,
+            "label": "彩色嘴巴",
+            "role": "mouth",
+            "program": {
+                "version": 2,
+                "type": "pixel_clip",
+                "fps": 10,
+                "palette": {".": "#000000", "1": "#ff0088"},
+                "roles": {"primary": "1"},
+                "frames": [{"rows": rows, "ticks": 30}],
             },
         }
     )
@@ -141,7 +162,7 @@ def test_dizzy_legacy_asset_migrates_without_copy(monkeypatch, tmp_path):
     assert resolved["eye_clip_id"] == "dizzy_eyes"
     assert resolved["eye_storage_clip_id"] == "dizzy"
     assert resolved["led_effect_id"] == "dizzy_mouth"
-    assert resolved["playback"] == "once"
+    assert resolved["playback"] == "loop"
 
 
 def test_preset_api_requires_confirmation_and_transient_play_does_not_save(monkeypatch, tmp_path):
@@ -170,6 +191,10 @@ def test_preset_api_requires_confirmation_and_transient_play_does_not_save(monke
         rejected = client.post("/api/expression-presets", json={"preset_id": "focus", **composition})
         assert rejected.status_code == 400
         assert "confirmed=true" in rejected.json()["error"]
+
+        rejected_update = client.put("/api/expression-presets/focus", json=composition)
+        assert rejected_update.status_code == 400
+        assert "confirmed=true" in rejected_update.json()["error"]
 
         saved = client.post(
             "/api/expression-presets",
@@ -247,3 +272,63 @@ def test_led_dsl_and_capacity_guards(monkeypatch, tmp_path):
     assert capacity["led_effects"]["installed_custom"] == 1
     assert capacity["led_effects"]["single_max_bytes"] == 8 * 1024
     assert capacity["presets"]["max_count"] == 64
+
+
+def test_pixel_led_auto_syncs_then_plays_by_id_with_loop_default(monkeypatch, tmp_path):
+    gateway = _gateway(monkeypatch, tmp_path)
+    _pixel_effect("color_mouth")
+    uploads: list[tuple[str, bytes, dict]] = []
+    plays: list[tuple[str, dict]] = []
+
+    async def fake_proxy_get(path: str):
+        assert path == "/device/led-effects"
+        return 200, {"ok": True, "result": {"led_effects": []}}, "application/json"
+
+    async def fake_proxy_post_bytes(path: str, payload: bytes, *, params=None, content_type="application/octet-stream"):
+        uploads.append((path, payload, params or {}))
+        return 200, {"ok": True, "action": "upload"}, "application/json"
+
+    async def fake_proxy_post(path: str, payload: dict):
+        plays.append((path, payload))
+        return 200, {"ok": True}, "application/json"
+
+    monkeypatch.setattr(gateway.server.esp32, "proxy_get", fake_proxy_get)
+    monkeypatch.setattr(gateway.server.esp32, "proxy_post_bytes", fake_proxy_post_bytes)
+    monkeypatch.setattr(gateway.server.esp32, "proxy_post", fake_proxy_post)
+
+    with TestClient(gateway.app) as client:
+        response = client.post("/api/expressions/play", json={"led_effect_id": "color_mouth"})
+        catalog = client.get("/api/expression-catalog")
+
+    assert response.status_code == 200
+    assert uploads[0][0] == "/device/led-effects/upload"
+    assert uploads[0][1].startswith(LEF_MAGIC)
+    assert uploads[0][2]["effect_id"] == "color_mouth"
+    assert plays[0][0] == "/device/expressions/play"
+    assert plays[0][1]["led_effect_id"] == "color_mouth"
+    assert plays[0][1]["playback"] == "loop"
+    assert "led_program" not in plays[0][1]
+    assert catalog.status_code == 200
+    assert any(
+        item["effect_id"] == "color_mouth"
+        for item in catalog.json()["result"]["led_effects"]
+    )
+
+
+def test_preset_name_can_generate_stable_machine_id(monkeypatch, tmp_path):
+    gateway = _gateway(monkeypatch, tmp_path)
+    _pixel_effect("color_mouth")
+    with TestClient(gateway.app) as client:
+        response = client.post(
+            "/api/expression-presets",
+            json={
+                "name": "我的彩色笑脸",
+                "led_effect_id": "color_mouth",
+                "confirmed": True,
+            },
+        )
+    assert response.status_code == 200
+    preset = response.json()["result"]["preset"]
+    assert preset["preset_id"].startswith("usr_")
+    assert preset["label"] == "我的彩色笑脸"
+    assert preset["playback"] == "loop"

--- a/tests/test_led_effects.py
+++ b/tests/test_led_effects.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import lampgo.expression_library as expression_library
+import lampgo.led_effects as led_effects
+from lampgo.expression_library import (
+    ExpressionLibraryError,
+    expression_capabilities,
+    refresh_llm_expression_catalog,
+    save_led_effect,
+)
+from lampgo.led_effects import (
+    LED_FRAME_BYTES,
+    LEF_HEADER,
+    LedEffectError,
+    compile_led_program,
+    inspect_led_package,
+    load_pixel_led_package,
+    load_pixel_led_source,
+)
+
+
+def _rows(*, offset: int = 0, symbol: str = "1") -> list[str]:
+    rows = [list("." * 51) for _ in range(9)]
+    for col in range(12 + offset, 39 + offset):
+        if 0 <= col < 51:
+            distance = abs(col - (25 + offset))
+            row = min(8, 3 + (distance * distance) // 190)
+            rows[row][col] = symbol
+    return ["".join(row) for row in rows]
+
+
+def _effect(effect_id: str = "rainbow_smile") -> dict:
+    return {
+        "effect_id": effect_id,
+        "label": "彩虹笑嘴",
+        "role": "mouth",
+        "program": {
+            "version": 2,
+            "type": "pixel_clip",
+            "fps": 10,
+            "palette": {".": "#000000", "1": "#ff0066", "2": "#00d8ff"},
+            "roles": {"primary": "1", "secondary": "2"},
+            "frames": [
+                {"rows": _rows(symbol="1"), "ticks": 10},
+                {"rows": _rows(offset=1, symbol="2"), "ticks": 10},
+                {"rows": _rows(symbol="1"), "ticks": 10},
+            ],
+        },
+    }
+
+
+def test_lef1_compile_is_deterministic_and_deduplicates_frames():
+    normalized, first = compile_led_program(_effect()["program"])
+    _, second = compile_led_program(_effect()["program"])
+    info = inspect_led_package(first)
+
+    assert first == second
+    assert normalized["fps"] == 10
+    assert info["frame_count"] == 30
+    assert info["unique_frame_count"] == 2
+    assert info["palette_count"] == 3
+    assert info["bytes"] == LEF_HEADER.size + 3 * 3 + 30 + 2 * LED_FRAME_BYTES
+    assert info["roles"] == {"primary": 1, "secondary": 2, "accent": 255}
+
+
+def test_lef1_rejects_unsafe_or_incomplete_programs():
+    bad = _effect()["program"]
+    bad["frames"][0]["rows"][0] = "." * 50
+    with pytest.raises(LedEffectError, match="51"):
+        compile_led_program(bad)
+
+    bad = _effect()["program"]
+    bad["frames"] = [{"rows": _rows(), "ticks": 29}]
+    with pytest.raises(LedEffectError, match="exactly 30"):
+        compile_led_program(bad)
+
+
+def test_pixel_effect_storage_capacity_and_llm_catalog(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    saved = save_led_effect(_effect())
+
+    assert saved["kind"] == "pixel_clip"
+    assert saved["default_playback"] == "loop"
+    assert saved["package"]["bytes"] < 8 * 1024
+    assert load_pixel_led_package("rainbow_smile")
+    assert load_pixel_led_source("rainbow_smile")["program"]["frames"][0]["ticks"] == 10
+    assert expression_capabilities()["led_effects"]["installed_custom"] == 1
+
+    path = refresh_llm_expression_catalog()
+    catalog = json.loads(path.read_text(encoding="utf-8"))
+    assert catalog["schema_version"] == 1
+    assert catalog["revision"] >= 2
+    assert any(item["effect_id"] == "rainbow_smile" for item in catalog["led_effects"])
+
+
+def test_custom_effect_limit_is_shared_with_legacy_templates(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    monkeypatch.setattr(expression_library, "MAX_CUSTOM_LED_EFFECTS", 1)
+    monkeypatch.setattr(led_effects, "MAX_CUSTOM_LED_EFFECTS", 1)
+    save_led_effect(
+        {
+            "effect_id": "legacy_mouth",
+            "role": "mouth",
+            "program": {"version": 1, "template": "mouth", "variant": "smile"},
+        }
+    )
+
+    with pytest.raises(ExpressionLibraryError, match="maximum custom LED effects"):
+        save_led_effect(_effect())


### PR DESCRIPTION
## What changed

- Adds safe, user-authored 51x9 LED pixel clips with 10fps / 30-tick timelines.
- Adds LED effect upload, S3 sync, looped playback, named eye/LED presets, and an LLM-readable catalog.
- Adds the Web editor for colored LED animation plus the eye/LED composition workflow.

## Why

Users can now design colorful LED mouths, symbols, and accents without a firmware update for each new effect. Presets retain only resource references and parameters.

## Safety and limits

- Official firmware effects remain immutable.
- User effects are data-only LEF1 packages, never executable code.
- 24 user effects, 8KiB each, 192KiB total; composition brightness is capped.
- Presets default to loop playback to avoid blank frames during recorded actions.

## Checks

- `.venv/bin/pytest -q` (266 passed)
- `.venv/bin/ruff check lampgo/led_effects.py lampgo/expression_library.py lampgo/core/led.py tests/test_led_effects.py tests/test_expression_library.py`
- `node --check lampgo/web/static/app.js`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 LED Pixel Clip 动画编辑器，支持逐帧绘制、调色板、预览、保存、同步与删除。
  * 新增表达式目录，可查看、管理并同步眼睛与 LED 资源。
  * 支持用户自定义 LED 效果及组合表情管理。

* **改进**
  * 组合表情默认循环播放，可明确设置为单次播放。
  * 预设名称可自动生成稳定标识，并支持颜色覆盖与删除。
  * 播放前自动检查并同步设备所需资源。

* **文档**
  * 更新表达式、预设及 LED 效果格式与使用说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->