### PR TITLE
Harden calibration and LiveKit lifecycle

### DIFF
--- a/lampgo/cli.py
+++ b/lampgo/cli.py
@@ -859,13 +859,48 @@ def _resolve_calibration_port(args: argparse.Namespace, config) -> str | None:
     return port
 
 
+def _require_calibration_project_root() -> Path:
+    """Abort before hardware access unless calibration starts from the repo root."""
+    from lampgo.core.config import _find_project_root
+
+    project_root = _find_project_root().resolve()
+    current_dir = Path.cwd().resolve()
+    is_lampgo_project = (project_root / "pyproject.toml").is_file() and (project_root / "lampgo" / "cli.py").is_file()
+    if current_dir != project_root or not is_lampgo_project:
+        print(
+            "Error: calibration must be run from the LampGo project root; "
+            f"current directory is {current_dir}.\n"
+            f"Run: cd {project_root} && uv run lampgo calibrate\n"
+            "Calibration aborted before accessing hardware.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return project_root
+
+
+def _require_calibration_path_in_project(project_root: Path, calibration_dir: Path, lamp_id: str) -> None:
+    """Prevent a calibration profile from being written outside this checkout."""
+    target = (calibration_dir / f"{lamp_id}.json").resolve()
+    try:
+        target.relative_to(project_root)
+    except ValueError:
+        print(
+            "Error: calibration target must stay inside the LampGo project root; "
+            f"got {target}.\nCalibration aborted before accessing hardware.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
 def _cmd_calibrate(args: argparse.Namespace) -> None:
-    from lampgo.core.config import DeviceConfig, load_config
+    from lampgo.core.config import load_config
     from lampgo.core.hal import HardwareAbstraction
 
+    project_root = _require_calibration_project_root()
     config = load_config(config_path=getattr(args, "config", None))
     port = _resolve_calibration_port(args, config)
     lamp_id = args.id or config.device.lamp_id
+    _require_calibration_path_in_project(project_root, config.device.calibration_dir, lamp_id)
 
     if not port:
         print(
@@ -874,7 +909,7 @@ def _cmd_calibrate(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    dev_config = DeviceConfig(motor_port=port, lamp_id=lamp_id)
+    dev_config = config.device.model_copy(update={"motor_port": port, "lamp_id": lamp_id})
     hal = HardwareAbstraction(dev_config)
     try:
         hal.connect(calibrate=False, configure=False)

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -2375,9 +2375,13 @@ class LampgoServer:
             if ready:
                 logger.info("server.agent_sdk_ready")
             else:
-                logger.warning("server.agent_sdk_ready_timeout")
+                error = self._agent_sdk.last_error or "voice agent SDK readiness timeout"
+                logger.warning("server.agent_sdk_ready_timeout", error=error)
+                await self._agent_sdk.stop()
         except Exception:
             logger.exception("server.agent_sdk_start_failed")
+            if self._agent_sdk is not None:
+                await self._agent_sdk.stop()
 
     async def ensure_agent_sdk_ready(self, *, timeout_s: float = 10.0) -> tuple[bool, str]:
         """Ensure the LiveKit Agent SDK is running for a manual browser call."""
@@ -2389,7 +2393,7 @@ class LampgoServer:
             return False, self._agent_sdk.last_error or "voice agent SDK is not running"
         ready = await self._agent_sdk.wait_ready(timeout_s=timeout_s)
         if not ready:
-            return False, "voice agent SDK is still starting"
+            return False, self._agent_sdk.last_error or "voice agent SDK is still starting"
         return True, ""
 
 

--- a/lampgo/voice/agent_sdk.py
+++ b/lampgo/voice/agent_sdk.py
@@ -10,6 +10,7 @@ audio in the room, runs ASR/TTS via Volcengine, and calls lampgo's
 from __future__ import annotations
 
 import asyncio
+import getpass
 import importlib.util
 import json
 import os
@@ -18,6 +19,7 @@ import signal
 import socket
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
@@ -107,6 +109,37 @@ _LOCAL_NO_PROXY_HOSTS = (
     "10.0.0.0/8",
     "172.16.0.0/12",
 )
+
+_BIND_FAILURE_MARKERS = (
+    "address already in use",
+    "errno 48",
+    "errno 98",
+    "winerror 10048",
+)
+
+
+@dataclass(frozen=True)
+class _SDKPortOwner:
+    """A verified LampGo SDK process group that owns the local SDK port."""
+
+    listener_pid: int
+    root_pid: int
+    process_group_id: int | None
+    process_name: str
+
+
+def _command_runs_agent_sdk(command: list[str]) -> bool:
+    """Return whether an argv contains the exact LampGo SDK executable."""
+    expected = {name.casefold() for name in AGENT_SDK_BINARIES}
+    for token in command:
+        # ``Path`` follows the host OS and therefore does not split a Windows
+        # path when tests or diagnostics run on Unix (and vice versa).
+        executable = str(token).replace("\\", "/").rsplit("/", 1)[-1].casefold()
+        if executable.endswith(".exe"):
+            executable = executable[:-4]
+        if executable in expected:
+            return True
+    return False
 
 
 def _yaml_string(value: str) -> str:
@@ -573,6 +606,8 @@ class AgentSDKManager:
         self._patch_dir: Path | None = None
         self._monitor_task: asyncio.Task | None = None
         self._ready_event = asyncio.Event()
+        self._startup_failed_event = asyncio.Event()
+        self._start_lock = asyncio.Lock()
         self._last_error = ""
 
     @property
@@ -685,6 +720,240 @@ class AgentSDKManager:
         return None
 
     @staticmethod
+    def _psutil():
+        """Import psutil lazily so missing voice extras still get a useful error."""
+        try:
+            import psutil
+        except ImportError as exc:  # pragma: no cover - guarded by the voice extra
+            raise RuntimeError("psutil is required to inspect the LiveKit Agent SDK port") from exc
+        return psutil
+
+    def _find_port_listener_pid(self) -> int | None:
+        """Return the unique PID listening on the SDK port, if any."""
+        psutil = self._psutil()
+        listener_pids: set[int] = set()
+        unknown_listener = False
+        try:
+            connections = [
+                (connection, connection.pid)
+                for connection in psutil.net_connections(kind="tcp")
+            ]
+        except (psutil.AccessDenied, OSError):
+            # macOS can reject the whole system-wide query because of one
+            # protected process. Fall back to inspecting current-user
+            # processes individually so a single denial is harmless.
+            connections = []
+            for process in psutil.process_iter():
+                if not self._process_is_current_user(process):
+                    continue
+                try:
+                    connections.extend(
+                        (connection, process.pid)
+                        for connection in process.net_connections(kind="tcp")
+                    )
+                except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+                    continue
+
+        for connection, owner_pid in connections:
+            if connection.status != psutil.CONN_LISTEN or not connection.laddr:
+                continue
+            local_port = getattr(connection.laddr, "port", None)
+            if local_port is None and len(connection.laddr) >= 2:
+                local_port = connection.laddr[1]
+            if local_port != self._port:
+                continue
+            if owner_pid is None:
+                unknown_listener = True
+            else:
+                listener_pids.add(int(owner_pid))
+
+        if unknown_listener or len(listener_pids) > 1:
+            raise RuntimeError(f"cannot determine the unique owner of TCP port {self._port}")
+        if listener_pids:
+            return next(iter(listener_pids))
+
+        # If no visible process owns the port, distinguish a genuinely free
+        # port from a listener hidden by OS permissions. Never assume the
+        # latter is safe to terminate or replace.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            try:
+                probe.bind(("127.0.0.1", self._port))
+            except OSError as exc:
+                raise RuntimeError(
+                    f"TCP port {self._port} is occupied but its owner cannot be inspected"
+                ) from exc
+        return None
+
+    @staticmethod
+    def _process_is_current_user(process) -> bool:
+        try:
+            if hasattr(os, "getuid"):
+                return int(process.uids().real) == os.getuid()
+            return process.username().casefold() == getpass.getuser().casefold()
+        except Exception:
+            return False
+
+    def _identify_sdk_port_owner(self, listener_pid: int) -> _SDKPortOwner | None:
+        """Resolve a listener to an SDK parent/process-group leader owned by this user."""
+        psutil = self._psutil()
+        try:
+            listener = psutil.Process(listener_pid)
+            if not self._process_is_current_user(listener):
+                return None
+
+            process_group_id: int | None = None
+            candidates = []
+            if os.name != "nt":
+                try:
+                    process_group_id = os.getpgid(listener_pid)
+                    candidates.append(psutil.Process(process_group_id))
+                except (OSError, psutil.Error):
+                    process_group_id = None
+
+            current = listener
+            seen: set[int] = set()
+            while current.pid not in seen and len(seen) < 8:
+                seen.add(current.pid)
+                candidates.append(current)
+                try:
+                    current = current.parent()
+                except psutil.Error:
+                    break
+                if current is None:
+                    break
+
+            for candidate in candidates:
+                if not self._process_is_current_user(candidate):
+                    continue
+                try:
+                    command = candidate.cmdline()
+                except psutil.Error:
+                    continue
+                if not _command_runs_agent_sdk(command):
+                    continue
+                if process_group_id is not None:
+                    try:
+                        if os.getpgid(candidate.pid) != process_group_id:
+                            continue
+                    except OSError:
+                        continue
+                return _SDKPortOwner(
+                    listener_pid=listener_pid,
+                    root_pid=int(candidate.pid),
+                    process_group_id=process_group_id,
+                    process_name=candidate.name(),
+                )
+        except psutil.Error:
+            return None
+        return None
+
+    def _describe_process(self, pid: int) -> str:
+        psutil = self._psutil()
+        try:
+            process = psutil.Process(pid)
+            return process.name()
+        except psutil.Error:
+            return "unknown"
+
+    def _signal_sdk_owner(self, owner: _SDKPortOwner, *, force: bool) -> None:
+        """Signal only the verified SDK process group/tree."""
+        psutil = self._psutil()
+        if os.name != "nt" and owner.process_group_id is not None:
+            if owner.process_group_id == os.getpgrp():
+                raise RuntimeError("refusing to signal LampGo's own process group")
+            signal_to_send = signal.SIGKILL if force else signal.SIGTERM
+            try:
+                os.killpg(owner.process_group_id, signal_to_send)
+            except ProcessLookupError:
+                pass
+            return
+
+        try:
+            root = psutil.Process(owner.root_pid)
+            process_tree = root.children(recursive=True) + [root]
+        except psutil.NoSuchProcess:
+            return
+        for process in reversed(process_tree):
+            try:
+                process.kill() if force else process.terminate()
+            except psutil.NoSuchProcess:
+                pass
+
+    async def _wait_for_port_free(self, timeout_s: float) -> bool:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_s
+        while True:
+            try:
+                listener_pid = await asyncio.to_thread(self._find_port_listener_pid)
+            except RuntimeError:
+                return False
+            if listener_pid is None:
+                return True
+            if loop.time() >= deadline:
+                return False
+            await asyncio.sleep(0.1)
+
+    async def _release_sdk_port(self) -> bool:
+        """Replace a stale LampGo SDK listener; never kill an unknown process."""
+        try:
+            listener_pid = await asyncio.to_thread(self._find_port_listener_pid)
+        except RuntimeError as exc:
+            self._set_last_error(str(exc))
+            logger.warning("agent_sdk.port_inspection_failed", port=self._port, error=str(exc))
+            return False
+        if listener_pid is None:
+            return True
+
+        owner = await asyncio.to_thread(self._identify_sdk_port_owner, listener_pid)
+        if owner is None:
+            process_name = await asyncio.to_thread(self._describe_process, listener_pid)
+            self._set_last_error(
+                f"TCP port {self._port} is occupied by an unknown process "
+                f"(pid={listener_pid}, process={process_name}); refusing to terminate it"
+            )
+            logger.warning(
+                "agent_sdk.port_owned_by_unknown_process",
+                port=self._port,
+                pid=listener_pid,
+                process=process_name,
+            )
+            return False
+
+        logger.warning(
+            "agent_sdk.stale_process_detected",
+            port=self._port,
+            listener_pid=owner.listener_pid,
+            root_pid=owner.root_pid,
+            pgid=owner.process_group_id,
+            process=owner.process_name,
+        )
+        try:
+            await asyncio.to_thread(self._signal_sdk_owner, owner, force=False)
+            if await self._wait_for_port_free(3.0):
+                logger.info("agent_sdk.stale_process_stopped", port=self._port, root_pid=owner.root_pid)
+                return True
+
+            logger.warning(
+                "agent_sdk.stale_process_stop_timeout",
+                port=self._port,
+                root_pid=owner.root_pid,
+                pgid=owner.process_group_id,
+            )
+            await asyncio.to_thread(self._signal_sdk_owner, owner, force=True)
+            if await self._wait_for_port_free(2.0):
+                logger.info("agent_sdk.stale_process_killed", port=self._port, root_pid=owner.root_pid)
+                return True
+        except Exception as exc:
+            self._set_last_error(f"failed to stop stale {AGENT_SDK_PACKAGE}: {exc}")
+            logger.exception("agent_sdk.stale_process_cleanup_failed", root_pid=owner.root_pid)
+            return False
+
+        self._set_last_error(
+            f"stale {AGENT_SDK_PACKAGE} did not release TCP port {self._port}"
+        )
+        return False
+
+    @staticmethod
     def _merge_no_proxy(value: str | None) -> str:
         existing = [item.strip() for item in (value or "").split(",") if item.strip()]
         seen = {item.lower() for item in existing}
@@ -696,9 +965,17 @@ class AgentSDKManager:
 
     async def start(self) -> bool:
         """Start the Agent SDK subprocess if config is complete."""
-        if self._process is not None:
+        async with self._start_lock:
+            return await self._start_locked()
+
+    async def _start_locked(self) -> bool:
+        if self.is_running:
             logger.debug("agent_sdk.already_running")
             return True
+        if self._process is not None:
+            # A previous parent may already have exited while worker children
+            # still hold stdout or sockets. Reap its whole managed group first.
+            await self.stop()
 
         if not self._can_start():
             return False
@@ -712,6 +989,9 @@ class AgentSDKManager:
                 binaries=AGENT_SDK_BINARIES,
                 hint=f"Agent SDK CLI is missing from PATH and venv/bin: {binaries}",
             )
+            return False
+
+        if not await self._release_sdk_port():
             return False
 
         self._roles_path = self._generate_roles_yaml()
@@ -748,6 +1028,7 @@ class AgentSDKManager:
         logger.info("agent_sdk.no_proxy_configured", no_proxy=no_proxy)
 
         self._ready_event.clear()
+        self._startup_failed_event.clear()
         try:
             self._process = await asyncio.create_subprocess_exec(
                 sdk_binary,
@@ -796,7 +1077,7 @@ class AgentSDKManager:
                 proc.send_signal(signal.SIGTERM)
             try:
                 await asyncio.wait_for(proc.wait(), timeout=5.0)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning("agent_sdk.stop_timeout_killing", pid=pid, pgid=pgid)
                 if pgid is not None:
                     os.killpg(pgid, signal.SIGKILL)
@@ -812,6 +1093,7 @@ class AgentSDKManager:
             self._process = None
         self._process_pgid = None
         self._ready_event.clear()
+        self._startup_failed_event.clear()
 
         if self._monitor_task and not self._monitor_task.done():
             self._monitor_task.cancel()
@@ -836,13 +1118,29 @@ class AgentSDKManager:
     async def wait_ready(self, timeout_s: float = 8.0) -> bool:
         if self.is_ready:
             return True
-        if not self.is_running:
+        if not self.is_running or self._startup_failed_event.is_set():
             return False
+
+        waiters = {
+            asyncio.create_task(self._ready_event.wait()),
+            asyncio.create_task(self._startup_failed_event.wait()),
+        }
+        done: set[asyncio.Task] = set()
         try:
-            await asyncio.wait_for(self._ready_event.wait(), timeout=timeout_s)
-        except asyncio.TimeoutError:
+            done, _ = await asyncio.wait(
+                waiters,
+                timeout=timeout_s,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for waiter in waiters:
+                if not waiter.done():
+                    waiter.cancel()
+            await asyncio.gather(*waiters, return_exceptions=True)
+        if not done:
+            self._set_last_error(f"voice agent SDK did not become ready within {timeout_s:.1f}s")
             return False
-        return self.is_ready
+        return not self._startup_failed_event.is_set() and self.is_ready
 
     async def _monitor(self) -> None:
         """Read stdout and watch for unexpected exits."""
@@ -854,6 +1152,10 @@ class AgentSDKManager:
                 text = line.decode(errors="replace").rstrip()
                 if text:
                     logger.info("agent_sdk.output", line=text)
+                    lowered = text.casefold()
+                    if any(marker in lowered for marker in _BIND_FAILURE_MARKERS):
+                        self._set_last_error(f"TCP port {self._port} became unavailable during SDK startup")
+                        self._startup_failed_event.set()
                     if "registered worker" in text:
                         self._ready_event.set()
         except asyncio.CancelledError:
@@ -861,9 +1163,15 @@ class AgentSDKManager:
         except Exception:
             logger.debug("agent_sdk.monitor_read_error", exc_info=True)
 
-        rc = proc.returncode
+        rc = await proc.wait()
         if rc is not None and rc != 0:
+            if not self._last_error:
+                self._set_last_error(f"{AGENT_SDK_PACKAGE} exited with status {rc}")
+            self._startup_failed_event.set()
             logger.warning("agent_sdk.exited_unexpectedly", returncode=rc)
+        elif not self._ready_event.is_set():
+            self._set_last_error(f"{AGENT_SDK_PACKAGE} exited before becoming ready")
+            self._startup_failed_event.set()
         if self._process is proc:
             self._process = None
             self._process_pgid = None

--- a/lampgo/web/gateway.py
+++ b/lampgo/web/gateway.py
@@ -1445,7 +1445,7 @@ class WebGateway:
         return JSONResponse({"ok": True, "result": result})
 
     async def api_livekit_room_end(self, request: Request) -> JSONResponse:
-        """Hard-close a LiveKit room when the browser ends a call."""
+        """Release LampGo's local call ownership after the browser disconnects."""
         try:
             body = await request.json()
         except Exception:
@@ -1505,7 +1505,7 @@ class WebGateway:
         reason: str,
         client_call_id: str = "",
     ) -> list[str]:
-        """Delete LiveKit rooms and forget them from the local active-room registry."""
+        """Forget local room ownership; cloud auth does not expose room administration."""
         targets = sorted(
             {
                 str(room or "").strip()

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -1691,7 +1691,7 @@
     releaseWebPageOwner();
     try { stopAllTts(); } catch (_) { /* ignore */ }
     try {
-      if (lkRoom || browserCallStartPromise) stopBrowserLiveKitCall();
+      if (lkRoom || browserCallStartPromise) void stopBrowserLiveKitCall("page_deactivated");
     } catch (_) {
       // The call module may not be initialized yet.
     }
@@ -5904,6 +5904,8 @@
   const CALL_WAKE_FRESH_MS = 15000;
   const CALL_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
   const CALL_AUDIO_ACTIVITY_THROTTLE_MS = 1000;
+  const CALL_DISCONNECT_TIMEOUT_MS = 5000;
+  const CALL_END_NOTIFY_TIMEOUT_MS = 3000;
   const browserCallClientId = (() => {
     try {
       let id = sessionStorage.getItem("lampgo.browserCallClientId");
@@ -5924,6 +5926,12 @@
   let browserCallLastAudioActivityAt = 0;
   let lkRoomName = "";
   let lkClientCallId = "";
+  let browserCallJoiningRoom = null;
+  let browserCallDisconnectingRoom = null;
+  let browserCallHangupPromise = null;
+  let browserCallStopRequested = false;
+  let browserCallPageExitNotified = false;
+  const browserCallDisconnectPromises = new WeakMap();
 
   let esp32AudioCtx = null;
   let esp32WorkletNode = null;
@@ -5966,7 +5974,7 @@
       if (idleMs >= CALL_IDLE_TIMEOUT_MS) {
         console.info("[call] idle timeout; closing LiveKit room", { idleMs });
         addCallSystemNote("5 分钟没有输入或输出，已自动结束通话");
-        stopBrowserLiveKitCall("idle_timeout");
+        void stopBrowserLiveKitCall("idle_timeout");
       } else {
         scheduleBrowserCallIdleTimer();
       }
@@ -6022,7 +6030,7 @@
     browserCallLockTimer = window.setInterval(() => {
       if (!refreshBrowserCallLock(reason || "call")) {
         console.warn("[call] lost call owner lock; stopping local call");
-        if (lkRoom || browserCallStartPromise) stopBrowserLiveKitCall();
+        if (lkRoom || browserCallStartPromise) void stopBrowserLiveKitCall("lock_lost");
       }
     }, CALL_LOCK_REFRESH_MS);
     return true;
@@ -6513,6 +6521,13 @@
     return startBrowserLiveKitCall({ reason });
   }
 
+  function throwIfBrowserCallStopRequested() {
+    if (!browserCallStopRequested) return;
+    const err = new Error("LiveKit call start cancelled");
+    err.name = "AbortError";
+    throw err;
+  }
+
   async function startBrowserLiveKitCall(options = {}) {
     const reason = options.reason || "manual";
     if (browserCallStartPromise) return browserCallStartPromise;
@@ -6524,6 +6539,8 @@
       if (reason === "manual") addCallSystemNote("已有另一个页面正在通话，已忽略本次启动");
       return null;
     }
+    browserCallStopRequested = false;
+    browserCallPageExitNotified = false;
 
     browserCallStartPromise = (async () => {
       if (btnCallStart) btnCallStart.disabled = true;
@@ -6533,6 +6550,7 @@
       browserCallPendingId = callAttemptId;
       const modeLabel = VOICE_CALL_MODE_LABELS[voiceCallMode] || VOICE_CALL_MODE_LABELS.stable;
       let room = null;
+      let issuedRoomName = "";
       try {
         console.log("[call] starting LiveKit call", {
           reason,
@@ -6563,9 +6581,15 @@
           }
           throw new Error(error);
         }
-        const { Room, Track, LocalAudioTrack, createLocalAudioTrack } = await loadLiveKitClient();
         const { token, serverUrl, roomName } = body.result;
+        issuedRoomName = roomName || "";
+        lkRoomName = issuedRoomName;
+        lkClientCallId = callAttemptId;
+        throwIfBrowserCallStopRequested();
+        const { Room, Track, LocalAudioTrack, createLocalAudioTrack } = await loadLiveKitClient();
+        throwIfBrowserCallStopRequested();
         room = new Room({ adaptiveStream: false, dynacast: false });
+        browserCallJoiningRoom = room;
         room.on("trackSubscribed", (track) => {
           if (track.kind !== Track.Kind.Audio) return;
           remoteAudioTrack = track;
@@ -6618,13 +6642,15 @@
           });
         });
         room.on("disconnected", () => {
-          const endedRoomName = lkRoomName;
-          const endedClientCallId = lkClientCallId;
-          cleanupBrowserLiveKitCall();
-          setBrowserCallState("idle");
-          notifyLiveKitRoomEnded(endedRoomName, "livekit_disconnected", endedClientCallId);
+          if (browserCallDisconnectingRoom === room || browserCallDisconnectPromises.has(room)) return;
+          if (lkRoom !== room && browserCallJoiningRoom !== room) return;
+          void stopBrowserLiveKitCall("livekit_disconnected", {
+            room,
+            alreadyDisconnected: true,
+          });
         });
         await room.connect(serverUrl, token);
+        throwIfBrowserCallStopRequested();
         if (typeof room.startAudio === "function") {
           try {
             await room.startAudio();
@@ -6657,9 +6683,12 @@
           lkLocalTrack = await createLocalAudioTrack(audioOptions);
         }
 
+        throwIfBrowserCallStopRequested();
         await room.localParticipant.publishTrack(lkLocalTrack, { source: Track.Source.Microphone });
+        throwIfBrowserCallStopRequested();
         console.log("[call] local microphone track published", { reason, roomName: lkRoomName, mic: useEsp32 ? "esp32" : (selectedMicId || "default") });
         lkRoom = room;
+        browserCallJoiningRoom = null;
         setBrowserCallState("active");
         touchBrowserCallActivity("room_connected");
         addCallSystemNote("通话已连接，正在等待语音识别…");
@@ -6667,13 +6696,32 @@
         return room;
       } catch (err) {
         browserCallPendingId = "";
-        console.error("[call] browser LiveKit start failed:", err);
-        addCallSystemNote(`通话启动失败：${err.message || err}`);
-        if (room) {
-          try { room.disconnect(); } catch (_) { /* ignore */ }
+        const cancelled = browserCallStopRequested || (err && err.name === "AbortError");
+        if (cancelled) {
+          console.info("[call] browser LiveKit start cancelled");
+        } else {
+          console.error("[call] browser LiveKit start failed:", err);
+          addCallSystemNote(`通话启动失败：${err.message || err}`);
         }
-        cleanupBrowserLiveKitCall();
-        setBrowserCallState("idle");
+        if (!browserCallHangupPromise) {
+          if (room) {
+            try {
+              browserCallDisconnectingRoom = room;
+              await disconnectBrowserLiveKitRoom(room);
+            } catch (disconnectErr) {
+              console.warn("[call] failed to disconnect partially started room:", disconnectErr);
+            } finally {
+              if (browserCallDisconnectingRoom === room) browserCallDisconnectingRoom = null;
+            }
+          }
+          await notifyLiveKitRoomEnded(
+            lkRoomName || issuedRoomName || (room && room.name) || "",
+            cancelled ? "start_cancelled" : "start_failed",
+            lkClientCallId || callAttemptId,
+          );
+          cleanupBrowserLiveKitCall();
+          setBrowserCallState("idle");
+        }
         return null;
       }
     })();
@@ -6701,7 +6749,7 @@
     const mediaStreamTrack = track && (track.mediaStreamTrack || track._mediaStreamTrack);
     if (!mediaStreamTrack) {
       await new Promise((resolve) => window.setTimeout(resolve, 7000));
-      stopBrowserLiveKitCall();
+      await stopBrowserLiveKitCall("goodbye");
       return;
     }
 
@@ -6768,7 +6816,30 @@
       cleanup();
     }
 
-    if (lkRoom) stopBrowserLiveKitCall("goodbye");
+    if (lkRoom) await stopBrowserLiveKitCall("goodbye");
+  }
+
+  function withBrowserCallTimeout(promise, timeoutMs, label) {
+    let timeoutId = null;
+    const timeout = new Promise((_, reject) => {
+      timeoutId = window.setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+    });
+    return Promise.race([Promise.resolve(promise), timeout]).finally(() => {
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+    });
+  }
+
+  function disconnectBrowserLiveKitRoom(room) {
+    if (!room || typeof room.disconnect !== "function") return Promise.resolve();
+    const existing = browserCallDisconnectPromises.get(room);
+    if (existing) return existing;
+    const pending = withBrowserCallTimeout(
+      Promise.resolve().then(() => room.disconnect()),
+      CALL_DISCONNECT_TIMEOUT_MS,
+      "LiveKit disconnect",
+    );
+    browserCallDisconnectPromises.set(room, pending);
+    return pending;
   }
 
   function cleanupBrowserLiveKitCall() {
@@ -6788,50 +6859,122 @@
     lkAudioEls.forEach((el) => el.remove());
     lkAudioEls.clear();
     lkRoom = null;
+    browserCallJoiningRoom = null;
     browserCallPendingId = "";
     releaseBrowserCallLock();
   }
 
-  function stopBrowserLiveKitCall(reason = "manual") {
-    if (lkRoom) {
-      const room = lkRoom;
-      const roomName = lkRoomName;
-      const clientCallId = lkClientCallId;
+  function stopBrowserLiveKitCall(reason = "manual", options = {}) {
+    browserCallStopRequested = true;
+    if (browserCallHangupPromise) return browserCallHangupPromise;
+
+    const startPromise = browserCallStartPromise;
+    const initialRoom = options.room || lkRoom || browserCallJoiningRoom;
+    if (!initialRoom && !startPromise) {
       cleanupBrowserLiveKitCall();
-      try { room.disconnect(); } catch (_) { /* ignore */ }
-      notifyLiveKitRoomEnded(roomName, reason, clientCallId);
+      setBrowserCallState("idle");
+      return Promise.resolve();
     }
-    setBrowserCallState("idle");
+
+    setBrowserCallState("leaving");
+    browserCallHangupPromise = (async () => {
+      let room = initialRoom;
+      if (!room && startPromise) {
+        try {
+          await withBrowserCallTimeout(startPromise, CALL_DISCONNECT_TIMEOUT_MS, "LiveKit call start cancellation");
+        } catch (err) {
+          console.warn("[call] call start did not settle before hangup cleanup:", err);
+        }
+        room = lkRoom || browserCallJoiningRoom;
+      }
+
+      const roomName = lkRoomName || (room && room.name) || "";
+      const clientCallId = lkClientCallId || browserCallPendingId;
+      if (room && !options.alreadyDisconnected) {
+        browserCallDisconnectingRoom = room;
+        try {
+          await disconnectBrowserLiveKitRoom(room);
+          console.info("[call] LiveKit room disconnected", { roomName, reason });
+        } catch (err) {
+          console.warn("[call] LiveKit disconnect did not complete cleanly:", err);
+        }
+      }
+      if (startPromise && initialRoom) {
+        try {
+          await withBrowserCallTimeout(startPromise, CALL_DISCONNECT_TIMEOUT_MS, "LiveKit call start teardown");
+        } catch (err) {
+          console.warn("[call] call start did not settle after disconnect:", err);
+        }
+      }
+
+      await notifyLiveKitRoomEnded(roomName, reason, clientCallId);
+    })().finally(() => {
+      cleanupBrowserLiveKitCall();
+      if (browserCallDisconnectingRoom === initialRoom || !initialRoom) {
+        browserCallDisconnectingRoom = null;
+      }
+      browserCallHangupPromise = null;
+      setBrowserCallState("idle");
+    });
+    return browserCallHangupPromise;
   }
 
-  function notifyLiveKitRoomEnded(roomName, reason = "manual", clientCallId = "") {
-    if (!roomName) return;
+  async function notifyLiveKitRoomEnded(roomName, reason = "manual", clientCallId = "", options = {}) {
+    if (!roomName) return false;
     const payload = JSON.stringify({
       room_name: roomName,
       reason,
       client_call_id: clientCallId,
     });
-    try {
-      if (navigator.sendBeacon) {
+    if (options.preferBeacon) {
+      try {
         const blob = new Blob([payload], { type: "application/json" });
-        if (navigator.sendBeacon("/api/livekit/room/end", blob)) return;
+        if (navigator.sendBeacon && navigator.sendBeacon("/api/livekit/room/end", blob)) return true;
+      } catch (_) {
+        // Fall through to keepalive fetch.
       }
-    } catch (_) {
-      // Fall through to fetch.
     }
-    fetch("/api/livekit/room/end", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: payload,
-      keepalive: true,
-    }).catch((err) => {
+
+    const controller = typeof AbortController === "function" ? new AbortController() : null;
+    const timeoutId = controller
+      ? window.setTimeout(() => controller.abort(), CALL_END_NOTIFY_TIMEOUT_MS)
+      : null;
+    try {
+      const response = await fetch("/api/livekit/room/end", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+        keepalive: true,
+        ...(controller ? { signal: controller.signal } : {}),
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return true;
+    } catch (err) {
       console.warn("[call] failed to notify room end:", err);
-    });
+      return false;
+    } finally {
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+    }
   }
 
-  window.addEventListener("beforeunload", () => {
-    if (lkRoomName) notifyLiveKitRoomEnded(lkRoomName, "page_unload", lkClientCallId);
-  });
+  function endBrowserLiveKitCallForPageExit() {
+    if (!lkRoomName || browserCallPageExitNotified) return;
+    browserCallPageExitNotified = true;
+    const room = lkRoom || browserCallJoiningRoom;
+    if (room && typeof room.disconnect === "function") {
+      browserCallDisconnectingRoom = room;
+      try {
+        const pending = room.disconnect();
+        if (pending && typeof pending.catch === "function") pending.catch(() => {});
+      } catch (_) {
+        // Unload teardown is best effort only.
+      }
+    }
+    void notifyLiveKitRoomEnded(lkRoomName, "page_unload", lkClientCallId, { preferBeacon: true });
+  }
+
+  window.addEventListener("pagehide", endBrowserLiveKitCallForPageExit);
+  window.addEventListener("beforeunload", endBrowserLiveKitCallForPageExit);
 
   function createCallSession() {
     const id = `call_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`;
@@ -6936,7 +7079,7 @@
   if (btnCallEnd) {
     btnCallEnd.addEventListener("click", () => {
       btnCallEnd.disabled = true;
-      if (lkRoom) stopBrowserLiveKitCall();
+      if (lkRoom || browserCallStartPromise) void stopBrowserLiveKitCall();
       else send({ type: "stop_conversation" });
     });
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ voice = [
     "livekit>=0.17",
     "livekit-api>=0.7",
     "lampgo-livekit-agent-sdk>=0.3.0",
+    "psutil>=7.0",
 ]
 bridge = [
     "pyautogui>=0.9",

--- a/tests/test_agent_sdk_lifecycle.py
+++ b/tests/test_agent_sdk_lifecycle.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from lampgo.core.config import VoiceConfig
+from lampgo.voice import agent_sdk
+
+
+def _manager() -> agent_sdk.AgentSDKManager:
+    return agent_sdk.AgentSDKManager(VoiceConfig())
+
+
+def test_command_runs_agent_sdk_matches_exact_executable() -> None:
+    assert agent_sdk._command_runs_agent_sdk(
+        ["python3", "/tmp/.venv/bin/lampgo-livekit-agent", "--port", "18790"]
+    )
+    assert agent_sdk._command_runs_agent_sdk([r"C:\venv\lampgo-livekit-agent.exe"])
+    assert not agent_sdk._command_runs_agent_sdk(["python3", "-m", "lampgo.cli"])
+    assert not agent_sdk._command_runs_agent_sdk(["lampgo-livekit-agent-helper"])
+
+
+def test_find_port_listener_falls_back_to_current_user_processes(monkeypatch) -> None:
+    manager = _manager()
+
+    class AccessDenied(Exception):
+        pass
+
+    class NoSuchProcess(Exception):
+        pass
+
+    process = SimpleNamespace(
+        pid=2468,
+        net_connections=lambda *, kind: [
+            SimpleNamespace(
+                status="LISTEN",
+                laddr=SimpleNamespace(port=manager.port),
+            )
+        ],
+    )
+    fake_psutil = SimpleNamespace(
+        AccessDenied=AccessDenied,
+        NoSuchProcess=NoSuchProcess,
+        CONN_LISTEN="LISTEN",
+        net_connections=lambda *, kind: (_ for _ in ()).throw(AccessDenied()),
+        process_iter=lambda: [process],
+    )
+    monkeypatch.setattr(manager, "_psutil", lambda: fake_psutil)
+    monkeypatch.setattr(manager, "_process_is_current_user", lambda _process: True)
+
+    assert manager._find_port_listener_pid() == process.pid
+
+
+@pytest.mark.asyncio
+async def test_release_sdk_port_does_nothing_when_port_is_free(monkeypatch) -> None:
+    manager = _manager()
+    monkeypatch.setattr(manager, "_find_port_listener_pid", lambda: None)
+
+    assert await manager._release_sdk_port()
+
+
+@pytest.mark.asyncio
+async def test_release_sdk_port_refuses_unknown_listener(monkeypatch) -> None:
+    manager = _manager()
+    monkeypatch.setattr(manager, "_find_port_listener_pid", lambda: 4321)
+    monkeypatch.setattr(manager, "_identify_sdk_port_owner", lambda _pid: None)
+    monkeypatch.setattr(manager, "_describe_process", lambda _pid: "other-server")
+
+    assert not await manager._release_sdk_port()
+    assert "unknown process" in manager.last_error
+    assert "4321" in manager.last_error
+
+
+@pytest.mark.asyncio
+async def test_release_sdk_port_terminates_verified_process_group(monkeypatch) -> None:
+    manager = _manager()
+    owner = agent_sdk._SDKPortOwner(
+        listener_pid=17368,
+        root_pid=17356,
+        process_group_id=17356,
+        process_name="python3.12",
+    )
+    signals: list[bool] = []
+    waits = iter([False, True])
+
+    monkeypatch.setattr(manager, "_find_port_listener_pid", lambda: owner.listener_pid)
+    monkeypatch.setattr(manager, "_identify_sdk_port_owner", lambda _pid: owner)
+    monkeypatch.setattr(manager, "_signal_sdk_owner", lambda _owner, *, force: signals.append(force))
+
+    async def fake_wait(_timeout_s: float) -> bool:
+        await asyncio.sleep(0)
+        return next(waits)
+
+    monkeypatch.setattr(manager, "_wait_for_port_free", fake_wait)
+
+    assert await manager._release_sdk_port()
+    assert signals == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_wait_ready_returns_immediately_on_bind_failure() -> None:
+    manager = _manager()
+    manager._process = type("Process", (), {"returncode": None})()
+    manager._set_last_error("TCP port 18790 became unavailable during SDK startup")
+    manager._startup_failed_event.set()
+
+    assert not await manager.wait_ready(timeout_s=10.0)
+
+
+@pytest.mark.asyncio
+async def test_monitor_turns_bind_error_into_startup_failure() -> None:
+    manager = _manager()
+
+    class Process:
+        returncode = 1
+
+        def __init__(self) -> None:
+            self.stdout = self._lines()
+
+        @staticmethod
+        async def _lines():
+            yield b"ERROR: [Errno 48] address already in use\n"
+
+        async def wait(self) -> int:
+            return self.returncode
+
+    process = Process()
+    manager._process = process
+
+    await manager._monitor()
+
+    assert manager._startup_failed_event.is_set()
+    assert "18790" in manager.last_error
+    assert not manager.is_running

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,8 @@ import sys
 import time
 from types import SimpleNamespace
 
+import pytest
+
 from lampgo import cli
 
 
@@ -70,6 +72,51 @@ def test_resolve_calibration_port_falls_back_to_autodetect(monkeypatch):
     monkeypatch.setattr(autodetect, "detect_ports", _detect_ports)
     port = cli._resolve_calibration_port(args, config)
     assert port == "/dev/tty.usbmodemB"
+
+
+def test_calibration_aborts_outside_project_root(monkeypatch, tmp_path, capsys):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'lampgo-test'\n", encoding="utf-8")
+    subdirectory = tmp_path / "assets"
+    subdirectory.mkdir()
+    monkeypatch.chdir(subdirectory)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli._require_calibration_project_root()
+
+    assert exc_info.value.code == 2
+    error = capsys.readouterr().err
+    assert "project root" in error
+    assert "before accessing hardware" in error
+
+
+def test_calibration_accepts_project_root(monkeypatch, tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'lampgo-test'\n", encoding="utf-8")
+    (tmp_path / "lampgo").mkdir()
+    (tmp_path / "lampgo" / "cli.py").touch()
+    monkeypatch.chdir(tmp_path)
+
+    assert cli._require_calibration_project_root() == tmp_path.resolve()
+
+
+def test_calibration_aborts_outside_a_lampgo_project(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli._require_calibration_project_root()
+
+    assert exc_info.value.code == 2
+    assert "project root" in capsys.readouterr().err
+
+
+def test_calibration_aborts_when_target_is_outside_project(monkeypatch, tmp_path, capsys):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli._require_calibration_path_in_project(project_root, tmp_path / "outside", "AL03")
+
+    assert exc_info.value.code == 2
+    assert "must stay inside" in capsys.readouterr().err
 
 
 def test_load_config_from_args_degrades_to_no_hw_when_motor_port_missing(monkeypatch, capsys):

--- a/tests/test_livekit_browser_lifecycle.py
+++ b/tests/test_livekit_browser_lifecycle.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+APP_JS = Path("lampgo/web/static/app.js")
+
+
+def _source() -> str:
+    return APP_JS.read_text(encoding="utf-8")
+
+
+def _section(source: str, start: str, end: str) -> str:
+    start_index = source.index(start)
+    return source[start_index : source.index(end, start_index)]
+
+
+def test_normal_livekit_hangup_waits_before_cleanup() -> None:
+    source = _source()
+    stop = _section(
+        source,
+        '  function stopBrowserLiveKitCall(reason = "manual", options = {}) {',
+        '  async function notifyLiveKitRoomEnded',
+    )
+
+    disconnect_index = stop.index("await disconnectBrowserLiveKitRoom(room);")
+    notify_index = stop.index("await notifyLiveKitRoomEnded(roomName, reason, clientCallId);")
+    finally_index = stop.index("})().finally(() => {")
+    cleanup_index = stop.index("cleanupBrowserLiveKitCall();", finally_index)
+
+    assert disconnect_index < notify_index < finally_index < cleanup_index
+    assert "if (browserCallHangupPromise) return browserCallHangupPromise;" in stop
+    assert 'setBrowserCallState("leaving");' in stop
+
+
+def test_livekit_disconnect_event_does_not_duplicate_active_hangup() -> None:
+    source = _source()
+    event_handler = _section(
+        source,
+        '        room.on("disconnected", () => {',
+        "        await room.connect(serverUrl, token);",
+    )
+
+    assert "browserCallDisconnectingRoom === room" in event_handler
+    assert "browserCallDisconnectPromises.has(room)" in event_handler
+    assert 'stopBrowserLiveKitCall("livekit_disconnected", {' in event_handler
+    assert "alreadyDisconnected: true" in event_handler
+
+
+def test_livekit_start_can_be_cancelled_during_each_async_stage() -> None:
+    source = _source()
+    start = _section(
+        source,
+        "  async function startBrowserLiveKitCall(options = {}) {",
+        "  async function scheduleHangupAfterTtsPlayout() {",
+    )
+
+    assert "browserCallJoiningRoom = room;" in start
+    assert start.count("throwIfBrowserCallStopRequested();") >= 4
+    assert "await disconnectBrowserLiveKitRoom(room);" in start
+    assert 'cancelled ? "start_cancelled" : "start_failed"' in start
+
+
+def test_livekit_room_end_uses_awaitable_fetch_and_beacon_only_for_page_exit() -> None:
+    source = _source()
+    notify = _section(
+        source,
+        "  async function notifyLiveKitRoomEnded",
+        "  function endBrowserLiveKitCallForPageExit() {",
+    )
+    page_exit = _section(
+        source,
+        "  function endBrowserLiveKitCallForPageExit() {",
+        "  function createCallSession() {",
+    )
+
+    assert "if (options.preferBeacon)" in notify
+    assert 'const response = await fetch("/api/livekit/room/end"' in notify
+    assert "CALL_END_NOTIFY_TIMEOUT_MS" in notify
+    assert "room.disconnect();" in page_exit
+    assert "{ preferBeacon: true }" in page_exit
+    assert 'window.addEventListener("pagehide", endBrowserLiveKitCallForPageExit);' in page_exit
+
+
+def test_all_non_unload_room_disconnects_use_the_serialized_helper() -> None:
+    source = _source()
+
+    # One call lives in the serialized helper; the other is the unavoidable
+    # synchronous best-effort path while the document is unloading.
+    assert source.count("room.disconnect()") == 2
+    assert "const browserCallDisconnectPromises = new WeakMap();" in source

--- a/uv.lock
+++ b/uv.lock
@@ -1146,6 +1146,7 @@ voice = [
     { name = "lampgo-livekit-agent-sdk" },
     { name = "livekit" },
     { name = "livekit-api" },
+    { name = "psutil" },
 ]
 
 [package.dev-dependencies]
@@ -1165,6 +1166,7 @@ requires-dist = [
     { name = "livekit-api", marker = "extra == 'voice'", specifier = ">=0.7" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "opencv-python", marker = "extra == 'perception'", specifier = ">=4.8" },
+    { name = "psutil", marker = "extra == 'voice'", specifier = ">=7.0" },
     { name = "pyautogui", marker = "extra == 'bridge'", specifier = ">=0.9" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyserial", specifier = ">=3.5" },


### PR DESCRIPTION
## What changed
- require calibration to run from the LampGo project root and keep calibration files inside the checkout
- safely detect and release stale LampGo LiveKit SDK listeners on TCP 18790 without terminating unknown processes
- serialize SDK startup/readiness failure handling and clean up failed subprocess groups
- make browser hangup await LiveKit disconnect, handle startup cancellation, and notify local room ownership on unload
- include psutil in the voice extra and add lifecycle regression tests

## Why
Stale SDK listeners could block local voice startup, while browser teardown did not consistently wait for LiveKit disconnect. Calibration could also resolve paths outside the intended checkout.

## Validation
- uv lock --check
- node --check lampgo/web/static/app.js
- uv run pytest: 282 passed
- targeted Ruff checks passed for the newly added and core modified Python files
- full touched-file Ruff still reports 23 pre-existing violations in lampgo/server.py and lampgo/web/gateway.py; none are on changed lines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 校准操作新增项目目录与输出路径安全校验，避免误访问硬件或将配置写入项目外部。
  - 语音服务启动失败时提供更明确的错误信息，并自动清理异常残留进程。
  - 优化语音通话的取消、挂断、页面退出和超时处理，降低通话卡住或重复结束的情况。
  - 页面关闭或切换时更可靠地释放通话资源并同步结束状态。

- **依赖**
  - 语音功能新增系统进程管理支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->