### PR TITLE
Fix fail-closed motor startup safety

### DIFF
--- a/lampgo/core/hal.py
+++ b/lampgo/core/hal.py
@@ -40,7 +40,13 @@ class HardwareAbstraction:
 
     _HOME_EDGE_MARGIN_RATIO = 0.15
     _MIN_VALID_RANGE_COUNTS = 80
-    _RECOVERY_LIMIT_MARGIN_COUNTS = 96
+    _MAX_VALID_RANGE_COUNTS = 3500
+    _MIN_NEUTRAL_MARGIN_RATIO = 0.10
+    _STARTUP_EDGE_MARGIN_RATIO = 0.05
+    _MIN_STARTUP_EDGE_MARGIN_COUNTS = 32
+    _NEUTRAL_CONFIRM_TOLERANCE_COUNTS = 128
+    _STS3215_MULTI_TURN_PHASE_BIT = 0x10
+    _CALIBRATION_SCHEMA_VERSION = 2
 
     def __init__(self, config: DeviceConfig) -> None:
         self._config = config
@@ -73,17 +79,29 @@ class HardwareAbstraction:
             motors=motors,
             calibration=calibration,
         )
-        self._bus.connect(handshake=False)
-        self._verify_expected_motors()
+        try:
+            self._bus.connect(handshake=False)
+            # A stale Goal_Position can become destructive as soon as torque is
+            # enabled. Make torque-off the first register operation after the
+            # serial port opens, before pinging or applying any calibration.
+            self._release_torque_for_manual_motion(strict=True)
+            self._verify_expected_motors()
 
-        if calibration:
-            logger.info("hal.calibration_loaded", lamp_id=self._config.lamp_id)
-        elif calibrate:
-            logger.info("Motor bus not calibrated — running interactive calibration")
-            self.calibrate()
+            if calibration:
+                logger.info("hal.calibration_loaded", lamp_id=self._config.lamp_id)
+            elif calibrate:
+                logger.info("Motor bus not calibrated — running interactive calibration")
+                self.calibrate()
 
-        if configure:
-            self._configure()
+            if configure:
+                self._configure()
+        except Exception:
+            try:
+                self._bus.disconnect(disable_torque=True)
+            except Exception:
+                logger.exception("hal.connect_cleanup_failed")
+            self._bus = None
+            raise
         self._connected = True
         logger.info("hal.connected", port=self._config.motor_port)
 
@@ -209,9 +227,13 @@ class HardwareAbstraction:
         if self._bus is None:
             logger.info("hal.enable_torque: stub mode")
             return
-        for motor in self._bus.motors:
-            self._safe_bus_write("Lock", motor, 1)
-            self._safe_bus_write("Torque_Enable", motor, 1)
+        # Re-run the complete fail-closed startup sequence. Recording can leave
+        # an arm at a range edge, and blindly restoring torque there is unsafe.
+        try:
+            self._configure()
+        except Exception:
+            self._release_torque_for_manual_motion(strict=False)
+            raise
         logger.info("hal.torque_enabled")
 
     def get_calibration_home(self) -> dict[str, float] | None:
@@ -246,6 +268,10 @@ class HardwareAbstraction:
         if self._bus is None:
             raise RuntimeError("Cannot calibrate in stub mode")
 
+        logger.info("calibration.preflight")
+        self._release_torque_for_manual_motion(strict=True)
+        changed_mode = self._ensure_sts3215_single_turn(list(self._bus.motors))
+
         existing = self._load_calibration()
         if existing:
             choice = input(
@@ -253,12 +279,19 @@ class HardwareAbstraction:
                 "or type 'c' to re-calibrate: "
             )
             if choice.strip().lower() != "c":
-                self._bus.write_calibration(existing)
+                if changed_mode:
+                    changed = ", ".join(sorted(changed_mode))
+                    raise RuntimeError(
+                        "STS3215 single-turn mode was repaired for "
+                        f"{changed}. The existing calibration cannot be reused; "
+                        "run calibration again and choose 'c'."
+                    )
+                self._require_single_turn_calibration_metadata(list(self._bus.motors))
+                self._apply_hardware_calibration(existing)
                 logger.info("calibration.loaded", lamp_id=self._config.lamp_id)
                 return
 
         logger.info("calibration.start")
-        self._release_torque_for_manual_motion(strict=True)
         for motor in self._bus.motors:
             self._write_register_or_raise("Operating_Mode", motor, OperatingMode.POSITION.value)
         self._open_manual_calibration_range()
@@ -293,6 +326,7 @@ class HardwareAbstraction:
 
         print("Move all joints through their full ranges of motion.\nPress ENTER to stop recording...")
         range_mins, range_maxes = self._bus.record_ranges_of_motion()
+        self._validate_recorded_calibration(neutral_raw, range_mins, range_maxes)
 
         calibration: dict[str, MotorCalibration] = {}
         for motor_name, m in self._bus.motors.items():
@@ -304,7 +338,8 @@ class HardwareAbstraction:
                 range_max=range_maxes[motor_name],
             )
 
-        self._bus.write_calibration(calibration)
+        self._apply_hardware_calibration(calibration)
+        self._wait_for_safe_neutral_pose(neutral_raw, calibration)
         self._save_calibration(calibration, neutral_raw=neutral_raw)
         logger.info("calibration.saved", lamp_id=self._config.lamp_id)
 
@@ -379,10 +414,17 @@ class HardwareAbstraction:
             logger.warning("hal.configure_skipped_all_motors")
             return
 
-        for motor in healthy_motors:
-            self._safe_bus_write("Torque_Enable", motor, 0)
-            self._safe_bus_write("Lock", motor, 0)
+        self._release_torque_for_manual_motion(strict=True)
 
+        changed_mode = self._ensure_sts3215_single_turn(healthy_motors)
+        if changed_mode:
+            changed = ", ".join(sorted(changed_mode))
+            raise RuntimeError(
+                "STS3215 single-turn mode was repaired for "
+                f"{changed}. Existing calibration is no longer trusted; "
+                "run `uv run lampgo calibrate` before enabling torque."
+            )
+        self._require_single_turn_calibration_metadata(healthy_motors)
         self._ensure_hardware_calibration()
 
         # Torque_Limit (0-1000) caps stall current for every motor.
@@ -397,17 +439,17 @@ class HardwareAbstraction:
             if getattr(self._bus, "protocol_version", None) == 0:
                 self._safe_bus_write("Maximum_Acceleration", motor, 50)
             self._safe_bus_write("Acceleration", motor, 50)
-            self._safe_bus_write("Operating_Mode", motor, OperatingMode.POSITION.value)
+            self._write_register_or_raise("Operating_Mode", motor, OperatingMode.POSITION.value)
             self._safe_bus_write("P_Coefficient", motor, 16)
             self._safe_bus_write("I_Coefficient", motor, 0)
             self._safe_bus_write("D_Coefficient", motor, 32)
-            self._safe_bus_write("Torque_Limit", motor, torque_limit_raw, normalize=False)
+            self._write_register_or_raise("Torque_Limit", motor, torque_limit_raw, normalize=False)
         logger.info("hal.torque_limit_set", pct=self._config.max_torque_pct, raw=torque_limit_raw)
 
         self._seed_goal_positions_to_present(healthy_motors)
         for motor in healthy_motors:
-            self._safe_bus_write("Lock", motor, 1)
-            self._safe_bus_write("Torque_Enable", motor, 1)
+            self._write_register_or_raise("Lock", motor, 1)
+            self._write_register_or_raise("Torque_Enable", motor, 1)
 
     def _safe_bus_write(
         self,
@@ -455,20 +497,157 @@ class HardwareAbstraction:
 
         try:
             actual = self._bus.read(data_name, motor, normalize=normalize)
-        except Exception:
-            logger.warning(
-                "hal.register_verify_read_failed",
-                motor=motor,
-                register=data_name,
-                expected=value,
-                exc_info=True,
-            )
-            return
+        except Exception as exc:
+            raise RuntimeError(
+                f"Cannot read back {data_name} for '{motor}' after writing {value!r}."
+            ) from exc
 
         if int(actual) != int(value):
             raise RuntimeError(
                 f"Cannot verify {data_name} for '{motor}': expected {value}, got {actual}."
             )
+
+    def _ensure_sts3215_single_turn(self, motors: list[str]) -> set[str]:
+        """Force STS3215 angle feedback into single-turn mode and verify it."""
+        if self._bus is None:
+            return set()
+
+        changed: set[str] = set()
+        for motor in motors:
+            motor_config = self._bus.motors[motor]
+            if getattr(motor_config, "model", "") != "sts3215":
+                continue
+
+            phase = int(self._bus.read("Phase", motor, normalize=False))
+            if phase & self._STS3215_MULTI_TURN_PHASE_BIT:
+                single_turn_phase = phase & ~self._STS3215_MULTI_TURN_PHASE_BIT
+                self._write_register_or_raise("Phase", motor, single_turn_phase, normalize=False)
+                changed.add(motor)
+                phase = int(self._bus.read("Phase", motor, normalize=False))
+
+            if phase & self._STS3215_MULTI_TURN_PHASE_BIT:
+                raise RuntimeError(
+                    f"Motor '{motor}' is still in unsafe STS3215 multi-turn feedback mode. "
+                    "Torque will remain disabled."
+                )
+
+        logger.info("hal.sts3215_single_turn_verified", motors=sorted(motors), changed=sorted(changed))
+        return changed
+
+    def _require_single_turn_calibration_metadata(self, motors: list[str]) -> None:
+        """Reject calibration captured before single-turn mode was verified."""
+        if self._bus is None or not self._bus.calibration:
+            return
+        if not any(getattr(self._bus.motors[motor], "model", "") == "sts3215" for motor in motors):
+            return
+
+        data = self._load_calibration_data() or {}
+        metadata = data.get("_meta", {}) if isinstance(data, dict) else {}
+        if not isinstance(metadata, dict) or metadata.get("sts3215_single_turn_verified") is not True:
+            raise RuntimeError(
+                "Calibration predates STS3215 single-turn safety verification. "
+                "Torque will remain disabled; run `uv run lampgo calibrate` to create a safe profile."
+            )
+
+    def _validate_recorded_calibration(
+        self,
+        neutral_raw: dict[str, float],
+        range_mins: dict[str, float],
+        range_maxes: dict[str, float],
+    ) -> None:
+        """Reject overflowed or severely off-centre ranges before hardware limits are written."""
+        if self._bus is None:
+            raise RuntimeError("Cannot validate calibration without a motor bus")
+
+        errors: list[str] = []
+        for motor, motor_config in self._bus.motors.items():
+            resolution_max = int(self._bus.model_resolution_table[motor_config.model]) - 1
+            neutral = int(neutral_raw[motor])
+            range_min = int(range_mins[motor])
+            range_max = int(range_maxes[motor])
+            span = range_max - range_min
+            margin = min(neutral - range_min, range_max - neutral)
+
+            if not (0 <= range_min < range_max <= resolution_max):
+                errors.append(
+                    f"{motor}: range {range_min}..{range_max} is outside single-turn 0..{resolution_max}"
+                )
+                continue
+            if span < self._MIN_VALID_RANGE_COUNTS or span > self._MAX_VALID_RANGE_COUNTS:
+                errors.append(f"{motor}: unsafe range span {span}")
+                continue
+            if margin < span * self._MIN_NEUTRAL_MARGIN_RATIO:
+                errors.append(
+                    f"{motor}: neutral {neutral} is too close to range edge {range_min}..{range_max}"
+                )
+
+        if errors:
+            raise RuntimeError(
+                "Unsafe calibration rejected before motor limits were written:\n- " + "\n- ".join(errors)
+            )
+
+    def _validate_neutral_return(
+        self,
+        neutral_raw: dict[str, float],
+        final_raw: dict[str, float],
+    ) -> None:
+        """Require the arm to be returned near its recorded neutral before saving."""
+        errors: list[str] = []
+        for motor, neutral in neutral_raw.items():
+            if motor not in final_raw:
+                errors.append(f"{motor}: final position could not be read")
+                continue
+            final = int(final_raw[motor])
+            if abs(final - int(neutral)) > self._NEUTRAL_CONFIRM_TOLERANCE_COUNTS:
+                errors.append(f"{motor}: expected near {int(neutral)}, got {final}")
+        if errors:
+            raise RuntimeError(
+                "Arm is not close to its recorded neutral pose:\n- " + "\n- ".join(errors)
+            )
+
+    def _wait_for_safe_neutral_pose(
+        self,
+        neutral_raw: dict[str, float],
+        calibration: dict[str, Any],
+    ) -> dict[str, float]:
+        """Keep torque off and let the user correct the final pose without recalibrating."""
+        if self._bus is None:
+            raise RuntimeError("Cannot confirm neutral pose without a motor bus")
+
+        while True:
+            input(
+                "Move every joint to a safe supported pose, preferably the recorded neutral pose; "
+                "do not leave a joint at its range limit. Press ENTER to verify..."
+            )
+            final_raw = self._bus.sync_read(
+                "Present_Position",
+                list(self._bus.motors),
+                normalize=False,
+            )
+            try:
+                self._validate_startup_positions(final_raw, calibration=calibration)
+            except RuntimeError as exc:
+                print(
+                    f"{exc}\nCalibration has not been saved yet. "
+                    "Torque remains disabled; reposition the reported joint and try again."
+                )
+                continue
+            try:
+                self._validate_neutral_return(neutral_raw, final_raw)
+            except RuntimeError as exc:
+                # Exact neutral is a convenience for the subsequent return_safe
+                # motion, not a prerequisite for safely enabling torque. A pose
+                # well inside every calibrated limit is safe to save and hold.
+                logger.warning(
+                    "calibration.final_pose_away_from_neutral",
+                    detail=str(exc),
+                    final_raw={motor: int(raw) for motor, raw in final_raw.items()},
+                )
+                print(
+                    f"Warning: {exc}\nThe pose is safely inside all calibrated limits, "
+                    "so calibration will be saved."
+                )
+            return final_raw
 
     def _release_torque_for_manual_motion(self, *, strict: bool) -> None:
         """Release every motor before hand-guided calibration/recording.
@@ -542,18 +721,21 @@ class HardwareAbstraction:
     def _ensure_hardware_calibration(self) -> None:
         if self._bus is None or not self._bus.calibration:
             return
-        try:
-            if self._bus.is_calibrated:
-                logger.info("hal.calibration_already_active", lamp_id=self._config.lamp_id)
-                return
-            self._bus.write_calibration(self._bus.calibration)
-            logger.info("hal.calibration_applied", lamp_id=self._config.lamp_id)
-        except Exception:
-            logger.warning(
-                "hal.calibration_apply_failed",
-                lamp_id=self._config.lamp_id,
-                exc_info=True,
+        if self._bus.is_calibrated:
+            logger.info("hal.calibration_already_active", lamp_id=self._config.lamp_id)
+            return
+        self._apply_hardware_calibration(self._bus.calibration)
+
+    def _apply_hardware_calibration(self, calibration: dict[str, Any]) -> None:
+        """Write calibration and refuse torque unless every register reads back."""
+        if self._bus is None:
+            raise RuntimeError("Cannot apply calibration without a motor bus")
+        self._bus.write_calibration(calibration)
+        if not self._bus.is_calibrated:
+            raise RuntimeError(
+                "Motor calibration register verification failed. Torque will remain disabled."
             )
+        logger.info("hal.calibration_applied", lamp_id=self._config.lamp_id)
 
     def _seed_goal_positions_to_present(self, motors: list[str]) -> None:
         if self._bus is None or not motors:
@@ -570,51 +752,73 @@ class HardwareAbstraction:
                 except Exception:
                     logger.warning("hal.goal_seed_read_failed", motor=motor, exc_info=True)
 
-        if not present_raw:
-            logger.warning("hal.goal_seed_no_present_position", motors=motors)
-            return
+        missing = [motor for motor in motors if motor not in present_raw]
+        if missing:
+            raise RuntimeError(f"Cannot safely seed Goal_Position; missing Present_Position for {missing}.")
 
-        self._expand_hardware_limits_to_present(present_raw)
+        for motor, raw in present_raw.items():
+            motor_config = self._bus.motors[motor]
+            resolution_max = int(self._bus.model_resolution_table[motor_config.model]) - 1
+            if not 0 <= int(raw) <= resolution_max:
+                raise RuntimeError(
+                    f"Unsafe Present_Position for '{motor}': {int(raw)} is outside 0..{resolution_max}. "
+                    "Torque will remain disabled."
+                )
+
+        self._validate_startup_positions(present_raw)
 
         seeded: dict[str, int] = {}
-        failed: list[str] = []
         for motor, raw in present_raw.items():
             raw_int = int(raw)
-            if self._safe_bus_write("Goal_Position", motor, raw_int, normalize=False):
-                seeded[motor] = raw_int
-            else:
-                failed.append(motor)
+            self._write_register_or_raise("Goal_Position", motor, raw_int, normalize=False)
+            seeded[motor] = raw_int
 
         if seeded:
             logger.info("hal.goal_seeded_to_present", present_raw=seeded)
-        if failed:
-            logger.warning("hal.goal_seed_failed", motors=failed)
 
-    def _expand_hardware_limits_to_present(self, present_raw: dict[str, float]) -> None:
-        if self._bus is None or not self._bus.calibration:
+    def _validate_startup_positions(
+        self,
+        present_raw: dict[str, float],
+        *,
+        calibration: dict[str, Any] | None = None,
+    ) -> None:
+        """Refuse to energize a joint outside or too close to a calibrated stop."""
+        if self._bus is None:
+            raise RuntimeError("Cannot validate startup positions without a motor bus")
+        active_calibration = calibration if calibration is not None else self._bus.calibration
+        if not active_calibration:
             return
 
+        errors: list[str] = []
         for motor, raw in present_raw.items():
-            cal = self._bus.calibration.get(motor)
+            cal = active_calibration.get(motor)
             if cal is None:
+                errors.append(f"{motor}: calibration is missing")
                 continue
 
             raw_int = int(raw)
-            recovery_min = max(0, min(cal.range_min, raw_int - self._RECOVERY_LIMIT_MARGIN_COUNTS))
-            recovery_max = min(4095, max(cal.range_max, raw_int + self._RECOVERY_LIMIT_MARGIN_COUNTS))
-            if recovery_min == cal.range_min and recovery_max == cal.range_max:
-                continue
+            range_min = int(cal.range_min)
+            range_max = int(cal.range_max)
+            span = range_max - range_min
+            margin = min(raw_int - range_min, range_max - raw_int)
+            required_margin = max(
+                self._MIN_STARTUP_EDGE_MARGIN_COUNTS,
+                int(span * self._STARTUP_EDGE_MARGIN_RATIO),
+            )
+            if raw_int < range_min or raw_int > range_max:
+                errors.append(
+                    f"{motor}: position {raw_int} is outside calibrated range {range_min}..{range_max}"
+                )
+            elif margin < required_margin:
+                errors.append(
+                    f"{motor}: position {raw_int} is only {margin} counts from calibrated limit "
+                    f"{range_min}..{range_max} (need at least {required_margin})"
+                )
 
-            self._safe_bus_write("Min_Position_Limit", motor, recovery_min, normalize=False)
-            self._safe_bus_write("Max_Position_Limit", motor, recovery_max, normalize=False)
-            logger.warning(
-                "hal.recovery_limits_expanded",
-                motor=motor,
-                present_raw=raw_int,
-                range_min=cal.range_min,
-                range_max=cal.range_max,
-                recovery_min=recovery_min,
-                recovery_max=recovery_max,
+        if errors:
+            raise RuntimeError(
+                "Unsafe startup pose; torque will remain disabled. Support the structure, move each "
+                "reported joint away from its hard stop, then retry:\n- " + "\n- ".join(errors)
             )
 
     def _calibration_path(self) -> Any:
@@ -689,7 +893,12 @@ class HardwareAbstraction:
 
         path = self._calibration_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        data = {}
+        data = {
+            "_meta": {
+                "schema_version": self._CALIBRATION_SCHEMA_VERSION,
+                "sts3215_single_turn_verified": True,
+            }
+        }
         for name, cal in calibration.items():
             data[name] = {
                 "id": cal.id,

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -140,6 +140,7 @@ class LampgoServer:
         self._last_foreground_activity_at = time.monotonic()
         self._next_idle_sway_at = 0.0
         self._auto_idle_sway_invoking = False
+        self._hal_startup_error: str | None = None
         self._started = False
         self.events.subscribe(SkillStarted, self._on_skill_started)
 
@@ -1462,6 +1463,8 @@ class LampgoServer:
         virtual = bool(getattr(self.motion, "is_virtual", False))
         if not self.hal.is_connected and not virtual:
             health = "disconnected"
+        if self._hal_startup_error:
+            health = "degraded"
         cat_teaser_camera = self._cat_teaser_camera_status()
         camera_ready = self._cat_teaser_camera_ready(cat_teaser_camera)
         return {
@@ -1477,6 +1480,7 @@ class LampgoServer:
                 "estop_reason": self.safety.last_estop_reason,
                 "recording": self._record_status(),
                 "hal_connected": bool(self.hal.is_connected),
+                "hardware_error": self._hal_startup_error,
                 "led_ready": bool(self.led.is_connected),
                 "camera_ready": camera_ready,
                 "cat_teaser_camera": cat_teaser_camera,
@@ -1926,6 +1930,8 @@ class LampgoServer:
             try:
                 self.hal.connect()
             except Exception as exc:  # noqa: BLE001
+                self._hal_startup_error = str(exc)
+                self.executor.set_motion_block_reason(self._hal_startup_error)
                 logger.warning(
                     "server.hal_connect_failed_degrading_to_no_hw",
                     motor_port=self.config.device.motor_port,
@@ -1941,6 +1947,8 @@ class LampgoServer:
                 self.config.home_on_start = False
                 self._use_virtual_motion()
             else:
+                self._hal_startup_error = None
+                self.executor.set_motion_block_reason(None)
                 try:
                     self.led.connect()
                 except Exception as exc:  # noqa: BLE001
@@ -2001,6 +2009,8 @@ class LampgoServer:
 
             self.hal = HardwareAbstraction(self.config.device)
             if not port:
+                self._hal_startup_error = None
+                self.executor.set_motion_block_reason(None)
                 self.config.no_hw = True
                 self._use_virtual_motion()
                 logger.info("server.motor_runtime_reload_virtual", reason="empty_motor_port")
@@ -2020,6 +2030,8 @@ class LampgoServer:
                 except Exception:
                     pass
                 self.hal = HardwareAbstraction(self.config.device)
+                self._hal_startup_error = str(exc)
+                self.executor.set_motion_block_reason(self._hal_startup_error)
                 self.config.no_hw = True
                 self._use_virtual_motion()
                 logger.warning(
@@ -2036,6 +2048,8 @@ class LampgoServer:
                 }
 
             self.hal = new_hal
+            self._hal_startup_error = None
+            self.executor.set_motion_block_reason(None)
             self.motion = MotionRuntime(self.hal, self.safety, self.config.motion)
             self.config.no_hw = False
             self.motion.start()

--- a/lampgo/skills/executor.py
+++ b/lampgo/skills/executor.py
@@ -43,6 +43,16 @@ class SkillExecutor:
         self._current_task: asyncio.Task | None = None
         self._current_skill: Skill | None = None
         self._current_invocation_id: str | None = None
+        self._motion_block_reason: str | None = None
+
+    def set_motion_block_reason(self, reason: str | None) -> None:
+        """Block physical motion skills after a failed hardware startup.
+
+        Explicit ``--no-hw`` sessions leave this unset and may still use the
+        virtual runtime for simulation. A hardware failure must never be
+        presented as a successful virtual movement.
+        """
+        self._motion_block_reason = reason
 
     async def invoke(self, skill_id: str, ctx: SkillContext, **params) -> InvokeResult:
         invocation_id = uuid.uuid4().hex[:12]
@@ -54,6 +64,19 @@ class SkillExecutor:
                 status="rejected",
                 error_code="unknown_skill",
                 error_detail=f"Skill '{skill_id}' not registered",
+            )
+
+        if skill_id in _MOTION_SKILLS and self._motion_block_reason:
+            logger.warning(
+                "executor.motion_blocked_hardware_unavailable",
+                skill_id=skill_id,
+                reason=self._motion_block_reason,
+            )
+            return InvokeResult(
+                invocation_id=invocation_id,
+                status="rejected",
+                error_code="motor_hardware_unavailable",
+                error_detail=self._motion_block_reason,
             )
 
         # Hardware not connected → return fake ok to prevent LLM retry loops

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -255,6 +255,19 @@ def test_no_hw_server_uses_virtual_motion_for_skills(tmp_path):
     asyncio.run(run())
 
 
+def test_server_status_exposes_hardware_startup_error() -> None:
+    from lampgo.core.config import LampgoConfig
+    from lampgo.server import LampgoServer
+
+    server = LampgoServer(LampgoConfig(no_hw=True))
+    server._hal_startup_error = "Unsafe startup pose; torque remains disabled"
+
+    status = server._handle_status()["result"]
+
+    assert status["device_health"] == "degraded"
+    assert status["hardware_error"] == "Unsafe startup pose; torque remains disabled"
+
+
 def test_cmd_ping_reports_status_error(monkeypatch, capsys):
     args = argparse.Namespace(port="/dev/tty.test", config=None)
 

--- a/tests/test_hal.py
+++ b/tests/test_hal.py
@@ -7,18 +7,86 @@ from types import SimpleNamespace
 import pytest
 
 
+class _SafetyFakeBus:
+    def __init__(
+        self,
+        *,
+        phase: int = 0,
+        present: int = 1800,
+        calibration=None,
+        ignore_phase_write: bool = False,
+        ignore_goal_write: bool = False,
+    ) -> None:
+        self.motors = {"base_pitch": SimpleNamespace(model="sts3215")}
+        self.model_resolution_table = {"sts3215": 4096}
+        self.protocol_version = 0
+        self.calibration = calibration or {}
+        self.present = present
+        self.ignore_phase_write = ignore_phase_write
+        self.ignore_goal_write = ignore_goal_write
+        self.values = {
+            ("Phase", "base_pitch"): phase,
+            ("Torque_Enable", "base_pitch"): 0,
+            ("Lock", "base_pitch"): 0,
+            ("Goal_Position", "base_pitch"): present - 1,
+        }
+        self.writes: list[tuple[str, str, int, bool]] = []
+
+    @property
+    def is_calibrated(self) -> bool:
+        return True
+
+    def write(
+        self,
+        data_name: str,
+        motor: str,
+        value: int,
+        *,
+        normalize: bool = True,
+        num_retry: int = 0,
+    ) -> None:
+        del num_retry
+        self.writes.append((data_name, motor, value, normalize))
+        if data_name == "Phase" and self.ignore_phase_write:
+            return
+        if data_name == "Goal_Position" and self.ignore_goal_write:
+            return
+        self.values[(data_name, motor)] = value
+
+    def read(self, data_name: str, motor: str, *, normalize: bool = True) -> int:
+        del normalize
+        if data_name == "Present_Position":
+            return self.present
+        return self.values[(data_name, motor)]
+
+    def sync_read(self, data_name: str, motors: list[str], *, normalize: bool = True) -> dict[str, int]:
+        assert data_name == "Present_Position"
+        assert motors == ["base_pitch"]
+        assert normalize is False
+        return {"base_pitch": self.present}
+
+    def disable_torque(self, motors: list[str], num_retry: int = 0) -> None:
+        del num_retry
+        for motor in motors:
+            self.values[("Torque_Enable", motor)] = 0
+
+    def write_calibration(self, calibration) -> None:
+        self.calibration = calibration
+
+
 def test_hal_configure_seeds_goal_position_before_enabling_torque() -> None:
     from lampgo.core.config import DeviceConfig
     from lampgo.core.hal import HardwareAbstraction
 
     class FakeBus:
         def __init__(self) -> None:
-            self.motors = {"base_pitch": object()}
+            self.motors = {"base_pitch": SimpleNamespace(model="dummy")}
+            self.model_resolution_table = {"dummy": 4096}
             self.protocol_version = 0
             self.calibration = {}
             self.writes: list[tuple[str, str, int, bool]] = []
             self.reads: list[tuple[str, str, bool]] = []
-            self.goals: dict[str, int] = {}
+            self.values: dict[tuple[str, str], int] = {}
 
         def write(
             self,
@@ -30,17 +98,15 @@ def test_hal_configure_seeds_goal_position_before_enabling_torque() -> None:
             num_retry: int = 0,
         ) -> None:
             self.writes.append((data_name, motor, value, normalize))
-            if data_name == "Goal_Position":
-                self.goals[motor] = value
+            self.values[(data_name, motor)] = value
 
         def read(self, data_name: str, motor: str, *, normalize: bool = True) -> int:
             self.reads.append((data_name, motor, normalize))
             assert motor == "base_pitch"
-            assert normalize is False
-            if data_name == "Goal_Position":
-                return self.goals[motor]
-            assert data_name == "Present_Position"
-            return 1739
+            if data_name == "Present_Position":
+                assert normalize is False
+                return 1739
+            return self.values[(data_name, motor)]
 
         def sync_read(self, data_name: str, motors: list[str], *, normalize: bool = True) -> dict[str, int]:
             assert data_name == "Present_Position"
@@ -48,6 +114,11 @@ def test_hal_configure_seeds_goal_position_before_enabling_torque() -> None:
             assert normalize is False
             self.reads.append((data_name, "base_pitch", normalize))
             return {"base_pitch": 1739}
+
+        def disable_torque(self, motors: list[str], num_retry: int = 0) -> None:
+            del num_retry
+            for motor in motors:
+                self.values[("Torque_Enable", motor)] = 0
 
     hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
     bus = FakeBus()
@@ -65,19 +136,20 @@ def test_hal_configure_seeds_goal_position_before_enabling_torque() -> None:
     assert disable_idx < seed_idx < torque_idx
 
 
-def test_hal_configure_expands_limits_and_holds_when_present_outside_calibration_range() -> None:
+def test_hal_configure_refuses_present_position_outside_calibration_range() -> None:
     from lampgo.core.config import DeviceConfig
     from lampgo.core.hal import HardwareAbstraction
 
     class FakeBus:
         def __init__(self) -> None:
-            self.motors = {"base_pitch": object()}
+            self.motors = {"base_pitch": SimpleNamespace(model="dummy")}
+            self.model_resolution_table = {"dummy": 4096}
             self.protocol_version = 0
             self.calibration = {
                 "base_pitch": SimpleNamespace(range_min=1739, range_max=3094, homing_offset=-562)
             }
             self.writes: list[tuple[str, str, int, bool]] = []
-            self.goals: dict[str, int] = {}
+            self.values: dict[tuple[str, str], int] = {}
 
         @property
         def is_calibrated(self) -> bool:
@@ -93,33 +165,36 @@ def test_hal_configure_expands_limits_and_holds_when_present_outside_calibration
             num_retry: int = 0,
         ) -> None:
             self.writes.append((data_name, motor, value, normalize))
-            if data_name == "Goal_Position":
-                self.goals[motor] = value
+            self.values[(data_name, motor)] = value
 
         def read(self, data_name: str, motor: str, *, normalize: bool = True) -> int:
             assert motor == "base_pitch"
-            assert normalize is False
-            if data_name == "Goal_Position":
-                return self.goals[motor]
-            assert data_name == "Present_Position"
-            return 540
+            if data_name == "Present_Position":
+                assert normalize is False
+                return 540
+            return self.values[(data_name, motor)]
 
         def sync_read(self, data_name: str, motors: list[str], *, normalize: bool = True) -> dict[str, int]:
             assert data_name == "Present_Position"
             assert normalize is False
             return {"base_pitch": 540}
 
+        def disable_torque(self, motors: list[str], num_retry: int = 0) -> None:
+            del num_retry
+            for motor in motors:
+                self.values[("Torque_Enable", motor)] = 0
+
     hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
     bus = FakeBus()
     hal._bus = bus
 
-    hal._configure()
+    with pytest.raises(RuntimeError, match="outside calibrated range"):
+        hal._configure()
 
-    assert ("Min_Position_Limit", "base_pitch", 444, False) in bus.writes
-    assert ("Goal_Position", "base_pitch", 540, False) in bus.writes
     assert ("Torque_Limit", "base_pitch", 800, False) in bus.writes
     assert ("Torque_Enable", "base_pitch", 0, True) in bus.writes
-    assert ("Torque_Enable", "base_pitch", 1, True) in bus.writes
+    assert ("Goal_Position", "base_pitch", 540, False) not in bus.writes
+    assert ("Torque_Enable", "base_pitch", 1, True) not in bus.writes
 
 
 def test_hal_calibration_home_uses_saved_neutral_degrees() -> None:
@@ -272,3 +347,194 @@ def test_hal_opens_full_manual_calibration_range_before_user_moves() -> None:
     assert ("Homing_Offset", "elbow_pitch", 0, False, 3) in bus.writes
     assert ("Min_Position_Limit", "elbow_pitch", 0, False, 3) in bus.writes
     assert ("Max_Position_Limit", "elbow_pitch", 4095, False, 3) in bus.writes
+
+
+def test_hal_clears_sts3215_multi_turn_phase_bit_and_preserves_other_bits() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = _SafetyFakeBus(phase=0x13)
+    hal._bus = bus
+
+    changed = hal._ensure_sts3215_single_turn(["base_pitch"])
+
+    assert changed == {"base_pitch"}
+    assert bus.values[("Phase", "base_pitch")] == 0x03
+    assert ("Phase", "base_pitch", 0x03, False) in bus.writes
+
+
+def test_hal_refuses_torque_when_sts3215_phase_bit_cannot_be_cleared() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = _SafetyFakeBus(phase=0x10, ignore_phase_write=True)
+    hal._bus = bus
+
+    with pytest.raises(RuntimeError, match="Cannot verify Phase"):
+        hal._configure()
+
+    assert ("Torque_Enable", "base_pitch", 1, True) not in bus.writes
+
+
+def test_hal_refuses_legacy_calibration_without_single_turn_metadata() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    calibration = {
+        "base_pitch": SimpleNamespace(range_min=1296, range_max=2279, homing_offset=1849)
+    }
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = _SafetyFakeBus(calibration=calibration)
+    hal._bus = bus
+    hal._load_calibration_data = lambda: {"base_pitch": {"range_min": 1296, "range_max": 2279}}
+
+    with pytest.raises(RuntimeError, match="predates STS3215 single-turn"):
+        hal._configure()
+
+    assert ("Torque_Enable", "base_pitch", 1, True) not in bus.writes
+
+
+def test_hal_refuses_startup_at_calibrated_edge_from_incident_log() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    calibration = {
+        "base_pitch": SimpleNamespace(range_min=1296, range_max=2279, homing_offset=1849)
+    }
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = _SafetyFakeBus(present=2276, calibration=calibration)
+    hal._bus = bus
+    hal._load_calibration_data = lambda: {
+        "_meta": {"schema_version": 2, "sts3215_single_turn_verified": True},
+        "base_pitch": {"range_min": 1296, "range_max": 2279},
+    }
+
+    with pytest.raises(RuntimeError, match="only 3 counts from calibrated limit"):
+        hal._configure()
+
+    assert ("Goal_Position", "base_pitch", 2276, False) not in bus.writes
+    assert ("Torque_Enable", "base_pitch", 1, True) not in bus.writes
+
+
+def test_hal_refuses_torque_when_seeded_goal_does_not_read_back() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = _SafetyFakeBus(ignore_goal_write=True)
+    hal._bus = bus
+
+    with pytest.raises(RuntimeError, match="Cannot verify Goal_Position"):
+        hal._configure()
+
+    assert ("Torque_Enable", "base_pitch", 1, True) not in bus.writes
+
+
+def test_hal_rejects_overflowed_and_edge_neutral_calibration() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    hal._bus = _SafetyFakeBus()
+
+    with pytest.raises(RuntimeError, match="outside single-turn"):
+        hal._validate_recorded_calibration(
+            {"base_pitch": 2047},
+            {"base_pitch": 1296},
+            {"base_pitch": 5000},
+        )
+
+    with pytest.raises(RuntimeError, match="too close to range edge"):
+        hal._validate_recorded_calibration(
+            {"base_pitch": 2276},
+            {"base_pitch": 1296},
+            {"base_pitch": 2279},
+        )
+
+
+def test_hal_final_neutral_confirmation_retries_without_discarding_calibration(
+    monkeypatch, capsys
+) -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    calibration = {
+        "base_pitch": SimpleNamespace(range_min=1429, range_max=2158, homing_offset=0)
+    }
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = _SafetyFakeBus(calibration=calibration)
+    positions = iter([2149, 2051])
+    prompts: list[str] = []
+
+    def sync_read(data_name: str, motors: list[str], *, normalize: bool = True) -> dict[str, int]:
+        assert data_name == "Present_Position"
+        assert motors == ["base_pitch"]
+        assert normalize is False
+        return {"base_pitch": next(positions)}
+
+    bus.sync_read = sync_read
+    hal._bus = bus
+    monkeypatch.setattr("builtins.input", lambda prompt: prompts.append(prompt) or "")
+
+    final_raw = hal._wait_for_safe_neutral_pose({"base_pitch": 2051}, calibration)
+
+    assert final_raw == {"base_pitch": 2051}
+    assert len(prompts) == 2
+    assert "only 9 counts from calibrated limit" in capsys.readouterr().out
+
+
+def test_hal_final_pose_inside_limits_saves_even_when_not_exactly_neutral(
+    monkeypatch, capsys
+) -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    calibration = {
+        "elbow_pitch": SimpleNamespace(range_min=1422, range_max=2776, homing_offset=0)
+    }
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = _SafetyFakeBus()
+    bus.motors = {"elbow_pitch": SimpleNamespace(model="sts3215")}
+    bus.calibration = calibration
+    bus.sync_read = lambda *args, **kwargs: {"elbow_pitch": 2198}
+    hal._bus = bus
+    prompts: list[str] = []
+    monkeypatch.setattr("builtins.input", lambda prompt: prompts.append(prompt) or "")
+
+    final_raw = hal._wait_for_safe_neutral_pose({"elbow_pitch": 2047}, calibration)
+
+    assert final_raw == {"elbow_pitch": 2198}
+    assert len(prompts) == 1
+    output = capsys.readouterr().out
+    assert "not close to its recorded neutral pose" in output
+    assert "calibration will be saved" in output
+
+
+def test_hal_saved_calibration_marks_single_turn_verification(tmp_path) -> None:
+    import json
+
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    hal = HardwareAbstraction(
+        DeviceConfig(motor_port="/dev/null", lamp_id="TEST", calibration_dir=tmp_path)
+    )
+    calibration = {
+        "base_pitch": SimpleNamespace(
+            id=2,
+            drive_mode=0,
+            homing_offset=1849,
+            range_min=1296,
+            range_max=2279,
+        )
+    }
+
+    hal._save_calibration(calibration, neutral_raw={"base_pitch": 2047})
+
+    data = json.loads((tmp_path / "TEST.json").read_text())
+    assert data["_meta"] == {
+        "schema_version": 2,
+        "sts3215_single_turn_verified": True,
+    }

--- a/tests/test_motion_skills.py
+++ b/tests/test_motion_skills.py
@@ -97,6 +97,33 @@ def test_executor_preempts_running_skill():
     asyncio.run(run())
 
 
+def test_executor_rejects_virtual_motion_after_hardware_startup_failure() -> None:
+    class FakeReturnSafe(Skill):
+        skill_id = "return_safe"
+
+        async def execute(self, ctx, **params):
+            del ctx, params
+            raise AssertionError("blocked motion must not execute")
+
+    async def run() -> None:
+        registry = SkillRegistry()
+        registry.register(FakeReturnSafe())
+        executor = SkillExecutor(registry, EventBus())
+        executor.set_motion_block_reason("Unsafe startup pose; torque remains disabled")
+        ctx = SimpleNamespace(
+            motion=SimpleNamespace(is_running=True, is_virtual=True),
+            led=SimpleNamespace(is_connected=False),
+        )
+
+        result = await executor.invoke("return_safe", ctx)
+
+        assert result.status == "rejected"
+        assert result.error_code == "motor_hardware_unavailable"
+        assert result.error_detail == "Unsafe startup pose; torque remains disabled"
+
+    asyncio.run(run())
+
+
 class _HangingSkill(Skill):
     skill_id = "first"
     description = "hang until cancelled"


### PR DESCRIPTION
## Summary

- disable and verify torque before calibration or motor configuration
- enforce STS3215 single-turn mode and reject stale or unverified calibration
- validate recorded and startup ranges, then seed Goal_Position from verified Present_Position before enabling torque
- preserve hardware startup failures and reject motion skills instead of reporting virtual success

## Root cause

Motor startup previously accepted unverified register writes and could widen limits around unsafe positions. When hardware startup failed, the server could degrade to virtual motion, so `return_safe` could misleadingly report success without powering the motors.

## Validation

- `uv run pytest -q` — 300 passed
- targeted `uv run ruff check`
- `git diff --check`

## Scope

This PR contains only the motor startup, calibration, server error propagation, motion-skill guard, and associated test changes. Local device calibration data and unrelated docs, installer, CI, and voice changes are intentionally excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **安全性改进**
  * 加强电机启动、校准和上电前的安全检查，异常时保持扭矩关闭。
  * 拒绝使用缺少安全元数据、范围不安全或姿态异常的校准数据。
  * 增加中性姿态确认，降低校准保存风险。

* **状态与错误提示**
  * 硬件启动或重连失败时显示降级状态及硬件错误信息。
  * 硬件不可用时阻止运动技能执行，并返回明确的错误原因。

* **测试**
  * 新增硬件故障、校准安全性及运动阻断场景的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->