### PR TITLE
fix: stabilize motor recovery and idle sway

### DIFF
--- a/lampgo/core/hal.py
+++ b/lampgo/core/hal.py
@@ -10,7 +10,9 @@ GPL-3.0. Low-level Feetech transport is provided by lerobot.
 
 from __future__ import annotations
 
+import math
 import time
+from enum import StrEnum
 from pprint import pformat
 from typing import Any
 
@@ -31,6 +33,16 @@ except ImportError:
     logger.warning("lerobot not installed — HAL will use stub mode")
 
 
+class MotorStartupState(StrEnum):
+    """Torque/startup disposition for the physical motor bus."""
+
+    DISCONNECTED = "disconnected"
+    READY = "ready"
+    RECOVERY_REQUIRED = "recovery_required"
+    RECOVERING = "recovering"
+    HARD_FAULT = "hard_fault"
+
+
 class HardwareAbstraction:
     """Thin wrapper around the Feetech motor bus.
 
@@ -47,12 +59,32 @@ class HardwareAbstraction:
     _NEUTRAL_CONFIRM_TOLERANCE_COUNTS = 128
     _STS3215_MULTI_TURN_PHASE_BIT = 0x10
     _CALIBRATION_SCHEMA_VERSION = 2
+    _RECOVERY_STABLE_SAMPLE_COUNT = 5
+    _RECOVERY_STABLE_SAMPLE_INTERVAL_S = 0.02
+    _RECOVERY_STABLE_SPREAD_COUNTS = 8
+    _RECOVERY_MAX_FRAME_STEP_COUNTS = 8
+    # Recovery must be strong enough to lift the arm under gravity.  These are
+    # still well below the normal acceleration profile, but no longer limit an
+    # STS3215 to the near-stall crawl used by the first recovery prototype.
+    _RECOVERY_ACCELERATION_RAW = 5
+    _RECOVERY_SPEED_RAW = 8
+    _NORMAL_ACCELERATION_RAW = 50
+    # Calibration limits describe the normal user-recorded operating range,
+    # not every pose a torque-free linkage can reach under gravity. Permit a
+    # one-way recovery from at most one quarter-turn beyond that range while
+    # staying clear of the absolute encoder wrap boundary.
+    _RECOVERY_MAX_OUTSIDE_RANGE_RATIO = 0.25
+    _RECOVERY_ENCODER_WRAP_GUARD_RATIO = 1 / 64
 
     def __init__(self, config: DeviceConfig) -> None:
         self._config = config
         self._bus: Any | None = None
         self._connected = False
         self._status_error_motors: set[str] = set()
+        self._startup_state = MotorStartupState.DISCONNECTED
+        self._recovery_reason: str | None = None
+        self._recovery_expanded_limit_motors: set[str] = set()
+        self._recovery_profile_motors: set[str] = set()
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -65,13 +97,11 @@ class HardwareAbstraction:
         if not LEROBOT_AVAILABLE:
             logger.info("hal.connect: stub mode (no lerobot)")
             self._connected = True
+            self._startup_state = MotorStartupState.READY
             return
 
         norm_mode = MotorNormMode.DEGREES if self._config.use_degrees else MotorNormMode.RANGE_M100_100
-        motors = {
-            name: Motor(mc.id, mc.model, norm_mode)
-            for name, mc in self._config.motors.items()
-        }
+        motors = {name: Motor(mc.id, mc.model, norm_mode) for name, mc in self._config.motors.items()}
         calibration = self._load_calibration()
 
         self._bus = FeetechMotorsBus(
@@ -94,8 +124,11 @@ class HardwareAbstraction:
                 self.calibrate()
 
             if configure:
-                self._configure()
+                self._startup_state = self._configure()
+            else:
+                self._startup_state = MotorStartupState.READY
         except Exception:
+            self._startup_state = MotorStartupState.HARD_FAULT
             try:
                 self._bus.disconnect(disable_torque=True)
             except Exception:
@@ -103,13 +136,21 @@ class HardwareAbstraction:
             self._bus = None
             raise
         self._connected = True
-        logger.info("hal.connected", port=self._config.motor_port)
+        logger.info(
+            "hal.connected",
+            port=self._config.motor_port,
+            startup_state=self._startup_state.value,
+        )
 
     def disconnect(self) -> None:
         if not self._connected:
             return
         if self._bus is not None:
             try:
+                if self._recovery_expanded_limit_motors or self._recovery_profile_motors:
+                    self._release_torque_for_manual_motion(strict=False)
+                    self._restore_normal_motion_profile(strict=False)
+                    self._restore_calibrated_hardware_limits(strict=False)
                 self._bus.disconnect(self._config.disable_torque_on_disconnect)
             except Exception:
                 logger.exception("hal.disconnect_error")
@@ -120,11 +161,33 @@ class HardwareAbstraction:
         self._connected = False
         self._status_error_motors.clear()
         self._bus = None
+        self._startup_state = MotorStartupState.DISCONNECTED
+        self._recovery_reason = None
+        self._recovery_expanded_limit_motors.clear()
+        self._recovery_profile_motors.clear()
         logger.info("hal.disconnected")
 
     @property
     def is_connected(self) -> bool:
         return self._connected
+
+    @property
+    def startup_state(self) -> MotorStartupState:
+        return self._startup_state
+
+    @property
+    def recovery_required(self) -> bool:
+        return self._startup_state is MotorStartupState.RECOVERY_REQUIRED
+
+    @property
+    def recovery_reason(self) -> str | None:
+        return self._recovery_reason
+
+    @property
+    def motor_names(self) -> list[str]:
+        if self._bus is not None:
+            return list(self._bus.motors)
+        return list(self._config.motors)
 
     # ------------------------------------------------------------------
     # Read / Write
@@ -154,6 +217,19 @@ class HardwareAbstraction:
 
         self._bus.sync_write("Goal_Position", positions)
 
+    def write_recovery_positions(self, positions: dict[str, float]) -> None:
+        """Write one prevalidated recovery command with the guarded STS profile."""
+        if not self._connected:
+            raise RuntimeError("HAL not connected")
+        if self._bus is None:
+            return
+        if self._startup_state is not MotorStartupState.RECOVERING:
+            raise RuntimeError(f"Recovery write is unavailable in startup state '{self._startup_state.value}'.")
+        # The recovery profile is configured and read back before torque-on.
+        # Position-only writes preserve Goal_Time=0 and the explicit low
+        # Goal_Velocity used by Feetech's STS position command protocol.
+        self._bus.sync_write("Goal_Position", positions)
+
     # Set to True after the first successful Goal_Position+Goal_Time sync write.
     _goal_time_confirmed: bool = False
 
@@ -174,8 +250,8 @@ class HardwareAbstraction:
 
         sw = self._bus.sync_writer
         sw.clearParam()
-        sw.start_address = 42   # Goal_Position register address
-        sw.data_length = 4      # 2 B position + 2 B time (consecutive registers)
+        sw.start_address = 42  # Goal_Position register address
+        sw.data_length = 4  # 2 B position + 2 B time (consecutive registers)
 
         for id_, raw in raw_pos.items():
             pos_bytes: list[int] = self._bus._serialize_data(raw, 2)
@@ -204,6 +280,8 @@ class HardwareAbstraction:
             return DeviceHealth.DISCONNECTED
         if self._bus is None:
             return DeviceHealth.DEGRADED
+        if self._startup_state is not MotorStartupState.READY:
+            return DeviceHealth.DEGRADED
         return DeviceHealth.OK
 
     def disable_torque(self) -> None:
@@ -230,10 +308,14 @@ class HardwareAbstraction:
         # Re-run the complete fail-closed startup sequence. Recording can leave
         # an arm at a range edge, and blindly restoring torque there is unsafe.
         try:
-            self._configure()
+            state = self._configure()
         except Exception:
             self._release_torque_for_manual_motion(strict=False)
             raise
+        if state is MotorStartupState.RECOVERY_REQUIRED:
+            self._startup_state = state
+            raise RuntimeError(self._recovery_reason or "Motor recovery is required before enabling torque.")
+        self._startup_state = state
         logger.info("hal.torque_enabled")
 
     def get_calibration_home(self) -> dict[str, float] | None:
@@ -275,8 +357,7 @@ class HardwareAbstraction:
         existing = self._load_calibration()
         if existing:
             choice = input(
-                f"Press ENTER to use existing calibration for '{self._config.lamp_id}', "
-                "or type 'c' to re-calibrate: "
+                f"Press ENTER to use existing calibration for '{self._config.lamp_id}', or type 'c' to re-calibrate: "
             )
             if choice.strip().lower() != "c":
                 if changed_mode:
@@ -304,7 +385,9 @@ class HardwareAbstraction:
             if actual != expected:
                 logger.warning(
                     "calibration.homing_offset_mismatch",
-                    motor=motor_name, expected=expected, actual=actual,
+                    motor=motor_name,
+                    expected=expected,
+                    actual=actual,
                 )
                 self._bus.write("Homing_Offset", motor_name, expected, num_retry=3)
                 verify = self._bus.read("Homing_Offset", motor_name, normalize=False)
@@ -400,9 +483,9 @@ class HardwareAbstraction:
         error_lines.append(pformat(found_models, indent=4, sort_dicts=False))
         raise RuntimeError("\n".join(error_lines))
 
-    def _configure(self) -> None:
+    def _configure(self) -> MotorStartupState:
         if self._bus is None:
-            return
+            return MotorStartupState.READY
 
         healthy_motors = [m for m in self._bus.motors if m not in self._status_error_motors]
         if len(healthy_motors) != len(self._bus.motors):
@@ -412,7 +495,7 @@ class HardwareAbstraction:
             )
         if not healthy_motors:
             logger.warning("hal.configure_skipped_all_motors")
-            return
+            return MotorStartupState.READY
 
         self._release_torque_for_manual_motion(strict=True)
 
@@ -437,19 +520,35 @@ class HardwareAbstraction:
             # does not block the whole arm from starting up.
             self._safe_bus_write("Return_Delay_Time", motor, 0)
             if getattr(self._bus, "protocol_version", None) == 0:
-                self._safe_bus_write("Maximum_Acceleration", motor, 50)
-            self._safe_bus_write("Acceleration", motor, 50)
+                self._safe_bus_write("Maximum_Acceleration", motor, self._NORMAL_ACCELERATION_RAW)
+            self._safe_bus_write("Acceleration", motor, self._NORMAL_ACCELERATION_RAW)
             self._write_register_or_raise("Operating_Mode", motor, OperatingMode.POSITION.value)
             self._safe_bus_write("P_Coefficient", motor, 16)
             self._safe_bus_write("I_Coefficient", motor, 0)
             self._safe_bus_write("D_Coefficient", motor, 32)
             self._write_register_or_raise("Torque_Limit", motor, torque_limit_raw, normalize=False)
+            # Clear stale SRAM motion fields left by an interrupted process
+            # before any goal is seeded or torque can be enabled.
+            self._write_register_or_raise("Goal_Time", motor, 0, normalize=False)
+            self._write_register_or_raise("Goal_Velocity", motor, 0, normalize=False)
         logger.info("hal.torque_limit_set", pct=self._config.max_torque_pct, raw=torque_limit_raw)
 
-        self._seed_goal_positions_to_present(healthy_motors)
+        recovery_required = self._seed_goal_positions_to_present(
+            healthy_motors,
+            allow_recovery=True,
+        )
+        if recovery_required:
+            logger.warning(
+                "hal.recovery_required",
+                reason=self._recovery_reason,
+            )
+            return MotorStartupState.RECOVERY_REQUIRED
+
         for motor in healthy_motors:
             self._write_register_or_raise("Lock", motor, 1)
             self._write_register_or_raise("Torque_Enable", motor, 1)
+        self._recovery_reason = None
+        return MotorStartupState.READY
 
     def _safe_bus_write(
         self,
@@ -498,14 +597,10 @@ class HardwareAbstraction:
         try:
             actual = self._bus.read(data_name, motor, normalize=normalize)
         except Exception as exc:
-            raise RuntimeError(
-                f"Cannot read back {data_name} for '{motor}' after writing {value!r}."
-            ) from exc
+            raise RuntimeError(f"Cannot read back {data_name} for '{motor}' after writing {value!r}.") from exc
 
         if int(actual) != int(value):
-            raise RuntimeError(
-                f"Cannot verify {data_name} for '{motor}': expected {value}, got {actual}."
-            )
+            raise RuntimeError(f"Cannot verify {data_name} for '{motor}': expected {value}, got {actual}.")
 
     def _ensure_sts3215_single_turn(self, motors: list[str]) -> set[str]:
         """Force STS3215 angle feedback into single-turn mode and verify it."""
@@ -527,8 +622,7 @@ class HardwareAbstraction:
 
             if phase & self._STS3215_MULTI_TURN_PHASE_BIT:
                 raise RuntimeError(
-                    f"Motor '{motor}' is still in unsafe STS3215 multi-turn feedback mode. "
-                    "Torque will remain disabled."
+                    f"Motor '{motor}' is still in unsafe STS3215 multi-turn feedback mode. Torque will remain disabled."
                 )
 
         logger.info("hal.sts3215_single_turn_verified", motors=sorted(motors), changed=sorted(changed))
@@ -569,17 +663,13 @@ class HardwareAbstraction:
             margin = min(neutral - range_min, range_max - neutral)
 
             if not (0 <= range_min < range_max <= resolution_max):
-                errors.append(
-                    f"{motor}: range {range_min}..{range_max} is outside single-turn 0..{resolution_max}"
-                )
+                errors.append(f"{motor}: range {range_min}..{range_max} is outside single-turn 0..{resolution_max}")
                 continue
             if span < self._MIN_VALID_RANGE_COUNTS or span > self._MAX_VALID_RANGE_COUNTS:
                 errors.append(f"{motor}: unsafe range span {span}")
                 continue
             if margin < span * self._MIN_NEUTRAL_MARGIN_RATIO:
-                errors.append(
-                    f"{motor}: neutral {neutral} is too close to range edge {range_min}..{range_max}"
-                )
+                errors.append(f"{motor}: neutral {neutral} is too close to range edge {range_min}..{range_max}")
 
         if errors:
             raise RuntimeError(
@@ -601,9 +691,7 @@ class HardwareAbstraction:
             if abs(final - int(neutral)) > self._NEUTRAL_CONFIRM_TOLERANCE_COUNTS:
                 errors.append(f"{motor}: expected near {int(neutral)}, got {final}")
         if errors:
-            raise RuntimeError(
-                "Arm is not close to its recorded neutral pose:\n- " + "\n- ".join(errors)
-            )
+            raise RuntimeError("Arm is not close to its recorded neutral pose:\n- " + "\n- ".join(errors))
 
     def _wait_for_safe_neutral_pose(
         self,
@@ -643,10 +731,7 @@ class HardwareAbstraction:
                     detail=str(exc),
                     final_raw={motor: int(raw) for motor, raw in final_raw.items()},
                 )
-                print(
-                    f"Warning: {exc}\nThe pose is safely inside all calibrated limits, "
-                    "so calibration will be saved."
-                )
+                print(f"Warning: {exc}\nThe pose is safely inside all calibrated limits, so calibration will be saved.")
             return final_raw
 
     def _release_torque_for_manual_motion(self, *, strict: bool) -> None:
@@ -689,10 +774,7 @@ class HardwareAbstraction:
             logger.warning("hal.torque_release_verify_failed", motors=bad)
             if strict:
                 detail = ", ".join(f"{motor}={state}" for motor, state in bad.items())
-                raise RuntimeError(
-                    "Motor torque/lock registers did not release before manual motion: "
-                    f"{detail}"
-                )
+                raise RuntimeError(f"Motor torque/lock registers did not release before manual motion: {detail}")
 
     def _open_manual_calibration_range(self) -> None:
         """Clear stale hardware limits before asking the user to move joints by hand."""
@@ -732,14 +814,17 @@ class HardwareAbstraction:
             raise RuntimeError("Cannot apply calibration without a motor bus")
         self._bus.write_calibration(calibration)
         if not self._bus.is_calibrated:
-            raise RuntimeError(
-                "Motor calibration register verification failed. Torque will remain disabled."
-            )
+            raise RuntimeError("Motor calibration register verification failed. Torque will remain disabled.")
         logger.info("hal.calibration_applied", lamp_id=self._config.lamp_id)
 
-    def _seed_goal_positions_to_present(self, motors: list[str]) -> None:
+    def _seed_goal_positions_to_present(
+        self,
+        motors: list[str],
+        *,
+        allow_recovery: bool = False,
+    ) -> bool:
         if self._bus is None or not motors:
-            return
+            return False
 
         try:
             present_raw = self._bus.sync_read("Present_Position", motors, normalize=False)
@@ -765,7 +850,15 @@ class HardwareAbstraction:
                     "Torque will remain disabled."
                 )
 
-        self._validate_startup_positions(present_raw)
+        recovery_required = self._validate_startup_positions(
+            present_raw,
+            allow_recovery=allow_recovery,
+        )
+        if recovery_required:
+            # Do not even seed a goal in the recoverable startup state. The
+            # current position and the complete return-safe path are re-read and
+            # validated immediately before the explicit recovery action.
+            return True
 
         seeded: dict[str, int] = {}
         for motor, raw in present_raw.items():
@@ -775,25 +868,35 @@ class HardwareAbstraction:
 
         if seeded:
             logger.info("hal.goal_seeded_to_present", present_raw=seeded)
+        return False
 
     def _validate_startup_positions(
         self,
         present_raw: dict[str, float],
         *,
         calibration: dict[str, Any] | None = None,
-    ) -> None:
-        """Refuse to energize a joint outside or too close to a calibrated stop."""
+        allow_recovery: bool = False,
+    ) -> bool:
+        """Classify startup feedback without confusing calibration with trust.
+
+        Calibration limits remain the hard boundary for normal motion. A stable
+        torque-free pose may sit a bounded distance outside those limits under
+        gravity, however, so ``allow_recovery`` also accepts a guarded subset of
+        the verified single-turn encoder range. Such a pose never enables torque
+        during startup; only a prevalidated one-way ``return_safe`` may do so.
+        """
         if self._bus is None:
             raise RuntimeError("Cannot validate startup positions without a motor bus")
         active_calibration = calibration if calibration is not None else self._bus.calibration
         if not active_calibration:
-            return
+            return False
 
-        errors: list[str] = []
+        hard_errors: list[str] = []
+        recoverable_errors: list[str] = []
         for motor, raw in present_raw.items():
             cal = active_calibration.get(motor)
             if cal is None:
-                errors.append(f"{motor}: calibration is missing")
+                hard_errors.append(f"{motor}: calibration is missing")
                 continue
 
             raw_int = int(raw)
@@ -805,21 +908,445 @@ class HardwareAbstraction:
                 self._MIN_STARTUP_EDGE_MARGIN_COUNTS,
                 int(span * self._STARTUP_EDGE_MARGIN_RATIO),
             )
+            recovery_min, recovery_max = self._recovery_envelope_bounds(motor, cal)
             if raw_int < range_min or raw_int > range_max:
-                errors.append(
-                    f"{motor}: position {raw_int} is outside calibrated range {range_min}..{range_max}"
-                )
+                outside_detail = f"{motor}: position {raw_int} is outside calibrated range {range_min}..{range_max}"
+                if allow_recovery and recovery_min <= raw_int <= recovery_max:
+                    recoverable_errors.append(
+                        f"{outside_detail}, but remains inside guarded single-turn recovery "
+                        f"range {recovery_min}..{recovery_max}"
+                    )
+                else:
+                    hard_errors.append(f"{outside_detail} and trusted recovery range {recovery_min}..{recovery_max}")
             elif margin < required_margin:
-                errors.append(
+                recoverable_errors.append(
                     f"{motor}: position {raw_int} is only {margin} counts from calibrated limit "
                     f"{range_min}..{range_max} (need at least {required_margin})"
                 )
 
-        if errors:
+        if hard_errors:
+            raise RuntimeError(
+                "Unsafe startup pose; torque will remain disabled. Position feedback is outside the "
+                "trusted calibrated range:\n- " + "\n- ".join(hard_errors)
+            )
+
+        if recoverable_errors:
+            reason = (
+                "Recovery required: the torque-free arm is outside or near its calibrated operating range, "
+                "but its feedback remains inside the guarded single-turn recovery envelope. Torque remains "
+                "disabled; only a fully prevalidated return_safe trajectory may energize the motors:\n- "
+                + "\n- ".join(recoverable_errors)
+            )
+            if allow_recovery:
+                self._recovery_reason = reason
+                return True
             raise RuntimeError(
                 "Unsafe startup pose; torque will remain disabled. Support the structure, move each "
-                "reported joint away from its hard stop, then retry:\n- " + "\n- ".join(errors)
+                "reported joint away from its hard stop, then retry:\n- " + "\n- ".join(recoverable_errors)
             )
+
+        return False
+
+    def _recovery_envelope_bounds(self, motor: str, cal: Any) -> tuple[int, int]:
+        """Return a bounded non-wrapping raw envelope for torque-off recovery."""
+        if self._bus is None:
+            raise RuntimeError("Cannot calculate recovery bounds without a motor bus.")
+        motor_config = self._bus.motors[motor]
+        resolution = int(self._bus.model_resolution_table[motor_config.model])
+        resolution_max = resolution - 1
+        max_outside = max(1, int(resolution * self._RECOVERY_MAX_OUTSIDE_RANGE_RATIO))
+        wrap_guard = max(1, int(resolution * self._RECOVERY_ENCODER_WRAP_GUARD_RATIO))
+        range_min = int(cal.range_min)
+        range_max = int(cal.range_max)
+        return (
+            min(range_min, max(wrap_guard, range_min - max_outside)),
+            max(range_max, min(resolution_max - wrap_guard, range_max + max_outside)),
+        )
+
+    def read_recovery_start(self) -> dict[str, float]:
+        """Return a stable, normalized recovery start while torque stays off."""
+        if not self._connected or self._bus is None:
+            raise RuntimeError("Motor bus is not connected for recovery.")
+        if self._startup_state is not MotorStartupState.RECOVERY_REQUIRED:
+            raise RuntimeError(f"Motor recovery is unavailable in startup state '{self._startup_state.value}'.")
+
+        self._release_torque_for_manual_motion(strict=True)
+        present_raw = self._read_stable_present_raw(list(self._bus.motors))
+        self._validate_startup_positions(present_raw, allow_recovery=True)
+        return {
+            motor: self._raw_to_normalized(motor, float(raw), self._bus.calibration[motor])
+            for motor, raw in present_raw.items()
+        }
+
+    def prepare_recovery(self, frames: list[dict[str, float]]) -> dict[str, float]:
+        """Validate an entire recovery path, then enable torque at the current pose.
+
+        This method must run before the motion control thread starts. No motor is
+        energized until stable feedback, every frame, and the final target have
+        all passed validation. Goal_Position is then seeded to the latest stable
+        Present_Position and verified before torque is enabled.
+        """
+        if not self._connected or self._bus is None:
+            raise RuntimeError("Motor bus is not connected for recovery.")
+        if self._startup_state is not MotorStartupState.RECOVERY_REQUIRED:
+            raise RuntimeError(f"Motor recovery is unavailable in startup state '{self._startup_state.value}'.")
+
+        motors = list(self._bus.motors)
+        self._release_torque_for_manual_motion(strict=True)
+        present_raw = self._read_stable_present_raw(motors)
+        self._validate_recovery_plan(present_raw, frames)
+
+        try:
+            self._expand_hardware_limits_for_recovery(present_raw)
+            self._configure_recovery_motion_profile(motors)
+            for motor, raw in present_raw.items():
+                self._write_register_or_raise(
+                    "Goal_Position",
+                    motor,
+                    int(raw),
+                    normalize=False,
+                )
+            for motor in motors:
+                self._write_register_or_raise("Lock", motor, 1)
+                self._write_register_or_raise("Torque_Enable", motor, 1)
+        except Exception:
+            self._release_torque_for_manual_motion(strict=False)
+            self._restore_normal_motion_profile(strict=False)
+            self._restore_calibrated_hardware_limits(strict=False)
+            raise
+
+        self._startup_state = MotorStartupState.RECOVERING
+        logger.info(
+            "hal.recovery_torque_enabled",
+            present_raw={motor: int(raw) for motor, raw in present_raw.items()},
+            frame_count=len(frames),
+        )
+        return {
+            motor: self._raw_to_normalized(motor, float(raw), self._bus.calibration[motor])
+            for motor, raw in present_raw.items()
+        }
+
+    def complete_recovery(self) -> None:
+        """Promote a completed recovery only after the final pose is safe."""
+        if self._bus is None or self._startup_state is not MotorStartupState.RECOVERING:
+            raise RuntimeError("No motor recovery is currently active.")
+        final_raw = self._read_stable_present_raw(list(self._bus.motors))
+        self._validate_startup_positions(final_raw)
+        self._restore_normal_motion_profile(strict=True)
+        self._restore_calibrated_hardware_limits(strict=True)
+        self._startup_state = MotorStartupState.READY
+        self._recovery_reason = None
+        logger.info(
+            "hal.recovery_complete",
+            final_raw={motor: int(raw) for motor, raw in final_raw.items()},
+            torque_held=True,
+        )
+
+    def abort_recovery(self) -> None:
+        """Fail closed after an incomplete recovery."""
+        if self._bus is None:
+            return
+        if self._startup_state is MotorStartupState.READY:
+            return
+        self._release_torque_for_manual_motion(strict=False)
+        self._restore_normal_motion_profile(strict=False)
+        self._restore_calibrated_hardware_limits(strict=False)
+        self._startup_state = MotorStartupState.RECOVERY_REQUIRED
+        if not self._recovery_reason:
+            self._recovery_reason = "Recovery did not reach the verified return_safe target."
+        logger.warning("hal.recovery_aborted", reason=self._recovery_reason)
+
+    def _configure_recovery_motion_profile(self, motors: list[str]) -> None:
+        """Install and verify a guarded STS position profile before torque-on."""
+        if self._bus is None:
+            raise RuntimeError("Cannot configure recovery profile without a motor bus.")
+
+        for motor in motors:
+            # Track before writing so a partial profile is restored on failure.
+            self._recovery_profile_motors.add(motor)
+            self._write_register_or_raise(
+                "Acceleration",
+                motor,
+                self._RECOVERY_ACCELERATION_RAW,
+                normalize=False,
+            )
+            self._write_register_or_raise("Goal_Time", motor, 0, normalize=False)
+            self._write_register_or_raise(
+                "Goal_Velocity",
+                motor,
+                self._RECOVERY_SPEED_RAW,
+                normalize=False,
+            )
+
+        logger.info(
+            "hal.recovery_motion_profile_verified",
+            motors=motors,
+            acceleration_raw=self._RECOVERY_ACCELERATION_RAW,
+            speed_raw=self._RECOVERY_SPEED_RAW,
+        )
+
+    def _restore_normal_motion_profile(self, *, strict: bool) -> None:
+        """Restore normal SRAM motion fields after recovery or abort."""
+        if self._bus is None or not self._recovery_profile_motors:
+            return
+
+        failures: list[str] = []
+        restored: list[str] = []
+        for motor in sorted(self._recovery_profile_motors):
+            try:
+                self._write_register_or_raise(
+                    "Acceleration",
+                    motor,
+                    self._NORMAL_ACCELERATION_RAW,
+                    normalize=False,
+                )
+                self._write_register_or_raise("Goal_Time", motor, 0, normalize=False)
+                self._write_register_or_raise("Goal_Velocity", motor, 0, normalize=False)
+            except Exception as exc:  # noqa: BLE001
+                failures.append(f"{motor}: {exc}")
+            else:
+                restored.append(motor)
+
+        self._recovery_profile_motors.difference_update(restored)
+        if restored:
+            logger.info("hal.normal_motion_profile_restored", motors=restored)
+        if failures:
+            detail = "; ".join(failures)
+            logger.error("hal.normal_motion_profile_restore_failed", detail=detail)
+            if strict:
+                raise RuntimeError(
+                    "Recovery reached its target, but the normal motor profile could not be restored: " + detail
+                )
+
+    def _expand_hardware_limits_for_recovery(self, present_raw: dict[str, int]) -> None:
+        """Temporarily include a verified recovery start in servo limits.
+
+        Goal_Position is seeded only after these EPROM-backed limits read back.
+        This prevents an out-of-range seed from being clipped to the calibrated
+        boundary when torque is enabled.
+        """
+        if self._bus is None:
+            raise RuntimeError("Cannot expand recovery limits without a motor bus.")
+
+        expanded: dict[str, dict[str, int]] = {}
+        for motor, raw in present_raw.items():
+            cal = self._bus.calibration[motor]
+            range_min = int(cal.range_min)
+            range_max = int(cal.range_max)
+            recovery_min = min(range_min, int(raw))
+            recovery_max = max(range_max, int(raw))
+            if recovery_min == range_min and recovery_max == range_max:
+                continue
+
+            # Track before the first limit write so a partially successful
+            # expansion is still restored by the exception path.
+            self._recovery_expanded_limit_motors.add(motor)
+            self._write_register_or_raise("Lock", motor, 0, normalize=False)
+            if recovery_min != range_min:
+                self._write_register_or_raise(
+                    "Min_Position_Limit",
+                    motor,
+                    recovery_min,
+                    normalize=False,
+                )
+            if recovery_max != range_max:
+                self._write_register_or_raise(
+                    "Max_Position_Limit",
+                    motor,
+                    recovery_max,
+                    normalize=False,
+                )
+            expanded[motor] = {"min": recovery_min, "max": recovery_max}
+
+        if expanded:
+            logger.info("hal.recovery_hardware_limits_expanded", motors=expanded)
+
+    def _restore_calibrated_hardware_limits(self, *, strict: bool) -> None:
+        """Restore temporary recovery limits while preserving fail-closed state."""
+        if self._bus is None or not self._recovery_expanded_limit_motors:
+            return
+
+        failures: list[str] = []
+        restored: list[str] = []
+        for motor in sorted(self._recovery_expanded_limit_motors):
+            cal = self._bus.calibration[motor]
+            try:
+                self._write_register_or_raise("Lock", motor, 0, normalize=False)
+                self._write_register_or_raise(
+                    "Min_Position_Limit",
+                    motor,
+                    int(cal.range_min),
+                    normalize=False,
+                )
+                self._write_register_or_raise(
+                    "Max_Position_Limit",
+                    motor,
+                    int(cal.range_max),
+                    normalize=False,
+                )
+                self._write_register_or_raise("Lock", motor, 1, normalize=False)
+            except Exception as exc:  # noqa: BLE001
+                failures.append(f"{motor}: {exc}")
+            else:
+                restored.append(motor)
+
+        self._recovery_expanded_limit_motors.difference_update(restored)
+        if restored:
+            logger.info("hal.recovery_hardware_limits_restored", motors=restored)
+        if failures:
+            detail = "; ".join(failures)
+            logger.error("hal.recovery_hardware_limit_restore_failed", detail=detail)
+            if strict:
+                raise RuntimeError(
+                    "Recovery reached its target, but calibrated hardware limits could not be restored: " + detail
+                )
+
+    def _read_stable_present_raw(self, motors: list[str]) -> dict[str, int]:
+        if self._bus is None:
+            raise RuntimeError("Cannot read recovery positions without a motor bus.")
+
+        samples: list[dict[str, int]] = []
+        for sample_idx in range(self._RECOVERY_STABLE_SAMPLE_COUNT):
+            raw = self._bus.sync_read(
+                "Present_Position",
+                motors,
+                normalize=False,
+            )
+            missing = [motor for motor in motors if motor not in raw]
+            if missing:
+                raise RuntimeError(
+                    f"Recovery position feedback is incomplete; missing {missing}. Torque remains disabled."
+                )
+            samples.append({motor: int(raw[motor]) for motor in motors})
+            if sample_idx + 1 < self._RECOVERY_STABLE_SAMPLE_COUNT:
+                time.sleep(self._RECOVERY_STABLE_SAMPLE_INTERVAL_S)
+
+        unstable: list[str] = []
+        for motor in motors:
+            values = [sample[motor] for sample in samples]
+            spread = max(values) - min(values)
+            if spread > self._RECOVERY_STABLE_SPREAD_COUNTS:
+                unstable.append(f"{motor}: readings {min(values)}..{max(values)} spread {spread}")
+        if unstable:
+            raise RuntimeError(
+                "Recovery position feedback is still moving or unstable; torque remains disabled:\n- "
+                + "\n- ".join(unstable)
+            )
+        return samples[-1]
+
+    def _validate_recovery_plan(
+        self,
+        present_raw: dict[str, int],
+        frames: list[dict[str, float]],
+    ) -> None:
+        if self._bus is None:
+            raise RuntimeError("Cannot validate recovery without a motor bus.")
+        if not frames:
+            raise RuntimeError("Recovery path is empty; torque remains disabled.")
+
+        motors = list(self._bus.motors)
+        self._validate_startup_positions(present_raw, allow_recovery=True)
+
+        raw_frames: list[dict[str, int]] = []
+        for index, frame in enumerate(frames):
+            missing = [motor for motor in motors if motor not in frame]
+            if missing:
+                raise RuntimeError(f"Recovery frame {index} is incomplete; missing {missing}. Torque remains disabled.")
+            if any(not math.isfinite(float(frame[motor])) for motor in motors):
+                raise RuntimeError(f"Recovery frame {index} contains a non-finite position. Torque remains disabled.")
+            raw_frames.append(
+                {
+                    motor: self._normalized_to_raw(
+                        motor,
+                        float(frame[motor]),
+                        self._bus.calibration[motor],
+                    )
+                    for motor in motors
+                }
+            )
+
+        final_raw = raw_frames[-1]
+        self._validate_startup_positions(final_raw)
+
+        errors: list[str] = []
+        for motor in motors:
+            cal = self._bus.calibration[motor]
+            start = int(present_raw[motor])
+            goal = int(final_raw[motor])
+            direction = 1 if goal > start else -1 if goal < start else 0
+            previous = start
+            path_min = min(start, goal)
+            path_max = max(start, goal)
+            recovery_min, recovery_max = self._recovery_envelope_bounds(motor, cal)
+
+            for index, raw_frame in enumerate(raw_frames):
+                value = int(raw_frame[motor])
+                if not recovery_min <= value <= recovery_max:
+                    errors.append(
+                        f"{motor}: frame {index} position {value} is outside guarded recovery range "
+                        f"{recovery_min}..{recovery_max}"
+                    )
+                    break
+                if not path_min <= value <= path_max:
+                    errors.append(
+                        f"{motor}: frame {index} position {value} leaves verified start-to-target "
+                        f"envelope {path_min}..{path_max}"
+                    )
+                    break
+                step = value - previous
+                if abs(step) > self._RECOVERY_MAX_FRAME_STEP_COUNTS:
+                    errors.append(
+                        f"{motor}: frame {index} jumps {abs(step)} counts; maximum is "
+                        f"{self._RECOVERY_MAX_FRAME_STEP_COUNTS}"
+                    )
+                    break
+                if direction > 0 and (value < previous or value > goal):
+                    errors.append(f"{motor}: frame {index} does not move monotonically toward safe target")
+                    break
+                if direction < 0 and (value > previous or value < goal):
+                    errors.append(f"{motor}: frame {index} does not move monotonically toward safe target")
+                    break
+                if direction == 0 and value != goal:
+                    errors.append(f"{motor}: frame {index} moves a joint that should remain still")
+                    break
+                previous = value
+
+            if previous != goal:
+                errors.append(f"{motor}: recovery path does not end at verified target {goal}")
+
+        if errors:
+            raise RuntimeError("Recovery path validation failed; torque remains disabled:\n- " + "\n- ".join(errors))
+
+        logger.info(
+            "hal.recovery_plan_verified",
+            start_raw={motor: int(raw) for motor, raw in present_raw.items()},
+            target_raw={motor: int(raw) for motor, raw in final_raw.items()},
+            frame_count=len(frames),
+        )
+
+    def _raw_to_normalized(self, motor: str, raw: float, cal: Any) -> float:
+        """Convert recovery feedback without display-oriented rounding."""
+        if self._config.use_degrees:
+            if self._bus is None:
+                raise RuntimeError("Cannot convert recovery positions without a motor bus.")
+            model = self._bus.motors[motor].model
+            resolution_max = int(self._bus.model_resolution_table[model]) - 1
+            midpoint = (float(cal.range_min) + float(cal.range_max)) / 2.0
+            return (raw - midpoint) * 360.0 / resolution_max
+        span = float(cal.range_max - cal.range_min)
+        value = ((raw - float(cal.range_min)) / span) * 200.0 - 100.0
+        return -value if bool(cal.drive_mode) else value
+
+    def _normalized_to_raw(self, motor: str, value: float, cal: Any) -> int:
+        if self._bus is None:
+            raise RuntimeError("Cannot convert recovery positions without a motor bus.")
+        model = self._bus.motors[motor].model
+        resolution_max = int(self._bus.model_resolution_table[model]) - 1
+        if self._config.use_degrees:
+            midpoint = (float(cal.range_min) + float(cal.range_max)) / 2.0
+            return round((value * resolution_max / 360.0) + midpoint)
+        normalized = -value if bool(cal.drive_mode) else value
+        return round(((normalized + 100.0) / 200.0) * (cal.range_max - cal.range_min) + cal.range_min)
 
     def _calibration_path(self) -> Any:
         return self._config.calibration_dir / f"{self._config.lamp_id}.json"

--- a/lampgo/core/motion.py
+++ b/lampgo/core/motion.py
@@ -34,6 +34,7 @@ Key design choices
 
 from __future__ import annotations
 
+import math
 import os
 import queue
 import threading
@@ -68,6 +69,7 @@ class _Command:
     frames: list[dict[str, float]] | None = None
     fps: int = 30
     playback_mode: str = "cleaned"
+    recovery: bool = False
     done_event: threading.Event | None = None
 
 
@@ -77,6 +79,14 @@ class MotionRuntime:
     The asyncio side communicates via a thread-safe command queue.
     The control thread never blocks on asyncio.
     """
+
+    _RECOVERY_COMMAND_LEAD_DEGREES = 8.0
+    _RECOVERY_FEEDBACK_ENVELOPE_TOLERANCE_DEGREES = 1.0
+    _RECOVERY_MAX_FEEDBACK_VELOCITY = 60.0
+    _RECOVERY_PROGRESS_EPSILON_DEGREES = 0.2
+    _RECOVERY_STALL_TIMEOUT_S = 2.5
+    _RECOVERY_TARGET_TOLERANCE_DEGREES = 5.0
+    _STREAM_SETTLE_TIMEOUT_S = 2.0
 
     def __init__(
         self,
@@ -97,6 +107,11 @@ class MotionRuntime:
 
         self._running = False
         self._thread: threading.Thread | None = None
+        self._recovery_target: dict[str, float] | None = None
+        self._recovery_start: dict[str, float] | None = None
+        self._recovery_max_velocity: float | None = None
+        self._recovery_failure_reason: str | None = None
+        self._recovery_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Public API (called from asyncio / skill side)
@@ -111,9 +126,7 @@ class MotionRuntime:
         # consuming that stale shutdown and exiting.
         self._command_queue = queue.Queue(maxsize=64)
         self._running = True
-        self._thread = threading.Thread(
-            target=self._control_loop, name="lampgo-motion", daemon=True
-        )
+        self._thread = threading.Thread(target=self._control_loop, name="lampgo-motion", daemon=True)
         self._thread.start()
         logger.info("motion.started", tick_hz=self._config.tick_rate_hz)
 
@@ -180,6 +193,153 @@ class MotionRuntime:
         self._command_queue.put(cmd)
         return done
 
+    def prepare_recovery(
+        self,
+        target: dict[str, float],
+        *,
+        max_velocity: float,
+        fps: int = 50,
+    ) -> list[dict[str, float]]:
+        """Precompute and validate a complete recovery path before torque-on."""
+        with self._recovery_lock:
+            return self._prepare_recovery_locked(
+                target,
+                max_velocity=max_velocity,
+                fps=fps,
+            )
+
+    def _prepare_recovery_locked(
+        self,
+        target: dict[str, float],
+        *,
+        max_velocity: float,
+        fps: int,
+    ) -> list[dict[str, float]]:
+        if self._running:
+            raise RuntimeError("Recovery preparation requires the motion loop to be stopped.")
+        if not self._hal.recovery_required:
+            raise RuntimeError("Motor recovery is not required.")
+        if max_velocity <= 0 or fps <= 0:
+            raise RuntimeError("Recovery velocity and frame rate must be positive.")
+
+        motor_names = self._hal.motor_names
+        recovery_target = {joint: float(target[joint]) for joint in motor_names if joint in target}
+        missing = [joint for joint in motor_names if joint not in recovery_target]
+        if missing:
+            raise RuntimeError(f"return_safe target is missing recovery joints: {missing}")
+
+        start = self._hal.read_recovery_start()
+        max_distance = max(
+            (abs(recovery_target[joint] - start[joint]) for joint in motor_names),
+            default=0.0,
+        )
+        frame_count = max(1, math.ceil(max_distance / max_velocity * fps))
+        frames = [
+            {
+                joint: start[joint] + (recovery_target[joint] - start[joint]) * ((index + 1) / frame_count)
+                for joint in motor_names
+            }
+            for index in range(frame_count)
+        ]
+
+        self._validate_recovery_frames(
+            start,
+            recovery_target,
+            frames,
+            fps=fps,
+            max_velocity=max_velocity,
+        )
+        verified_start = self._hal.prepare_recovery(frames)
+        self._current_state = JointState(positions=verified_start)
+        self._recovery_start = dict(verified_start)
+        self._recovery_target = recovery_target
+        self._recovery_max_velocity = max_velocity
+        self._recovery_failure_reason = None
+        self.start()
+        logger.info(
+            "motion.recovery_prepared",
+            frame_count=len(frames),
+            fps=fps,
+            max_velocity=max_velocity,
+            max_command_lead=self._RECOVERY_COMMAND_LEAD_DEGREES,
+            stall_timeout_s=self._RECOVERY_STALL_TIMEOUT_S,
+            target=recovery_target,
+        )
+        return frames
+
+    def stream_recovery_frames(self, frames: list[dict[str, float]], fps: int = 50) -> threading.Event:
+        if not self._running or self._recovery_target is None:
+            raise RuntimeError("Recovery has not been prepared.")
+        done = threading.Event()
+        self._command_queue.put(
+            _Command(
+                type=_CommandType.STREAM_FRAMES,
+                frames=frames,
+                fps=fps,
+                playback_mode="raw",
+                recovery=True,
+                done_event=done,
+            )
+        )
+        return done
+
+    def complete_recovery(self) -> None:
+        with self._recovery_lock:
+            if self._running:
+                self.stop()
+            self._hal.complete_recovery()
+            self._recovery_start = None
+            self._recovery_target = None
+            self._recovery_max_velocity = None
+            self._recovery_failure_reason = None
+            self.start()
+
+    def abort_recovery(self) -> None:
+        with self._recovery_lock:
+            if self._running:
+                self.stop()
+            self._hal.abort_recovery()
+            self._recovery_start = None
+            self._recovery_target = None
+            self._recovery_max_velocity = None
+
+    def _validate_recovery_frames(
+        self,
+        start: dict[str, float],
+        target: dict[str, float],
+        frames: list[dict[str, float]],
+        *,
+        fps: int,
+        max_velocity: float,
+    ) -> None:
+        validated_target = self._safety.validate_target(
+            JointState(positions=start),
+            MotionTarget(joints=target, anticipation=False),
+        )
+        if not isinstance(validated_target, MotionTarget) or any(
+            abs(validated_target.joints.get(joint, float("inf")) - value) > 1e-9 for joint, value in target.items()
+        ):
+            raise RuntimeError("return_safe target is outside normal software safety limits.")
+
+        previous = JointState(positions=dict(start))
+        dt = 1.0 / fps
+        for index, frame in enumerate(frames):
+            checked = self._safety.validate_recovery_frame(
+                previous,
+                frame,
+                target,
+                dt,
+                max_velocity=max_velocity,
+            )
+            if any(abs(checked.get(joint, float("inf")) - value) > 1e-9 for joint, value in frame.items()):
+                raise RuntimeError(f"return_safe recovery frame {index} failed monotonic or velocity validation.")
+            previous = JointState(positions=dict(frame))
+
+        if not frames or any(
+            abs(frames[-1].get(joint, float("inf")) - value) > 1e-9 for joint, value in target.items()
+        ):
+            raise RuntimeError("return_safe recovery path does not end at the verified target.")
+
     def stop_smooth(self) -> None:
         self._command_queue.put(_Command(type=_CommandType.STOP_SMOOTH))
 
@@ -197,6 +357,14 @@ class MotionRuntime:
     @property
     def is_running(self) -> bool:
         return self._running
+
+    @property
+    def recovery_required(self) -> bool:
+        return self._hal.recovery_required
+
+    @property
+    def recovery_error(self) -> str | None:
+        return self._recovery_failure_reason
 
     # ------------------------------------------------------------------
     # Control thread
@@ -254,6 +422,15 @@ class MotionRuntime:
         _stream_clipped_joints_in_window: set[str] = set()
         _stream_clip_events_in_window = 0
 
+        # Recovery feedback watchdog. Each joint must keep making measurable
+        # progress, remain inside its verified start-to-target envelope, and
+        # never accelerate far beyond the guarded command profile.
+        _recovery_best_error: dict[str, float] = {}
+        _recovery_last_progress_at: dict[str, float] = {}
+        _recovery_previous_feedback: dict[str, float] = {}
+        _recovery_previous_feedback_at = time.monotonic()
+        _recovery_last_warning_at = 0.0
+
         # --- Move-to completion tracking ---
         _initial_distance = 0.0
         _stall_ticks = 0
@@ -309,35 +486,22 @@ class MotionRuntime:
                     # Springs decelerate naturally — no hard stop
 
                 elif cmd.type == _CommandType.MOVE_TO:
-                    validated = self._safety.validate_target(
-                        self._current_state, cmd.target
-                    )
+                    validated = self._safety.validate_target(self._current_state, cmd.target)
                     if isinstance(validated, MotionTarget):
                         _stream_frames = []
                         _current_stream_target = {}
 
                         # Resolve style → spring params
-                        style_key = resolve_style_name(
-                            validated.style, self._config.default_style
-                        )
-                        style = get_motion_style(
-                            style_key, self._config.default_style
-                        )
+                        style_key = resolve_style_name(validated.style, self._config.default_style)
+                        style = get_motion_style(style_key, self._config.default_style)
 
                         # Cap f to stay within velocity budget; preserve z
-                        v_limit = (
-                            validated.max_velocity or self._config.default_max_velocity
-                        ) * 0.9
+                        v_limit = (validated.max_velocity or self._config.default_max_velocity) * 0.9
                         max_dist = max(
-                            (
-                                abs(v - self._current_state.get(k, v))
-                                for k, v in validated.joints.items()
-                            ),
+                            (abs(v - self._current_state.get(k, v)) for k, v in validated.joints.items()),
                             default=0.0,
                         )
-                        effective_f = cap_spring_f(
-                            style.f, style.z, max_dist, v_limit
-                        )
+                        effective_f = cap_spring_f(style.f, style.z, max_dist, v_limit)
                         _spring_f = effective_f
                         _spring_z = style.z
 
@@ -356,8 +520,7 @@ class MotionRuntime:
                             _active_done.set()
                         _active_done = cmd.done_event
                         _initial_distance = sum(
-                            abs(v - self._current_state.get(k, v))
-                            for k, v in validated.joints.items()
+                            abs(v - self._current_state.get(k, v)) for k, v in validated.joints.items()
                         )
                         _stall_ticks = 0
                         _prev_hw_remaining = -1.0
@@ -369,11 +532,7 @@ class MotionRuntime:
                             ant_cfg.anticipation_enabled
                             and validated.anticipation is not False
                             and max_dist >= ant_cfg.anticipation_threshold
-                            and all(
-                                abs(_springs[j].velocity) < 5.0
-                                for j in validated.joints
-                                if j in _springs
-                            )
+                            and all(abs(_springs[j].velocity) < 5.0 for j in validated.joints if j in _springs)
                         ):
                             ratio = ant_cfg.anticipation_ratio
                             windup_joints: dict[str, float] = {}
@@ -388,18 +547,12 @@ class MotionRuntime:
                                 style=validated.style,
                                 anticipation=False,
                             )
-                            windup_validated = self._safety.validate_target(
-                                self._current_state, windup_target
-                            )
+                            windup_validated = self._safety.validate_target(self._current_state, windup_target)
                             if isinstance(windup_validated, MotionTarget):
                                 _anticipation_final_target = validated
                                 _anticipation_ticks_remaining = max(
                                     1,
-                                    round(
-                                        ant_cfg.anticipation_duration_ms
-                                        / 1000.0
-                                        / self._tick_interval
-                                    ),
+                                    round(ant_cfg.anticipation_duration_ms / 1000.0 / self._tick_interval),
                                 )
                                 self._current_target = windup_validated
                                 logger.debug(
@@ -417,9 +570,7 @@ class MotionRuntime:
                             _anticipation_ticks_remaining = 0
                             self._current_target = validated
 
-                        self._status = MotionStatus(
-                            target=validated, progress=0.0, is_done=False
-                        )
+                        self._status = MotionStatus(target=validated, progress=0.0, is_done=False)
                         logger.info(
                             "motion.move_accepted",
                             target=validated.joints,
@@ -438,18 +589,19 @@ class MotionRuntime:
                             cmd.done_event.set()
 
                 elif cmd.type == _CommandType.STREAM_FRAMES:
+                    if cmd.recovery and self._recovery_target is None:
+                        logger.error("motion.recovery_stream_rejected_without_preflight")
+                        if cmd.done_event:
+                            cmd.done_event.set()
+                        continue
                     _stream_frames = cmd.frames or []
                     _stream_idx = 0
                     _stream_accumulator = 0.0
                     _stream_fps = cmd.fps or 30
                     cmd_mode = cmd.playback_mode or "cleaned"
                     _stream_passthrough = cmd_mode == "raw"
-                    _stream_enable_overlap = (
-                        self._config.overlapping_action and cmd_mode == "expressive"
-                    )
-                    _current_stream_target = (
-                        dict(_stream_frames[0]) if _stream_frames else {}
-                    )
+                    _stream_enable_overlap = self._config.overlapping_action and cmd_mode == "expressive"
+                    _current_stream_target = dict(_stream_frames[0]) if _stream_frames else {}
                     self._current_target = None
                     _anticipation_final_target = None
                     _anticipation_ticks_remaining = 0
@@ -479,6 +631,15 @@ class MotionRuntime:
                     _active_done = cmd.done_event
                     _stream_settling = False
                     self._status = MotionStatus(progress=0.0, is_done=False)
+                    if cmd.recovery and self._recovery_target is not None:
+                        now = time.monotonic()
+                        _recovery_best_error = {
+                            joint: abs(self._current_state.get(joint, goal) - goal)
+                            for joint, goal in self._recovery_target.items()
+                        }
+                        _recovery_last_progress_at = {joint: now for joint in self._recovery_target}
+                        _recovery_previous_feedback = dict(self._current_state.positions)
+                        _recovery_previous_feedback_at = now
 
             # --- Read hardware state ---
             try:
@@ -488,6 +649,70 @@ class MotionRuntime:
                 self._safety.report_bus_health(False)
                 self._tick_sleep(t0)
                 continue
+
+            if self._recovery_target is not None and self._recovery_start is not None:
+                now = time.monotonic()
+                # A stream command can be dequeued immediately before the next
+                # bus sample. Use at least one control interval so one encoder
+                # count of normal quantization cannot look like a huge speed.
+                feedback_elapsed = max(now - _recovery_previous_feedback_at, dt)
+                feedback_warnings: list[str] = []
+                stalled_joints: list[str] = []
+
+                for joint, goal in self._recovery_target.items():
+                    start = self._recovery_start[joint]
+                    actual = self._current_state.get(joint, start)
+                    envelope_min = min(start, goal) - self._RECOVERY_FEEDBACK_ENVELOPE_TOLERANCE_DEGREES
+                    envelope_max = max(start, goal) + self._RECOVERY_FEEDBACK_ENVELOPE_TOLERANCE_DEGREES
+                    if not envelope_min <= actual <= envelope_max:
+                        feedback_warnings.append(
+                            f"{joint}: feedback {actual:.2f} left verified envelope "
+                            f"{envelope_min:.2f}..{envelope_max:.2f}"
+                        )
+
+                    previous_actual = _recovery_previous_feedback.get(joint, actual)
+                    feedback_velocity = abs(actual - previous_actual) / feedback_elapsed
+                    if feedback_velocity > self._RECOVERY_MAX_FEEDBACK_VELOCITY:
+                        feedback_warnings.append(
+                            f"{joint}: feedback velocity {feedback_velocity:.2f} deg/s exceeds "
+                            f"{self._RECOVERY_MAX_FEEDBACK_VELOCITY:.2f} deg/s"
+                        )
+
+                    error = abs(actual - goal)
+                    best_error = _recovery_best_error.get(joint, error)
+                    if error <= self._RECOVERY_TARGET_TOLERANCE_DEGREES:
+                        _recovery_best_error[joint] = error
+                        _recovery_last_progress_at[joint] = now
+                    elif best_error - error >= self._RECOVERY_PROGRESS_EPSILON_DEGREES:
+                        _recovery_best_error[joint] = error
+                        _recovery_last_progress_at[joint] = now
+                    elif (
+                        joint in _recovery_last_progress_at
+                        and now - _recovery_last_progress_at[joint] >= self._RECOVERY_STALL_TIMEOUT_S
+                    ):
+                        stalled_joints.append(joint)
+
+                _recovery_previous_feedback = dict(self._current_state.positions)
+                _recovery_previous_feedback_at = now
+
+                if stalled_joints:
+                    feedback_warnings.append(
+                        "no measurable progress for "
+                        f"{self._RECOVERY_STALL_TIMEOUT_S:.1f}s: {', '.join(sorted(stalled_joints))}"
+                    )
+
+                if feedback_warnings and now - _recovery_last_warning_at >= 1.0:
+                    # A software observation alone must not release torque.
+                    # Recovery commands remain bounded and monotonic; if a
+                    # loaded joint pauses, keep holding/commanding the verified
+                    # target and let the configured motor torque/current limit
+                    # provide the electrical protection layer.
+                    logger.warning(
+                        "motion.recovery_feedback_warning",
+                        reason="; ".join(feedback_warnings),
+                        torque_held=True,
+                    )
+                    _recovery_last_warning_at = now
 
             if self._safety.is_estopped():
                 self._tick_sleep(t0)
@@ -507,18 +732,13 @@ class MotionRuntime:
             # --- Build per-joint targets ---
             # Start with each spring holding its own current position
             # (passive joints decelerate naturally rather than tracking noisy hw)
-            joint_targets: dict[str, float] = {
-                j: s.position for j, s in _springs.items()
-            }
+            joint_targets: dict[str, float] = {j: s.position for j, s in _springs.items()}
 
             if _stream_frames:
                 # Advance accumulator and update frame target when due
                 _stream_accumulator += dt
                 frame_interval = 1.0 / _stream_fps
-                while (
-                    _stream_accumulator >= frame_interval
-                    and _stream_idx < len(_stream_frames)
-                ):
+                while _stream_accumulator >= frame_interval and _stream_idx < len(_stream_frames):
                     _current_stream_target = dict(_stream_frames[_stream_idx])
                     _stream_idx += 1
                     _stream_accumulator -= frame_interval
@@ -533,23 +753,54 @@ class MotionRuntime:
                 if _stream_idx >= len(_stream_frames):
                     _stream_frames = []
                     _stream_settling = True
-                    # Give the spring at most 2 s to settle before forcing done
-                    _stream_settle_timeout = time.monotonic() + 2.0
+                    if self._recovery_target is not None:
+                        # A loaded joint may legitimately lag behind the
+                        # prevalidated command timeline. Keep commanding the
+                        # verified endpoint until feedback actually reaches it;
+                        # the recovery watchdog remains responsible for real
+                        # stalls and unsafe feedback. A wall-clock timeout here
+                        # used to release torque while the arm was still making
+                        # steady progress, causing it to fall.
+                        _stream_settle_timeout = 0.0
+                        logger.info(
+                            "motion.recovery_holding_target",
+                            remaining={
+                                joint: round(abs(self._current_state.get(joint, goal) - goal), 2)
+                                for joint, goal in self._recovery_target.items()
+                            },
+                        )
+                    else:
+                        _stream_settle_timeout = time.monotonic() + self._STREAM_SETTLE_TIMEOUT_S
 
             elif _stream_settling:
                 # All frames consumed; keep feeding last target until arm settles.
                 # Use hardware position for done-detection (not spring internal state)
                 # so large frame steps that get velocity-clamped still complete.
                 joint_targets.update(_current_stream_target)
-                hw_settle_tol = 1.0   # degrees — arm close enough to last frame
+                # Recovery uses the same final tolerance as its progress
+                # watchdog.  A joint already within that envelope must not
+                # keep the whole arm settling until timeout or be called
+                # stalled because of encoder quantization/static friction.
+                hw_settle_tol = (
+                    self._RECOVERY_TARGET_TOLERANCE_DEGREES if self._recovery_target is not None else 1.0
+                )
                 hw_at_target = all(
-                    abs(self._current_state.get(j, v) - v) < hw_settle_tol
+                    abs(self._current_state.get(j, v) - v) <= hw_settle_tol
                     for j, v in _current_stream_target.items()
                 )
-                timed_out = time.monotonic() >= _stream_settle_timeout
+                is_recovery = self._recovery_target is not None
+                timed_out = not is_recovery and time.monotonic() >= _stream_settle_timeout
                 if hw_at_target or timed_out:
                     _stream_settling = False
                     self._status = MotionStatus(progress=1.0, is_done=True)
+                    if is_recovery and hw_at_target:
+                        logger.info(
+                            "motion.recovery_target_reached",
+                            actual={
+                                joint: round(self._current_state.get(joint, goal), 2)
+                                for joint, goal in self._recovery_target.items()
+                            },
+                        )
                     if _active_done:
                         _active_done.set()
                         _active_done = None
@@ -578,35 +829,58 @@ class MotionRuntime:
             # --- Overlapping Action (P2) ---
             overlap_enabled = _stream_enable_overlap if stream_active else self._config.overlapping_action
             if overlap_enabled and next_frame:
-                next_frame = self._apply_overlapping_action(
-                    next_frame, _overlap_prev, _overlap_buffers
-                )
+                next_frame = self._apply_overlapping_action(next_frame, _overlap_prev, _overlap_buffers)
             _overlap_prev = dict(next_frame)
 
             # --- Safety validate and write (unified path for all sources) ---
             clip_events: list[dict[str, float | str]] = []
             command_reference = dict(self._current_state.positions)
             command_reference.update(_last_safe_frame)
-            safe_frame = self._safety.validate_frame(
-                JointState(positions=command_reference, timestamp=self._current_state.timestamp),
-                next_frame,
-                dt,
-                clip_events=clip_events,
-            )
+            if self._recovery_target is not None:
+                safe_frame = self._safety.validate_recovery_frame(
+                    self._current_state,
+                    next_frame,
+                    self._recovery_target,
+                    dt,
+                    max_velocity=self._recovery_max_velocity,
+                    command_reference=_last_safe_frame,
+                    max_command_lead=self._RECOVERY_COMMAND_LEAD_DEGREES,
+                    clip_events=clip_events,
+                )
+            else:
+                safe_frame = self._safety.validate_frame(
+                    JointState(positions=command_reference, timestamp=self._current_state.timestamp),
+                    next_frame,
+                    dt,
+                    clip_events=clip_events,
+                )
             _last_safe_frame.update(safe_frame)
             if stream_active and clip_events:
                 _stream_clip_events_in_window += len(clip_events)
-                _stream_clipped_joints_in_window.update(
-                    str(event["joint"]) for event in clip_events
-                )
+                _stream_clipped_joints_in_window.update(str(event["joint"]) for event in clip_events)
             now = time.monotonic()
             window_elapsed = now - _stream_clip_window_start
-            should_flush_stream_clip_log = (
-                window_elapsed >= 1.0
-                or (not stream_active and _stream_clip_events_in_window > 0)
+            should_flush_stream_clip_log = window_elapsed >= 1.0 or (
+                not stream_active and _stream_clip_events_in_window > 0
             )
             if should_flush_stream_clip_log:
-                if _stream_clip_events_in_window > 0:
+                if self._recovery_target is not None:
+                    logger.info(
+                        "motion.recovery_tracking",
+                        actual={
+                            joint: round(self._current_state.get(joint, goal), 2)
+                            for joint, goal in self._recovery_target.items()
+                        },
+                        commanded={
+                            joint: round(_last_safe_frame.get(joint, goal), 2)
+                            for joint, goal in self._recovery_target.items()
+                        },
+                        remaining={
+                            joint: round(abs(self._current_state.get(joint, goal) - goal), 2)
+                            for joint, goal in self._recovery_target.items()
+                        },
+                    )
+                elif _stream_clip_events_in_window > 0:
                     logger.warning(
                         "motion.stream_velocity_clipped_summary",
                         window_seconds=round(window_elapsed, 3),
@@ -626,8 +900,11 @@ class MotionRuntime:
                     _springs[joint].sync_position(safe_pos)
 
             try:
-                tick_ms = max(1, round(self._tick_interval * 1000))
-                self._hal.write_positions(safe_frame, move_time_ms=tick_ms)
+                if self._recovery_target is not None:
+                    self._hal.write_recovery_positions(safe_frame)
+                else:
+                    tick_ms = max(1, round(self._tick_interval * 1000))
+                    self._hal.write_positions(safe_frame, move_time_ms=tick_ms)
             except Exception:
                 self._safety.report_bus_health(False)
                 logger.exception("motion.write_failed")
@@ -645,26 +922,19 @@ class MotionRuntime:
             # --- Done detection for MOVE_TO ---
             if self._current_target is not None and not _stream_frames:
                 spring_settled = all(
-                    _springs[j].is_settled(tv)
-                    for j, tv in self._current_target.joints.items()
-                    if j in _springs
+                    _springs[j].is_settled(tv) for j, tv in self._current_target.joints.items() if j in _springs
                 )
                 hardware_at_target = all(
-                    abs(self._current_state.get(j, tv) - tv) < 1.0
-                    for j, tv in self._current_target.joints.items()
+                    abs(self._current_state.get(j, tv) - tv) < 1.0 for j, tv in self._current_target.joints.items()
                 )
                 all_settled = spring_settled and hardware_at_target
 
                 _was_stalled = False
                 if not all_settled:
                     hw_remaining = sum(
-                        abs(tv - self._current_state.get(j, tv))
-                        for j, tv in self._current_target.joints.items()
+                        abs(tv - self._current_state.get(j, tv)) for j, tv in self._current_target.joints.items()
                     )
-                    if (
-                        _prev_hw_remaining >= 0
-                        and abs(hw_remaining - _prev_hw_remaining) < 0.3
-                    ):
+                    if _prev_hw_remaining >= 0 and abs(hw_remaining - _prev_hw_remaining) < 0.3:
                         _stall_ticks += 1
                     else:
                         _stall_ticks = 0
@@ -683,23 +953,16 @@ class MotionRuntime:
 
                 if all_settled:
                     self._current_target = None
-                    self._status = MotionStatus(
-                        progress=1.0, is_done=True, stalled=_was_stalled
-                    )
+                    self._status = MotionStatus(progress=1.0, is_done=True, stalled=_was_stalled)
                     logger.info("motion.move_done")
                     if _active_done:
                         _active_done.set()
                         _active_done = None
                 else:
                     hw_remaining = sum(
-                        abs(tv - self._current_state.get(j, tv))
-                        for j, tv in self._current_target.joints.items()
+                        abs(tv - self._current_state.get(j, tv)) for j, tv in self._current_target.joints.items()
                     )
-                    progress = (
-                        1.0 - hw_remaining / _initial_distance
-                        if _initial_distance > 1.0
-                        else 1.0
-                    )
+                    progress = 1.0 - hw_remaining / _initial_distance if _initial_distance > 1.0 else 1.0
                     self._status = MotionStatus(
                         target=self._current_target,
                         progress=max(0.0, min(1.0, progress)),
@@ -729,11 +992,11 @@ class MotionRuntime:
         # Ratios raised 3-4x from original (0.04/0.06/0.03) so the coupling
         # is actually visible; lag increased for more organic follow-through.
         # When the lamp pitches, yaw and elbow follow with a delay.
-        ("base_pitch",  "base_yaw",    0.12, 5),
-        ("base_pitch",  "elbow_pitch", 0.18, 6),
+        ("base_pitch", "base_yaw", 0.12, 5),
+        ("base_pitch", "elbow_pitch", 0.18, 6),
         # When the lamp yaws, wrist roll and elbow follow.
-        ("base_yaw",    "wrist_roll",  0.10, 4),
-        ("base_yaw",    "elbow_pitch", 0.08, 5),
+        ("base_yaw", "wrist_roll", 0.10, 4),
+        ("base_yaw", "elbow_pitch", 0.08, 5),
         # When the elbow moves, the wrist pitch follows (energy transfer down the chain).
         ("elbow_pitch", "wrist_pitch", 0.15, 5),
     ]

--- a/lampgo/core/safety.py
+++ b/lampgo/core/safety.py
@@ -124,9 +124,7 @@ class SafetyKernel:
                     value = prev + direction * self._config.max_velocity * dt
                     value = max(limits.min, min(limits.max, value))
                     clamped_velocity = abs(value - prev) / dt
-                    retained_ratio = (
-                        clamped_velocity / raw_velocity if raw_velocity > 1e-9 else 1.0
-                    )
+                    retained_ratio = clamped_velocity / raw_velocity if raw_velocity > 1e-9 else 1.0
                     clip_ratio = 1.0 - retained_ratio
                     if clip_events is not None:
                         clip_events.append(
@@ -148,6 +146,96 @@ class SafetyKernel:
                         retained_ratio=retained_ratio,
                         clip_ratio=clip_ratio,
                     )
+
+            safe[joint] = value
+
+        return safe
+
+    def validate_recovery_frame(
+        self,
+        current: JointState,
+        next_frame: dict[str, float],
+        target: dict[str, float],
+        dt: float,
+        max_velocity: float | None = None,
+        command_reference: dict[str, float] | None = None,
+        max_command_lead: float | None = None,
+        clip_events: list[dict[str, float | str]] | None = None,
+    ) -> dict[str, float]:
+        """Validate a prechecked one-way escape from a calibrated edge.
+
+        A naturally resting joint can be outside both the normal software limits
+        and the user-recorded calibration range while still inside a guarded,
+        non-wrapping subset of its verified single-turn encoder range. HAL
+        validates that raw envelope before torque is enabled. During recovery
+        this gate only permits monotonic movement toward a target that is itself
+        inside the normal software limits. Runtime recovery may advance from the
+        previous command rather than raw feedback so it can overcome servo
+        deadband, but the lead over measured feedback stays explicitly bounded.
+        """
+        if self._estopped:
+            return dict(current.positions)
+
+        safe: dict[str, float] = {}
+        for joint, requested in next_frame.items():
+            limits = self._config.joint_limits.get(joint)
+            goal = target.get(joint)
+            actual = current.get(joint, requested)
+            prev = float(command_reference.get(joint, actual)) if command_reference is not None else actual
+            if limits is None or goal is None or not limits.min <= goal <= limits.max:
+                safe[joint] = actual
+                continue
+
+            # If feedback has already advanced past the previous command, adopt
+            # it as the new command reference so we never pull back against the
+            # intended recovery direction.
+            if goal > actual and prev < actual:
+                prev = actual
+            elif goal < actual and prev > actual:
+                prev = actual
+
+            # Never command past the final target or back toward the physical
+            # edge. Velocity is measured from the previous command so a small,
+            # bounded position error can accumulate across ticks instead of
+            # remaining forever inside the servo's deadband.
+            lower = min(prev, goal)
+            upper = max(prev, goal)
+            value = max(lower, min(upper, requested))
+
+            if dt > 0:
+                velocity_limit = min(
+                    self._config.max_velocity,
+                    max_velocity if max_velocity is not None else self._config.max_velocity,
+                )
+                raw_velocity = abs(value - prev) / dt
+                if raw_velocity > velocity_limit:
+                    direction = 1.0 if value > prev else -1.0
+                    unclamped = value
+                    value = prev + direction * velocity_limit * dt
+                    value = max(lower, min(upper, value))
+                    if clip_events is not None:
+                        allowed_velocity = abs(value - prev) / dt
+                        retained_ratio = allowed_velocity / raw_velocity if raw_velocity > 1e-9 else 1.0
+                        clip_events.append(
+                            {
+                                "joint": joint,
+                                "requested_velocity": raw_velocity,
+                                "allowed_velocity": allowed_velocity,
+                                "retained_ratio": retained_ratio,
+                                "clip_ratio": 1.0 - retained_ratio,
+                                "requested_value": unclamped,
+                                "clamped_value": value,
+                            }
+                        )
+
+            if max_command_lead is not None:
+                lead = max(0.0, float(max_command_lead))
+                if goal > actual:
+                    value = max(actual, min(value, min(goal, actual + lead)))
+                elif goal < actual:
+                    value = min(actual, max(value, max(goal, actual - lead)))
+                else:
+                    value = goal
 
             safe[joint] = value
 

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -36,7 +36,7 @@ from lampgo.core.events import (
     ToolCallPlanned,
     TtsAudio,
 )
-from lampgo.core.hal import HardwareAbstraction
+from lampgo.core.hal import HardwareAbstraction, MotorStartupState
 from lampgo.core.led import LEDController
 from lampgo.core.motion import MotionRuntime
 from lampgo.core.safety import SafetyKernel
@@ -521,6 +521,11 @@ class LampgoServer:
         async with self._record_lock:
             if self.config.no_hw or not self.hal.is_connected:
                 return {"ok": False, "error": "hardware not connected"}
+            if self.hal.recovery_required:
+                return {
+                    "ok": False,
+                    "error": "motor recovery required; run return_safe before recording",
+                }
             if self._record_recorder is not None:
                 return {"ok": False, "error": "recording session already active"}
 
@@ -1461,9 +1466,11 @@ class LampgoServer:
         positions = self.motion.current_state.positions
         health = "ok" if not self.safety.is_estopped() else "degraded"
         virtual = bool(getattr(self.motion, "is_virtual", False))
+        motor_startup_state = self.hal.startup_state.value
+        recovery_error = self.hal.recovery_reason if self.hal.recovery_required else None
         if not self.hal.is_connected and not virtual:
             health = "disconnected"
-        if self._hal_startup_error:
+        if self._hal_startup_error or recovery_error:
             health = "degraded"
         cat_teaser_camera = self._cat_teaser_camera_status()
         camera_ready = self._cat_teaser_camera_ready(cat_teaser_camera)
@@ -1480,7 +1487,8 @@ class LampgoServer:
                 "estop_reason": self.safety.last_estop_reason,
                 "recording": self._record_status(),
                 "hal_connected": bool(self.hal.is_connected),
-                "hardware_error": self._hal_startup_error,
+                "motor_startup_state": motor_startup_state,
+                "hardware_error": self._hal_startup_error or recovery_error,
                 "led_ready": bool(self.led.is_connected),
                 "camera_ready": camera_ready,
                 "cat_teaser_camera": cat_teaser_camera,
@@ -1948,12 +1956,19 @@ class LampgoServer:
                 self._use_virtual_motion()
             else:
                 self._hal_startup_error = None
-                self.executor.set_motion_block_reason(None)
+                if self.hal.recovery_required:
+                    self.executor.set_motion_block_reason(
+                        self.hal.recovery_reason or "Motor recovery is required.",
+                        allow_return_safe_recovery=True,
+                    )
+                else:
+                    self.executor.set_motion_block_reason(None)
                 try:
                     self.led.connect()
                 except Exception as exc:  # noqa: BLE001
                     logger.warning("server.led_connect_failed", error=str(exc))
-                self.motion.start()
+                if not self.hal.recovery_required:
+                    self.motion.start()
                 home = self.hal.get_calibration_home()
                 if home is not None:
                     from lampgo.skills.builtin.motion_skills import set_calibration_home
@@ -2049,10 +2064,16 @@ class LampgoServer:
 
             self.hal = new_hal
             self._hal_startup_error = None
-            self.executor.set_motion_block_reason(None)
             self.motion = MotionRuntime(self.hal, self.safety, self.config.motion)
             self.config.no_hw = False
-            self.motion.start()
+            if self.hal.recovery_required:
+                self.executor.set_motion_block_reason(
+                    self.hal.recovery_reason or "Motor recovery is required.",
+                    allow_return_safe_recovery=True,
+                )
+            else:
+                self.executor.set_motion_block_reason(None)
+                self.motion.start()
             home = self.hal.get_calibration_home()
             if home is not None:
                 from lampgo.skills.builtin.motion_skills import set_calibration_home
@@ -2062,8 +2083,13 @@ class LampgoServer:
             return {
                 "ok": True,
                 "connected": True,
-                "mode": "hardware",
+                "mode": (
+                    "hardware_recovery"
+                    if self.hal.startup_state is MotorStartupState.RECOVERY_REQUIRED
+                    else "hardware"
+                ),
                 "port": port,
+                "motor_startup_state": self.hal.startup_state.value,
             }
 
     async def _home_on_start(self) -> None:

--- a/lampgo/skills/builtin/motion_skills.py
+++ b/lampgo/skills/builtin/motion_skills.py
@@ -21,6 +21,7 @@ SAFE_POSITION: dict[str, float] = {
     "wrist_pitch": 0.0,
 }
 
+
 def set_calibration_home(home: dict[str, float]) -> None:
     """Inject calibration-derived home for return_safe/startup homing."""
     for joint in SAFE_POSITION:
@@ -84,6 +85,9 @@ class MoveToSkill(Skill):
 
 
 STARTUP_HOME_VELOCITY = 30.0
+RECOVERY_HOME_VELOCITY = 30.0
+RECOVERY_HOME_FPS = 50
+RECOVERY_FINAL_TOLERANCE_DEGREES = 5.0
 
 
 class ReturnSafeSkill(Skill):
@@ -100,9 +104,85 @@ class ReturnSafeSkill(Skill):
         ),
     }
 
+    def __init__(self) -> None:
+        self._motion = None
+        self._recovery_active = False
+
     async def execute(self, ctx: SkillContext, **params: Any) -> SkillResult:
+        self._motion = ctx.motion
         velocity = float(params.get("velocity", 60.0))
         safe = get_safe_position()
+
+        if bool(getattr(ctx.motion, "recovery_required", False)):
+            self._recovery_active = True
+            logger.info(
+                "return_safe.recovery_preflight",
+                requested_velocity=velocity,
+                recovery_velocity=RECOVERY_HOME_VELOCITY,
+                target=safe,
+            )
+            try:
+                frames = await asyncio.to_thread(
+                    ctx.motion.prepare_recovery,
+                    safe,
+                    max_velocity=RECOVERY_HOME_VELOCITY,
+                    fps=RECOVERY_HOME_FPS,
+                )
+                done_event = ctx.motion.stream_recovery_frames(frames, fps=RECOVERY_HOME_FPS)
+                # Do not infer failure from the precomputed frame duration.
+                # Under gravity a healthy loaded joint can trail the command
+                # timeline while still moving steadily toward the safe target.
+                # MotionRuntime signals completion only after real feedback is
+                # at target, or after its safety watchdog has already stopped a
+                # genuine fault.
+                while not done_event.is_set():
+                    await asyncio.sleep(0.05)
+
+                recovery_error = getattr(ctx.motion, "recovery_error", None)
+                if recovery_error:
+                    raise RuntimeError(str(recovery_error))
+
+                actual = ctx.motion.current_state.positions
+                errors = {
+                    joint: round(actual.get(joint, float("inf")) - target, 2)
+                    for joint, target in safe.items()
+                    if abs(actual.get(joint, float("inf")) - target) > RECOVERY_FINAL_TOLERANCE_DEGREES
+                }
+                if errors:
+                    raise RuntimeError(
+                        f"Recovery did not reach the verified return_safe target; joint errors: {errors}"
+                    )
+
+                await asyncio.to_thread(ctx.motion.complete_recovery)
+                self._recovery_active = False
+            except Exception as exc:  # noqa: BLE001
+                # Recovery failures are reported without automatically
+                # releasing torque. The motor bus already enforces its torque
+                # limit, and ordinary software observations (lag, clipping or
+                # a completion mismatch) must not make a raised arm fall.
+                logger.warning(
+                    "return_safe.recovery_failed_holding_torque",
+                    error=str(exc),
+                    torque_held=True,
+                )
+                self._recovery_active = False
+                return SkillResult(status="error", message=str(exc))
+
+            self._recovery_active = False
+            logger.info(
+                "return_safe.recovery_done",
+                velocity=RECOVERY_HOME_VELOCITY,
+                frame_count=len(frames),
+            )
+            return SkillResult(
+                status="ok",
+                data={
+                    "recovered": True,
+                    "velocity": RECOVERY_HOME_VELOCITY,
+                    "frame_count": len(frames),
+                },
+            )
+
         target = MotionTarget(joints=dict(safe), max_velocity=velocity, anticipation=False)
         logger.info("return_safe.queueing", velocity=velocity, target=safe)
         done_event = ctx.motion.move_to(target)
@@ -112,6 +192,17 @@ class ReturnSafeSkill(Skill):
             return SkillResult(status="error", message="Homing did not complete within timeout")
         logger.info("return_safe.done")
         return SkillResult(status="ok")
+
+    async def cancel(self) -> None:
+        if self._motion is None:
+            return
+        if self._recovery_active:
+            # Cancellation/pre-emption is not an emergency stop. Keep the
+            # active servo goals and torque so the structure cannot fall.
+            self._motion.stop_immediate()
+            self._recovery_active = False
+            return
+        self._motion.stop_immediate()
 
 
 class EStopSkill(Skill):

--- a/lampgo/skills/builtin/parametric_skills.py
+++ b/lampgo/skills/builtin/parametric_skills.py
@@ -22,10 +22,13 @@ from lampgo.core.config import DEFAULT_JOINT_LIMITS
 from lampgo.core.trajectory import generate_sine_frames, generate_waypoint_frames
 from lampgo.core.types import MotionTarget, SkillResult
 from lampgo.skills.base import ParameterSpec, Skill, SkillContext
+from lampgo.skills.builtin.motion_skills import get_safe_position
 
 logger = structlog.get_logger(__name__)
 
 _FPS = 50  # matches MotionRuntime's default control rate
+_IDLE_SWAY_RECENTER_VELOCITY = 30.0
+_IDLE_SWAY_RECENTER_TIMEOUT_S = 15.0
 
 
 async def _await_done(done_event, timeout: float) -> bool:
@@ -272,11 +275,29 @@ class IdleSwaySkill(Skill):
         yaw_scale = random.uniform(0.22, 0.42)
         yaw_period_ratio = random.uniform(0.62, 0.82)
 
-        base_pitch = ctx.state.get("base_pitch", 0.0)
-        base_yaw = ctx.state.get("base_yaw", 0.0)
+        # Anchor every invocation to the calibration-derived safe pose. Using
+        # the current feedback as the next centre compounds any small settling
+        # error, making repeated automatic sways progressively lower.
+        safe_position = get_safe_position()
+        centre = {
+            "base_pitch": safe_position["base_pitch"],
+            "base_yaw": safe_position["base_yaw"],
+        }
+        current = {
+            "base_pitch": ctx.state.get("base_pitch", centre["base_pitch"]),
+            "base_yaw": ctx.state.get("base_yaw", centre["base_yaw"]),
+        }
 
-        frames = generate_sine_frames(
-            base={"base_pitch": base_pitch, "base_yaw": base_yaw},
+        max_recentering_distance = max(abs(current[joint] - centre[joint]) for joint in centre)
+        recenter_duration = max(0.4, max_recentering_distance / _IDLE_SWAY_RECENTER_VELOCITY)
+        recenter_frames = generate_waypoint_frames(
+            [(current, 0.0), (centre, recenter_duration)],
+            fps=_FPS,
+            ease_fn="ease_in_out_cubic",
+        )
+
+        sway_frames = generate_sine_frames(
+            base=centre,
             axes={
                 "base_pitch": {
                     "amplitude": amplitude * pitch_direction,
@@ -292,12 +313,27 @@ class IdleSwaySkill(Skill):
             duration=duration,
             fps=_FPS,
         )
+        frames = recenter_frames + sway_frames
 
         try:
             done = ctx.motion.stream_frames(frames, fps=_FPS)
-            if not await _await_done(done, timeout=duration + 5.0):
+            if not await _await_done(done, timeout=len(frames) / _FPS + 5.0):
                 logger.warning("idle_sway.timeout", frames=len(frames))
                 return SkillResult(status="error", message="IdleSway timed out")
+
+            # Use an absolute point-to-point hold after the streamed gesture.
+            # This removes any residual hardware lag before the scheduler can
+            # launch another sway, and leaves the lamp holding the safe centre.
+            recenter_done = ctx.motion.move_to(
+                MotionTarget(
+                    joints=dict(centre),
+                    max_velocity=_IDLE_SWAY_RECENTER_VELOCITY,
+                    anticipation=False,
+                )
+            )
+            if not await _await_done(recenter_done, timeout=_IDLE_SWAY_RECENTER_TIMEOUT_S):
+                logger.warning("idle_sway.recenter_timeout", target=centre)
+                return SkillResult(status="error", message="IdleSway could not return to its safe centre")
         finally:
             self._motion = None
 
@@ -307,6 +343,7 @@ class IdleSwaySkill(Skill):
                 "amplitude": round(amplitude, 2),
                 "period": round(period, 2),
                 "duration": round(duration, 2),
+                "centre": centre,
             },
         )
 

--- a/lampgo/skills/executor.py
+++ b/lampgo/skills/executor.py
@@ -44,8 +44,14 @@ class SkillExecutor:
         self._current_skill: Skill | None = None
         self._current_invocation_id: str | None = None
         self._motion_block_reason: str | None = None
+        self._allow_return_safe_recovery = False
 
-    def set_motion_block_reason(self, reason: str | None) -> None:
+    def set_motion_block_reason(
+        self,
+        reason: str | None,
+        *,
+        allow_return_safe_recovery: bool = False,
+    ) -> None:
         """Block physical motion skills after a failed hardware startup.
 
         Explicit ``--no-hw`` sessions leave this unset and may still use the
@@ -53,6 +59,7 @@ class SkillExecutor:
         presented as a successful virtual movement.
         """
         self._motion_block_reason = reason
+        self._allow_return_safe_recovery = bool(reason) and allow_return_safe_recovery
 
     async def invoke(self, skill_id: str, ctx: SkillContext, **params) -> InvokeResult:
         invocation_id = uuid.uuid4().hex[:12]
@@ -66,7 +73,8 @@ class SkillExecutor:
                 error_detail=f"Skill '{skill_id}' not registered",
             )
 
-        if skill_id in _MOTION_SKILLS and self._motion_block_reason:
+        recovery_exception = self._allow_return_safe_recovery and skill_id in {"return_safe", "estop"}
+        if skill_id in _MOTION_SKILLS and self._motion_block_reason and not recovery_exception:
             logger.warning(
                 "executor.motion_blocked_hardware_unavailable",
                 skill_id=skill_id,
@@ -80,7 +88,7 @@ class SkillExecutor:
             )
 
         # Hardware not connected → return fake ok to prevent LLM retry loops
-        if skill_id in _MOTION_SKILLS and not ctx.motion.is_running:
+        if skill_id in _MOTION_SKILLS and not ctx.motion.is_running and not recovery_exception:
             logger.debug("executor.hw_skip", skill_id=skill_id, reason="motor not connected")
             return InvokeResult(
                 invocation_id=invocation_id,
@@ -127,6 +135,15 @@ class SkillExecutor:
         except Exception as e:
             logger.exception("executor.skill_error", skill_id=skill_id)
             result = SkillResult(status="error", message=str(e))
+
+        if (
+            skill_id == "return_safe"
+            and result.status == "ok"
+            and self._allow_return_safe_recovery
+            and not bool(getattr(ctx.motion, "recovery_required", False))
+        ):
+            self.set_motion_block_reason(None)
+            logger.info("executor.motor_recovery_unblocked")
 
         await self._events.publish(
             SkillFinished(skill_id=skill_id, invocation_id=invocation_id, status=result.status)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -268,6 +268,44 @@ def test_server_status_exposes_hardware_startup_error() -> None:
     assert status["hardware_error"] == "Unsafe startup pose; torque remains disabled"
 
 
+def test_server_status_exposes_recoverable_motor_startup_state() -> None:
+    from lampgo.core.config import LampgoConfig
+    from lampgo.core.hal import MotorStartupState
+    from lampgo.server import LampgoServer
+
+    server = LampgoServer(LampgoConfig(no_hw=True))
+    server.hal._connected = True
+    server.hal._startup_state = MotorStartupState.RECOVERY_REQUIRED
+    server.hal._recovery_reason = "Recovery required: base_pitch is near a calibrated limit"
+
+    status = server._handle_status()["result"]
+
+    assert status["device_health"] == "degraded"
+    assert status["hal_connected"] is True
+    assert status["motor_startup_state"] == "recovery_required"
+    assert status["hardware_error"].startswith("Recovery required")
+
+
+def test_server_blocks_teach_recording_until_motor_recovery_finishes() -> None:
+    async def run() -> None:
+        from lampgo.core.config import LampgoConfig
+        from lampgo.core.hal import MotorStartupState
+        from lampgo.server import LampgoServer
+
+        server = LampgoServer(LampgoConfig(no_hw=False))
+        server.hal._connected = True
+        server.hal._startup_state = MotorStartupState.RECOVERY_REQUIRED
+
+        result = await server.start_recording_session()
+
+        assert result == {
+            "ok": False,
+            "error": "motor recovery required; run return_safe before recording",
+        }
+
+    asyncio.run(run())
+
+
 def test_cmd_ping_reports_status_error(monkeypatch, capsys):
     args = argparse.Namespace(port="/dev/tty.test", config=None)
 

--- a/tests/test_hal.py
+++ b/tests/test_hal.py
@@ -129,6 +129,8 @@ def test_hal_configure_seeds_goal_position_before_enabling_torque() -> None:
     assert ("Present_Position", "base_pitch", False) in bus.reads
     assert ("Goal_Position", "base_pitch", 1739, False) in bus.writes
     assert ("Torque_Limit", "base_pitch", 800, False) in bus.writes
+    assert ("Goal_Time", "base_pitch", 0, False) in bus.writes
+    assert ("Goal_Velocity", "base_pitch", 0, False) in bus.writes
 
     disable_idx = bus.writes.index(("Torque_Enable", "base_pitch", 0, True))
     seed_idx = bus.writes.index(("Goal_Position", "base_pitch", 1739, False))
@@ -145,9 +147,7 @@ def test_hal_configure_refuses_present_position_outside_calibration_range() -> N
             self.motors = {"base_pitch": SimpleNamespace(model="dummy")}
             self.model_resolution_table = {"dummy": 4096}
             self.protocol_version = 0
-            self.calibration = {
-                "base_pitch": SimpleNamespace(range_min=1739, range_max=3094, homing_offset=-562)
-            }
+            self.calibration = {"base_pitch": SimpleNamespace(range_min=1739, range_max=3094, homing_offset=-562)}
             self.writes: list[tuple[str, str, int, bool]] = []
             self.values: dict[tuple[str, str], int] = {}
 
@@ -382,9 +382,7 @@ def test_hal_refuses_legacy_calibration_without_single_turn_metadata() -> None:
     from lampgo.core.config import DeviceConfig
     from lampgo.core.hal import HardwareAbstraction
 
-    calibration = {
-        "base_pitch": SimpleNamespace(range_min=1296, range_max=2279, homing_offset=1849)
-    }
+    calibration = {"base_pitch": SimpleNamespace(range_min=1296, range_max=2279, homing_offset=1849)}
     hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
     bus = _SafetyFakeBus(calibration=calibration)
     hal._bus = bus
@@ -396,13 +394,11 @@ def test_hal_refuses_legacy_calibration_without_single_turn_metadata() -> None:
     assert ("Torque_Enable", "base_pitch", 1, True) not in bus.writes
 
 
-def test_hal_refuses_startup_at_calibrated_edge_from_incident_log() -> None:
+def test_hal_keeps_torque_off_and_requires_recovery_at_calibrated_edge() -> None:
     from lampgo.core.config import DeviceConfig
-    from lampgo.core.hal import HardwareAbstraction
+    from lampgo.core.hal import HardwareAbstraction, MotorStartupState
 
-    calibration = {
-        "base_pitch": SimpleNamespace(range_min=1296, range_max=2279, homing_offset=1849)
-    }
+    calibration = {"base_pitch": SimpleNamespace(range_min=1296, range_max=2279, homing_offset=1849)}
     hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
     bus = _SafetyFakeBus(present=2276, calibration=calibration)
     hal._bus = bus
@@ -411,9 +407,232 @@ def test_hal_refuses_startup_at_calibrated_edge_from_incident_log() -> None:
         "base_pitch": {"range_min": 1296, "range_max": 2279},
     }
 
-    with pytest.raises(RuntimeError, match="only 3 counts from calibrated limit"):
-        hal._configure()
+    state = hal._configure()
 
+    assert state is MotorStartupState.RECOVERY_REQUIRED
+    assert "only 3 counts from calibrated limit" in (hal.recovery_reason or "")
+    assert ("Goal_Position", "base_pitch", 2276, False) not in bus.writes
+    assert ("Torque_Enable", "base_pitch", 1, True) not in bus.writes
+
+
+def test_hal_classifies_logged_natural_rest_pose_as_guarded_recovery() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    calibration = {
+        "base_pitch": SimpleNamespace(range_min=1124, range_max=2345),
+        "elbow_pitch": SimpleNamespace(range_min=1444, range_max=2673),
+    }
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    hal._bus = SimpleNamespace(
+        motors={
+            "base_pitch": SimpleNamespace(model="sts3215"),
+            "elbow_pitch": SimpleNamespace(model="sts3215"),
+        },
+        model_resolution_table={"sts3215": 4096},
+        calibration=calibration,
+    )
+
+    recovery_required = hal._validate_startup_positions(
+        {"base_pitch": 2812, "elbow_pitch": 2858},
+        allow_recovery=True,
+    )
+
+    assert recovery_required is True
+    assert "base_pitch: position 2812" in (hal.recovery_reason or "")
+    assert "elbow_pitch: position 2858" in (hal.recovery_reason or "")
+
+
+def test_hal_configure_keeps_logged_outside_range_pose_connected_for_recovery() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction, MotorStartupState
+
+    calibration = {
+        "base_pitch": SimpleNamespace(
+            range_min=1124,
+            range_max=2345,
+            homing_offset=-1528,
+            drive_mode=0,
+        )
+    }
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = _SafetyFakeBus(present=2812, calibration=calibration)
+    hal._bus = bus
+    hal._load_calibration_data = lambda: {
+        "_meta": {"schema_version": 2, "sts3215_single_turn_verified": True},
+        "base_pitch": {"range_min": 1124, "range_max": 2345},
+    }
+
+    state = hal._configure()
+
+    assert state is MotorStartupState.RECOVERY_REQUIRED
+    assert "position 2812 is outside calibrated range 1124..2345" in (hal.recovery_reason or "")
+    assert ("Goal_Position", "base_pitch", 2812, False) not in bus.writes
+    assert ("Torque_Enable", "base_pitch", 1, True) not in bus.writes
+
+
+def test_hal_recovery_validates_entire_slow_path_before_enabling_torque() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction, MotorStartupState
+
+    calibration = {
+        "base_pitch": SimpleNamespace(
+            range_min=1296,
+            range_max=2279,
+            homing_offset=1849,
+            drive_mode=0,
+        )
+    }
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = _SafetyFakeBus(present=2276, calibration=calibration)
+    hal._bus = bus
+    hal._connected = True
+    hal._startup_state = MotorStartupState.RECOVERY_REQUIRED
+
+    start = hal.read_recovery_start()["base_pitch"]
+    frames = [{"base_pitch": start + (0.0 - start) * (index / 240)} for index in range(1, 241)]
+
+    hal.prepare_recovery(frames)
+
+    assert hal.startup_state is MotorStartupState.RECOVERING
+    seed_idx = bus.writes.index(("Goal_Position", "base_pitch", 2276, False))
+    torque_idx = bus.writes.index(("Torque_Enable", "base_pitch", 1, True))
+    assert seed_idx < torque_idx
+
+
+def test_hal_recovery_from_logged_pose_expands_then_restores_hardware_limit() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction, MotorStartupState
+
+    calibration = {
+        "base_pitch": SimpleNamespace(
+            range_min=1124,
+            range_max=2345,
+            homing_offset=-1528,
+            drive_mode=0,
+        )
+    }
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = _SafetyFakeBus(present=2812, calibration=calibration)
+    hal._bus = bus
+    hal._connected = True
+    hal._startup_state = MotorStartupState.RECOVERY_REQUIRED
+
+    start = hal.read_recovery_start()["base_pitch"]
+    target = 27.3
+    frames = [{"base_pitch": start + (target - start) * (index / 800)} for index in range(1, 801)]
+
+    hal.prepare_recovery(frames)
+
+    expand_idx = bus.writes.index(("Max_Position_Limit", "base_pitch", 2812, False))
+    profile_idx = bus.writes.index(("Goal_Velocity", "base_pitch", 8, False))
+    seed_idx = bus.writes.index(("Goal_Position", "base_pitch", 2812, False))
+    torque_idx = bus.writes.index(("Torque_Enable", "base_pitch", 1, True))
+    assert expand_idx < profile_idx < seed_idx < torque_idx
+    assert bus.values[("Acceleration", "base_pitch")] == 5
+    assert bus.values[("Goal_Time", "base_pitch")] == 0
+    assert bus.values[("Goal_Velocity", "base_pitch")] == 8
+    assert hal.startup_state is MotorStartupState.RECOVERING
+
+    bus.present = 2045
+    hal.complete_recovery()
+
+    assert hal.startup_state is MotorStartupState.READY
+    assert not any(
+        register == "Torque_Enable" and value == 0
+        for register, _motor, value, _retry in bus.writes[torque_idx + 1 :]
+    )
+    assert bus.values[("Acceleration", "base_pitch")] == 50
+    assert bus.values[("Goal_Velocity", "base_pitch")] == 0
+    assert bus.values[("Max_Position_Limit", "base_pitch")] == 2345
+    assert not hal._recovery_expanded_limit_motors
+    assert not hal._recovery_profile_motors
+
+
+def test_hal_recovery_path_preserves_logged_wrist_pitch_start_count() -> None:
+    import math
+
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction
+
+    raw_ranges = {
+        "base_yaw": (1226, 2839),
+        "base_pitch": (1124, 2345),
+        "elbow_pitch": (1444, 2673),
+        "wrist_roll": (1029, 2553),
+        "wrist_pitch": (1090, 3115),
+    }
+    calibration = {
+        motor: SimpleNamespace(
+            range_min=range_min,
+            range_max=range_max,
+            drive_mode=0,
+        )
+        for motor, (range_min, range_max) in raw_ranges.items()
+    }
+    present_raw = {
+        "base_yaw": 2047,
+        "base_pitch": 2769,
+        "elbow_pitch": 2860,
+        "wrist_roll": 2047,
+        "wrist_pitch": 2046,
+    }
+    target = {
+        "base_yaw": 1.3,
+        "base_pitch": 27.3,
+        "elbow_pitch": -0.9,
+        "wrist_roll": 22.5,
+        "wrist_pitch": -4.9,
+    }
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    hal._bus = SimpleNamespace(
+        motors={motor: SimpleNamespace(model="sts3215") for motor in calibration},
+        model_resolution_table={"sts3215": 4096},
+        calibration=calibration,
+    )
+
+    start = {motor: hal._raw_to_normalized(motor, float(raw), calibration[motor]) for motor, raw in present_raw.items()}
+    assert hal._normalized_to_raw("wrist_pitch", start["wrist_pitch"], calibration["wrist_pitch"]) == 2046
+
+    max_distance = max(abs(target[motor] - start[motor]) for motor in target)
+    frame_count = max(1, math.ceil(max_distance / 30.0 * 50))
+    frames = [
+        {motor: start[motor] + (target[motor] - start[motor]) * ((index + 1) / frame_count) for motor in target}
+        for index in range(frame_count)
+    ]
+
+    hal._validate_recovery_plan(present_raw, frames)
+
+    first_wrist_raw = hal._normalized_to_raw(
+        "wrist_pitch",
+        frames[0]["wrist_pitch"],
+        calibration["wrist_pitch"],
+    )
+    assert first_wrist_raw == 2046
+
+
+def test_hal_recovery_rejects_untrusted_path_without_enabling_torque() -> None:
+    from lampgo.core.config import DeviceConfig
+    from lampgo.core.hal import HardwareAbstraction, MotorStartupState
+
+    calibration = {
+        "base_pitch": SimpleNamespace(
+            range_min=1296,
+            range_max=2279,
+            homing_offset=1849,
+            drive_mode=0,
+        )
+    }
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
+    bus = _SafetyFakeBus(present=2276, calibration=calibration)
+    hal._bus = bus
+    hal._connected = True
+    hal._startup_state = MotorStartupState.RECOVERY_REQUIRED
+
+    with pytest.raises(RuntimeError, match="jumps"):
+        hal.prepare_recovery([{"base_pitch": 0.0}])
+
+    assert hal.startup_state is MotorStartupState.RECOVERY_REQUIRED
     assert ("Goal_Position", "base_pitch", 2276, False) not in bus.writes
     assert ("Torque_Enable", "base_pitch", 1, True) not in bus.writes
 
@@ -454,15 +673,11 @@ def test_hal_rejects_overflowed_and_edge_neutral_calibration() -> None:
         )
 
 
-def test_hal_final_neutral_confirmation_retries_without_discarding_calibration(
-    monkeypatch, capsys
-) -> None:
+def test_hal_final_neutral_confirmation_retries_without_discarding_calibration(monkeypatch, capsys) -> None:
     from lampgo.core.config import DeviceConfig
     from lampgo.core.hal import HardwareAbstraction
 
-    calibration = {
-        "base_pitch": SimpleNamespace(range_min=1429, range_max=2158, homing_offset=0)
-    }
+    calibration = {"base_pitch": SimpleNamespace(range_min=1429, range_max=2158, homing_offset=0)}
     hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
     bus = _SafetyFakeBus(calibration=calibration)
     positions = iter([2149, 2051])
@@ -485,15 +700,11 @@ def test_hal_final_neutral_confirmation_retries_without_discarding_calibration(
     assert "only 9 counts from calibrated limit" in capsys.readouterr().out
 
 
-def test_hal_final_pose_inside_limits_saves_even_when_not_exactly_neutral(
-    monkeypatch, capsys
-) -> None:
+def test_hal_final_pose_inside_limits_saves_even_when_not_exactly_neutral(monkeypatch, capsys) -> None:
     from lampgo.core.config import DeviceConfig
     from lampgo.core.hal import HardwareAbstraction
 
-    calibration = {
-        "elbow_pitch": SimpleNamespace(range_min=1422, range_max=2776, homing_offset=0)
-    }
+    calibration = {"elbow_pitch": SimpleNamespace(range_min=1422, range_max=2776, homing_offset=0)}
     hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null"))
     bus = _SafetyFakeBus()
     bus.motors = {"elbow_pitch": SimpleNamespace(model="sts3215")}
@@ -518,9 +729,7 @@ def test_hal_saved_calibration_marks_single_turn_verification(tmp_path) -> None:
     from lampgo.core.config import DeviceConfig
     from lampgo.core.hal import HardwareAbstraction
 
-    hal = HardwareAbstraction(
-        DeviceConfig(motor_port="/dev/null", lamp_id="TEST", calibration_dir=tmp_path)
-    )
+    hal = HardwareAbstraction(DeviceConfig(motor_port="/dev/null", lamp_id="TEST", calibration_dir=tmp_path))
     calibration = {
         "base_pitch": SimpleNamespace(
             id=2,

--- a/tests/test_install_lampgo.py
+++ b/tests/test_install_lampgo.py
@@ -8,12 +8,18 @@ from tools.install_lampgo import (
     HostInfo,
     Installer,
     InstallError,
+    _console_safe,
     assert_public_dependency_sources,
     build_uv_sync_command,
     detect_host,
     redact,
     validate_host,
 )
+
+
+def test_console_output_survives_legacy_windows_encoding() -> None:
+    rendered = _console_safe("LampGo 全量依赖安装器", "cp1252")
+    assert rendered == r"LampGo \u5168\u91cf\u4f9d\u8d56\u5b89\u88c5\u5668"
 
 
 def test_detects_supported_platform_families() -> None:

--- a/tests/test_motion_runtime.py
+++ b/tests/test_motion_runtime.py
@@ -43,3 +43,332 @@ def test_motion_velocity_clamp_advances_from_last_command_when_hardware_lags():
         assert max(hal.commands) > -80.0
     finally:
         motion.stop()
+
+
+def test_recovery_frame_can_escape_physical_edge_outside_normal_software_limit():
+    from lampgo.core.config import SafetyConfig
+    from lampgo.core.safety import SafetyKernel
+    from lampgo.core.types import JointState
+
+    safety = SafetyKernel(SafetyConfig(max_velocity=120.0))
+    current = JointState(positions={"wrist_pitch": -80.0})
+
+    normal = safety.validate_frame(current, {"wrist_pitch": -79.9}, dt=0.02)
+    recovery = safety.validate_recovery_frame(
+        current,
+        {"wrist_pitch": -70.0},
+        {"wrist_pitch": -4.9},
+        dt=0.02,
+        max_velocity=5.0,
+    )
+    away_from_safe = safety.validate_recovery_frame(
+        current,
+        {"wrist_pitch": -80.1},
+        {"wrist_pitch": -4.9},
+        dt=0.02,
+    )
+
+    assert normal["wrist_pitch"] == -45.0
+    assert recovery["wrist_pitch"] == -79.9
+    assert away_from_safe["wrist_pitch"] == -80.0
+
+
+def test_recovery_command_builds_bounded_lead_over_static_feedback():
+    from lampgo.core.config import SafetyConfig
+    from lampgo.core.safety import SafetyKernel
+    from lampgo.core.types import JointState
+
+    safety = SafetyKernel(SafetyConfig(max_velocity=120.0))
+    actual = JointState(positions={"base_pitch": -60.0})
+    command = {"base_pitch": -60.0}
+
+    for _ in range(40):
+        command = safety.validate_recovery_frame(
+            actual,
+            {"base_pitch": 0.0},
+            {"base_pitch": 0.0},
+            dt=0.02,
+            max_velocity=15.0,
+            command_reference=command,
+            max_command_lead=8.0,
+        )
+
+    assert command["base_pitch"] == -52.0
+
+
+def test_motion_recovery_overcomes_deadband_with_bounded_command_lead():
+    from lampgo.core.config import MotionConfig, SafetyConfig
+    from lampgo.core.motion import MotionRuntime
+    from lampgo.core.safety import SafetyKernel
+    from lampgo.core.types import JointState
+
+    class DeadbandRecoveryHal:
+        motor_names = ["base_pitch"]
+
+        def __init__(self) -> None:
+            self.recovery_required = True
+            self.position = -2.0
+            self.command_samples: list[tuple[float, float]] = []
+            self.completed = False
+            self.aborted = False
+
+        def read_recovery_start(self) -> dict[str, float]:
+            return {"base_pitch": self.position}
+
+        def prepare_recovery(self, frames: list[dict[str, float]]) -> dict[str, float]:
+            assert frames
+            self.recovery_required = False
+            return {"base_pitch": self.position}
+
+        def read_positions(self) -> JointState:
+            return JointState(positions={"base_pitch": self.position})
+
+        def write_recovery_positions(self, positions: dict[str, float]) -> None:
+            command = positions["base_pitch"]
+            before = self.position
+            self.command_samples.append((before, command))
+            error = command - before
+            # Model static friction/deadband: a one-tick 0.1 degree command
+            # cannot move the joint, but a bounded accumulated lead can.
+            if abs(error) >= 0.35:
+                self.position += 0.1 if error > 0 else -0.1
+
+        def complete_recovery(self) -> None:
+            self.completed = True
+
+        def abort_recovery(self) -> None:
+            self.aborted = True
+            self.recovery_required = True
+
+    hal = DeadbandRecoveryHal()
+    motion = MotionRuntime(
+        hal,
+        SafetyKernel(SafetyConfig(max_velocity=120.0)),
+        MotionConfig(tick_rate_hz=50, breathing_enabled=False),
+    )
+    frames = motion.prepare_recovery({"base_pitch": 0.0}, max_velocity=15.0, fps=50)
+    try:
+        done = motion.stream_recovery_frames(frames, fps=50)
+        assert done.wait(timeout=2.0)
+        assert _wait_for(lambda: abs(hal.position) < 1.0, timeout=0.5)
+        assert max(abs(command - actual) for actual, command in hal.command_samples) >= 0.35
+        assert max(abs(command - actual) for actual, command in hal.command_samples) <= 8.0
+        assert motion.recovery_error is None
+        motion.complete_recovery()
+        assert hal.completed is True
+        assert hal.aborted is False
+    finally:
+        motion.stop()
+
+
+def test_motion_recovery_ignores_stalled_joint_already_within_final_tolerance():
+    from lampgo.core.config import MotionConfig, SafetyConfig
+    from lampgo.core.motion import MotionRuntime
+    from lampgo.core.safety import SafetyKernel
+    from lampgo.core.types import JointState
+
+    class NearTargetJointHal:
+        motor_names = ["base_pitch", "wrist_roll"]
+
+        def __init__(self) -> None:
+            self.recovery_required = True
+            self.positions = {"base_pitch": -10.0, "wrist_roll": 1.15}
+            self.abort_count = 0
+
+        def read_recovery_start(self) -> dict[str, float]:
+            return dict(self.positions)
+
+        def prepare_recovery(self, frames: list[dict[str, float]]) -> dict[str, float]:
+            assert frames
+            self.recovery_required = False
+            return dict(self.positions)
+
+        def read_positions(self) -> JointState:
+            return JointState(positions=dict(self.positions))
+
+        def write_recovery_positions(self, positions: dict[str, float]) -> None:
+            # The load-bearing joint follows the command.  wrist_roll models
+            # the logged case: static at 1.15 degrees from target, already
+            # inside the return_safe completion envelope.
+            error = positions["base_pitch"] - self.positions["base_pitch"]
+            self.positions["base_pitch"] += max(-0.5, min(0.5, error))
+
+        def abort_recovery(self) -> None:
+            self.abort_count += 1
+            self.recovery_required = True
+
+    hal = NearTargetJointHal()
+    motion = MotionRuntime(
+        hal,
+        SafetyKernel(SafetyConfig(max_velocity=120.0)),
+        MotionConfig(tick_rate_hz=50, breathing_enabled=False),
+    )
+    frames = motion.prepare_recovery(
+        {"base_pitch": 0.0, "wrist_roll": 0.0},
+        max_velocity=15.0,
+        fps=50,
+    )
+    try:
+        done = motion.stream_recovery_frames(frames, fps=50)
+        assert done.wait(timeout=1.5)
+        assert hal.abort_count == 0
+        assert motion.recovery_error is None
+        assert abs(hal.positions["base_pitch"]) <= 5.0
+        assert hal.positions["wrist_roll"] == 1.15
+    finally:
+        motion.stop()
+
+
+def test_motion_recovery_keeps_holding_target_while_loaded_joint_is_progressing():
+    from lampgo.core.config import MotionConfig, SafetyConfig
+    from lampgo.core.motion import MotionRuntime
+    from lampgo.core.safety import SafetyKernel
+    from lampgo.core.types import JointState
+
+    class LoadedRecoveryHal:
+        motor_names = ["elbow_pitch"]
+
+        def __init__(self) -> None:
+            self.recovery_required = True
+            self.position = -10.0
+            self.abort_count = 0
+
+        def read_recovery_start(self) -> dict[str, float]:
+            return {"elbow_pitch": self.position}
+
+        def prepare_recovery(self, frames: list[dict[str, float]]) -> dict[str, float]:
+            assert frames
+            self.recovery_required = False
+            return {"elbow_pitch": self.position}
+
+        def read_positions(self) -> JointState:
+            return JointState(positions={"elbow_pitch": self.position})
+
+        def write_recovery_positions(self, positions: dict[str, float]) -> None:
+            error = positions["elbow_pitch"] - self.position
+            self.position += max(-0.1, min(0.1, error))
+
+        def abort_recovery(self) -> None:
+            self.abort_count += 1
+            self.recovery_required = True
+
+    hal = LoadedRecoveryHal()
+    motion = MotionRuntime(
+        hal,
+        SafetyKernel(SafetyConfig(max_velocity=120.0)),
+        MotionConfig(tick_rate_hz=50, breathing_enabled=False),
+    )
+    # A tiny ordinary-stream settle timeout makes this test fail immediately
+    # if recovery accidentally starts using a wall-clock settle cutoff again.
+    motion._STREAM_SETTLE_TIMEOUT_S = 0.1
+    frames = motion.prepare_recovery({"elbow_pitch": 0.0}, max_velocity=15.0, fps=50)
+    try:
+        done = motion.stream_recovery_frames(frames, fps=50)
+        time.sleep(0.9)
+        assert done.is_set() is False
+        assert hal.position < -5.0
+        assert done.wait(timeout=1.5)
+        assert abs(hal.position) <= 5.0
+        assert hal.abort_count == 0
+        assert motion.recovery_error is None
+    finally:
+        motion.stop()
+
+
+def test_motion_recovery_stall_warning_keeps_torque_and_target_active():
+    from lampgo.core.config import MotionConfig, SafetyConfig
+    from lampgo.core.motion import MotionRuntime
+    from lampgo.core.safety import SafetyKernel
+    from lampgo.core.types import JointState
+
+    class StalledRecoveryHal:
+        motor_names = ["base_pitch"]
+
+        def __init__(self) -> None:
+            self.recovery_required = True
+            self.abort_count = 0
+            self.commands: list[float] = []
+
+        def read_recovery_start(self) -> dict[str, float]:
+            return {"base_pitch": -10.0}
+
+        def prepare_recovery(self, frames: list[dict[str, float]]) -> dict[str, float]:
+            self.recovery_required = False
+            return {"base_pitch": -10.0}
+
+        def read_positions(self) -> JointState:
+            return JointState(positions={"base_pitch": -10.0})
+
+        def write_recovery_positions(self, positions: dict[str, float]) -> None:
+            self.commands.append(positions["base_pitch"])
+
+        def abort_recovery(self) -> None:
+            self.abort_count += 1
+            self.recovery_required = True
+
+    hal = StalledRecoveryHal()
+    motion = MotionRuntime(
+        hal,
+        SafetyKernel(SafetyConfig(max_velocity=120.0)),
+        MotionConfig(tick_rate_hz=50, breathing_enabled=False),
+    )
+    motion._RECOVERY_STALL_TIMEOUT_S = 0.3
+    frames = motion.prepare_recovery({"base_pitch": 0.0}, max_velocity=15.0, fps=50)
+    try:
+        done = motion.stream_recovery_frames(frames, fps=50)
+        time.sleep(0.8)
+        assert done.is_set() is False
+        assert hal.abort_count == 0
+        assert motion.recovery_error is None
+        assert max(command + 10.0 for command in hal.commands) <= 8.0
+    finally:
+        motion.stop()
+
+
+def test_motion_recovery_feedback_warning_does_not_release_torque():
+    from lampgo.core.config import MotionConfig, SafetyConfig
+    from lampgo.core.motion import MotionRuntime
+    from lampgo.core.safety import SafetyKernel
+    from lampgo.core.types import JointState
+
+    class EscapingRecoveryHal:
+        motor_names = ["base_pitch"]
+
+        def __init__(self) -> None:
+            self.recovery_required = True
+            self.position = -10.0
+            self.abort_count = 0
+
+        def read_recovery_start(self) -> dict[str, float]:
+            return {"base_pitch": self.position}
+
+        def prepare_recovery(self, frames: list[dict[str, float]]) -> dict[str, float]:
+            self.recovery_required = False
+            return {"base_pitch": self.position}
+
+        def read_positions(self) -> JointState:
+            return JointState(positions={"base_pitch": self.position})
+
+        def write_recovery_positions(self, positions: dict[str, float]) -> None:
+            del positions
+            self.position = -12.0
+
+        def abort_recovery(self) -> None:
+            self.abort_count += 1
+            self.recovery_required = True
+
+    hal = EscapingRecoveryHal()
+    motion = MotionRuntime(
+        hal,
+        SafetyKernel(SafetyConfig(max_velocity=120.0)),
+        MotionConfig(tick_rate_hz=50, breathing_enabled=False),
+    )
+    frames = motion.prepare_recovery({"base_pitch": 0.0}, max_velocity=15.0, fps=50)
+    try:
+        done = motion.stream_recovery_frames(frames, fps=50)
+        time.sleep(0.3)
+        assert done.is_set() is False
+        assert hal.abort_count == 0
+        assert motion.recovery_error is None
+    finally:
+        motion.stop()

--- a/tests/test_motion_skills.py
+++ b/tests/test_motion_skills.py
@@ -45,6 +45,181 @@ def test_return_safe_disables_anticipation():
     asyncio.run(run())
 
 
+def test_return_safe_recovery_prevalidates_guarded_path_before_streaming():
+    from lampgo.skills.builtin.motion_skills import (
+        RECOVERY_HOME_FPS,
+        RECOVERY_HOME_VELOCITY,
+        ReturnSafeSkill,
+        get_safe_position,
+        set_calibration_home,
+    )
+
+    class FakeRecoveryMotion:
+        def __init__(self) -> None:
+            self.recovery_required = True
+            self.current_state = SimpleNamespace(positions=get_safe_position())
+            self.prepared: tuple[dict[str, float], float, int] | None = None
+            self.streamed = False
+            self.completed = False
+
+        def prepare_recovery(self, target, *, max_velocity, fps):
+            self.prepared = (dict(target), max_velocity, fps)
+            return [dict(target)]
+
+        def stream_recovery_frames(self, frames, fps):
+            import threading
+
+            assert self.prepared is not None
+            assert frames == [self.prepared[0]]
+            assert fps == RECOVERY_HOME_FPS
+            self.streamed = True
+            done = threading.Event()
+            done.set()
+            return done
+
+        def complete_recovery(self):
+            self.completed = True
+            self.recovery_required = False
+
+        def abort_recovery(self):
+            raise AssertionError("successful recovery must not abort")
+
+    async def run() -> None:
+        set_calibration_home(
+            {
+                "base_yaw": 0.0,
+                "base_pitch": 27.3,
+                "elbow_pitch": -0.9,
+                "wrist_roll": 22.5,
+                "wrist_pitch": -4.9,
+            }
+        )
+        motion = FakeRecoveryMotion()
+        motion.current_state = SimpleNamespace(positions=get_safe_position())
+
+        result = await ReturnSafeSkill().execute(SimpleNamespace(motion=motion), velocity=60.0)
+
+        assert result.status == "ok"
+        assert motion.prepared is not None
+        assert motion.prepared[1:] == (RECOVERY_HOME_VELOCITY, RECOVERY_HOME_FPS)
+        assert motion.streamed is True
+        assert motion.completed is True
+
+    asyncio.run(run())
+
+
+def test_return_safe_recovery_velocity_is_thirty_degrees_per_second():
+    from lampgo.skills.builtin.motion_skills import RECOVERY_HOME_VELOCITY
+
+    assert RECOVERY_HOME_VELOCITY == 30.0
+
+
+def test_return_safe_logged_three_degree_elbow_error_unblocks_next_motion():
+    from lampgo.skills.builtin.motion_skills import ReturnSafeSkill, get_safe_position, set_calibration_home
+
+    class NearSafeRecoveryMotion:
+        def __init__(self) -> None:
+            self.recovery_required = True
+            self.is_running = True
+            positions = get_safe_position()
+            positions["elbow_pitch"] += 3.05
+            self.current_state = SimpleNamespace(positions=positions)
+            self.completed = False
+
+        def prepare_recovery(self, target, *, max_velocity, fps):
+            del max_velocity, fps
+            return [dict(target)]
+
+        def stream_recovery_frames(self, frames, fps):
+            import threading
+
+            del frames, fps
+            done = threading.Event()
+            done.set()
+            return done
+
+        def complete_recovery(self):
+            self.completed = True
+            self.recovery_required = False
+
+        def abort_recovery(self):
+            raise AssertionError("a safe three-degree residual must not release torque")
+
+    class FakeIdleSway(Skill):
+        skill_id = "idle_sway"
+
+        async def execute(self, ctx, **params):
+            del ctx, params
+            return SkillResult(status="ok", data={"started": True})
+
+    async def run() -> None:
+        set_calibration_home(
+            {
+                "base_yaw": 1.3,
+                "base_pitch": 27.3,
+                "elbow_pitch": -0.9,
+                "wrist_roll": 22.5,
+                "wrist_pitch": -4.9,
+            }
+        )
+        motion = NearSafeRecoveryMotion()
+        registry = SkillRegistry()
+        registry.register(ReturnSafeSkill())
+        registry.register(FakeIdleSway())
+        executor = SkillExecutor(registry, EventBus())
+        executor.set_motion_block_reason("Recovery required", allow_return_safe_recovery=True)
+        ctx = SimpleNamespace(motion=motion, led=SimpleNamespace(is_connected=False), clock=None)
+
+        recovered = await executor.invoke("return_safe", ctx)
+        next_motion = await executor.invoke("idle_sway", ctx)
+
+        assert recovered.status == "ok"
+        assert motion.completed is True
+        assert next_motion.status == "ok"
+        assert next_motion.result == {"started": True}
+
+    asyncio.run(run())
+
+
+def test_return_safe_recovery_error_keeps_torque_enabled():
+    from lampgo.skills.builtin.motion_skills import ReturnSafeSkill, get_safe_position
+
+    class FailedRecoveryMotion:
+        def __init__(self) -> None:
+            self.recovery_required = True
+            self.recovery_error = "Recovery feedback watchdog stopped motion: base_pitch stalled"
+            self.current_state = SimpleNamespace(positions=get_safe_position())
+            self.aborted = False
+
+        def prepare_recovery(self, target, *, max_velocity, fps):
+            del max_velocity, fps
+            return [dict(target)]
+
+        def stream_recovery_frames(self, frames, fps):
+            import threading
+
+            del frames, fps
+            done = threading.Event()
+            done.set()
+            return done
+
+        def abort_recovery(self):
+            self.aborted = True
+
+        def stop_immediate(self):
+            pass
+
+    async def run() -> None:
+        motion = FailedRecoveryMotion()
+        result = await ReturnSafeSkill().execute(SimpleNamespace(motion=motion), velocity=60.0)
+
+        assert result.status == "error"
+        assert "feedback watchdog" in result.message
+        assert motion.aborted is False
+
+    asyncio.run(run())
+
+
 def test_executor_preempts_running_skill():
     class SlowSkill(Skill):
         skill_id = "slow_test"
@@ -120,6 +295,46 @@ def test_executor_rejects_virtual_motion_after_hardware_startup_failure() -> Non
         assert result.status == "rejected"
         assert result.error_code == "motor_hardware_unavailable"
         assert result.error_detail == "Unsafe startup pose; torque remains disabled"
+
+    asyncio.run(run())
+
+
+def test_executor_allows_only_return_safe_while_recovery_is_required() -> None:
+    class FakeReturnSafe(Skill):
+        skill_id = "return_safe"
+
+        async def execute(self, ctx, **params):
+            del params
+            ctx.motion.recovery_required = False
+            return SkillResult(status="ok", data={"recovered": True})
+
+    class FakeMoveTo(Skill):
+        skill_id = "move_to"
+
+        async def execute(self, ctx, **params):
+            del ctx, params
+            raise AssertionError("ordinary motion must stay blocked during recovery")
+
+    async def run() -> None:
+        registry = SkillRegistry()
+        registry.register(FakeReturnSafe())
+        registry.register(FakeMoveTo())
+        executor = SkillExecutor(registry, EventBus())
+        executor.set_motion_block_reason(
+            "Recovery required",
+            allow_return_safe_recovery=True,
+        )
+        ctx = SimpleNamespace(
+            motion=SimpleNamespace(is_running=False, recovery_required=True),
+            led=SimpleNamespace(is_connected=False),
+        )
+
+        blocked = await executor.invoke("move_to", ctx)
+        recovered = await executor.invoke("return_safe", ctx)
+
+        assert blocked.status == "rejected"
+        assert recovered.status == "ok"
+        assert recovered.result == {"recovered": True}
 
     asyncio.run(run())
 

--- a/tests/test_parametric_skills.py
+++ b/tests/test_parametric_skills.py
@@ -1,0 +1,86 @@
+"""Regression tests for parametric factory motions."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+
+def test_idle_sway_repeated_runs_share_calibration_centre_and_recenter(monkeypatch) -> None:
+    from lampgo.core.types import JointState, MotionStatus
+    from lampgo.skills.builtin import parametric_skills
+    from lampgo.skills.builtin.motion_skills import set_calibration_home
+    from lampgo.skills.builtin.parametric_skills import IdleSwaySkill
+
+    monkeypatch.setattr(parametric_skills, "_jitter", lambda value, ratio=0.15: value)
+    monkeypatch.setattr(parametric_skills.random, "choice", lambda values: values[-1])
+    monkeypatch.setattr(parametric_skills.random, "uniform", lambda low, high: (low + high) / 2.0)
+
+    centre = {"base_yaw": 1.3, "base_pitch": 27.3}
+    set_calibration_home({**centre, "elbow_pitch": -0.9, "wrist_roll": 22.5, "wrist_pitch": -4.9})
+
+    class FakeMotion:
+        def __init__(self) -> None:
+            self.streams: list[list[dict[str, float]]] = []
+            self.targets = []
+            self.current_state = JointState(positions=dict(centre))
+            self.status = MotionStatus()
+
+        def stream_frames(self, frames, fps=50):
+            del fps
+            self.streams.append([dict(frame) for frame in frames])
+            done = threading.Event()
+            done.set()
+            return done
+
+        def move_to(self, target):
+            self.targets.append(target)
+            self.current_state = JointState(positions=dict(target.joints))
+            done = threading.Event()
+            done.set()
+            return done
+
+        def stop_immediate(self):
+            pass
+
+    async def run() -> None:
+        motion = FakeMotion()
+        skill = IdleSwaySkill()
+
+        first = await skill.execute(
+            SimpleNamespace(
+                motion=motion,
+                state=JointState(positions={"base_pitch": 12.0, "base_yaw": -8.0}),
+            ),
+            amplitude=6.0,
+            period=4.0,
+            duration=1.0,
+        )
+        second = await skill.execute(
+            SimpleNamespace(
+                motion=motion,
+                state=JointState(positions={"base_pitch": -5.0, "base_yaw": 15.0}),
+            ),
+            amplitude=6.0,
+            period=4.0,
+            duration=1.0,
+        )
+
+        assert first.status == "ok"
+        assert second.status == "ok"
+        assert first.data["centre"] == centre
+        assert second.data["centre"] == centre
+        assert len(motion.streams) == 2
+        assert all(stream[-1] == centre for stream in motion.streams)
+        assert len(motion.targets) == 2
+        assert all(target.joints == centre for target in motion.targets)
+        assert all(target.max_velocity == 30.0 for target in motion.targets)
+        assert all(target.anticipation is False for target in motion.targets)
+
+        # The oscillation section is identical across runs even though the
+        # measured starting poses differ, proving there is no cumulative base.
+        sway_frame_count = 50
+        assert motion.streams[0][-sway_frame_count:] == motion.streams[1][-sway_frame_count:]
+
+    asyncio.run(run())

--- a/tools/install_lampgo.py
+++ b/tools/install_lampgo.py
@@ -16,6 +16,7 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -182,6 +183,13 @@ def _format_command(command: Sequence[str]) -> str:
     return shlex.join(command)
 
 
+def _console_safe(message: str, encoding: str | None = None) -> str:
+    """Render text without failing on legacy Windows console encodings."""
+
+    target_encoding = encoding or getattr(sys.stdout, "encoding", None) or "utf-8"
+    return message.encode(target_encoding, errors="backslashreplace").decode(target_encoding)
+
+
 class Installer:
     def __init__(self, project_root: Path, log_path: Path) -> None:
         self.project_root = project_root
@@ -195,7 +203,7 @@ class Installer:
 
     def emit(self, message: str = "") -> None:
         safe = redact(message.rstrip("\n"))
-        print(safe, flush=True)
+        print(_console_safe(safe), flush=True)
         self._log.write(safe + "\n")
 
     def run(self, command: Sequence[str], *, stage: str) -> None:


### PR DESCRIPTION
## What
- Add an explicit recovery-required startup state for torque-free poses outside the calibrated operating range but inside a guarded single-turn envelope.
- Allow only a fully prevalidated return-safe trajectory to energize motors during recovery, then keep torque enabled at the safe target.
- Increase recovery return-safe speed to 30 deg/s with larger raw frame steps so a fallen lamp can stand up in one motion.
- Keep runtime target clipping and safety monitoring without releasing torque for ordinary non-overcurrent motion warnings.
- Recenter idle-sway on the fixed calibration safe pose before and after each cycle so repeated idle motion cannot drift the lamp progressively lower.
- Make installer console output safe on legacy Windows encodings while retaining the original UTF-8 text in persistent logs.

## Why
A naturally fallen, torque-free lamp could not start return-safe, while earlier safety handling could also interrupt motion and drop the arm. Repeated idle-sway cycles additionally inherited the measured pose and accumulated downward drift. The PR also exposed a deterministic Windows CI failure when CP1252 attempted to print the installers Chinese status text.

## Root cause
Startup validation treated recoverable out-of-range feedback as unavailable hardware, and recovery execution used ordinary motion lifecycle assumptions. Idle-sway used the current measured pose as its next center instead of the calibrated safe center. Installer output assumed every console could encode Chinese text.

## Impact
Recovery remains fail-closed for untrusted feedback and invalid paths, but a validated fallen pose can return to the calibrated home and hold there. Normal actions remain available after recovery, idle motion no longer accumulates a lower center, and Windows installation diagnostics cannot crash solely because of console encoding.

## Checks
- uv run pytest -q: 321 passed, 1 existing deprecation warning
- uv run pytest tests/test_install_lampgo.py -q: 8 passed
- uv run ruff check --ignore E501 on all changed recovery source/test files: passed
- uv run ruff check tools/install_lampgo.py tests/test_install_lampgo.py: passed
- git diff --check: passed

The unignored lint run only reported three pre-existing E501 lines in lampgo/server.py outside this PR diff.