### PR TITLE
feat: add LED matrix clock mode

### DIFF
--- a/lampgo/clock.py
+++ b/lampgo/clock.py
@@ -1,0 +1,144 @@
+"""Backend-owned LED clock state and minute-level device updates."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable
+
+from lampgo.core.led import LEDController
+
+CLOCK_EFFECTS = frozenset({"steady", "blink", "orbit"})
+DEFAULT_CLOCK_COLOR = "#37d6ff"
+DEFAULT_CLOCK_BRIGHTNESS = 32
+
+
+def _clock_path() -> Path:
+    root = Path(os.environ.get("LAMPGO_HOME", Path.home() / ".lampgo"))
+    return root / "clock.json"
+
+
+def _normalize_color(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    if len(text) == 7 and text.startswith("#") and all(ch in "0123456789abcdef" for ch in text[1:]):
+        return text
+    return DEFAULT_CLOCK_COLOR
+
+
+def _normalize_effect(value: Any) -> str:
+    effect = str(value or "").strip().lower()
+    return effect if effect in CLOCK_EFFECTS else "steady"
+
+
+def _normalize_brightness(value: Any) -> int:
+    try:
+        return max(1, min(96, int(value)))
+    except (TypeError, ValueError):
+        return DEFAULT_CLOCK_BRIGHTNESS
+
+
+@dataclass
+class ClockSettings:
+    enabled: bool = False
+    color: str = DEFAULT_CLOCK_COLOR
+    brightness: int = DEFAULT_CLOCK_BRIGHTNESS
+    effect: str = "steady"
+
+    @classmethod
+    def from_mapping(cls, value: Any) -> "ClockSettings":
+        data = value if isinstance(value, dict) else {}
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            color=_normalize_color(data.get("color")),
+            brightness=_normalize_brightness(data.get("brightness")),
+            effect=_normalize_effect(data.get("effect")),
+        )
+
+
+class ClockController:
+    """Keeps a durable clock preference and sends only minute changes to S3."""
+
+    def __init__(
+        self,
+        led: LEDController,
+        *,
+        path: Path | None = None,
+        now: Callable[[], datetime] | None = None,
+        brightness_ceiling: Callable[[], int] | None = None,
+    ) -> None:
+        self._led = led
+        self._path = path or _clock_path()
+        self._now = now or (lambda: datetime.now().astimezone())
+        self._brightness_ceiling = brightness_ceiling or (lambda: 96)
+        self._settings = self._load()
+        self._last_minute_key = ""
+        self._last_sent_at = ""
+
+    def _load(self) -> ClockSettings:
+        try:
+            return ClockSettings.from_mapping(json.loads(self._path.read_text(encoding="utf-8")))
+        except Exception:
+            return ClockSettings()
+
+    def _save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(asdict(self._settings), ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def snapshot(self, now: datetime | None = None) -> dict[str, Any]:
+        current = now or self._now()
+        return {
+            **asdict(self._settings),
+            "time": current.strftime("%H:%M"),
+            "timezone": current.tzname() or "local",
+            "last_sent_at": self._last_sent_at or None,
+        }
+
+    def show(self, *, color: Any = None, brightness: Any = None, effect: Any = None) -> dict[str, Any]:
+        if color is not None:
+            self._settings.color = _normalize_color(color)
+        if brightness is not None:
+            self._settings.brightness = min(_normalize_brightness(brightness), _normalize_brightness(self._brightness_ceiling()))
+        if effect is not None:
+            self._settings.effect = _normalize_effect(effect)
+        self._settings.enabled = True
+        self._save()
+        return self.refresh(force=True)
+
+    def refresh(self, *, force: bool = False) -> dict[str, Any]:
+        current = self._now()
+        state = self.snapshot(current)
+        if not self._settings.enabled:
+            return {"ok": True, "sent": False, **state}
+
+        minute_key = current.strftime("%Y%m%d%H%M")
+        if not force and minute_key == self._last_minute_key:
+            return {"ok": True, "sent": False, **state}
+
+        ok = self._led.show_clock(
+            hour=current.hour,
+            minute=current.minute,
+            color=self._settings.color,
+            brightness=min(self._settings.brightness, _normalize_brightness(self._brightness_ceiling())),
+            effect=self._settings.effect,
+        )
+        if ok:
+            self._last_minute_key = minute_key
+            self._last_sent_at = current.isoformat(timespec="seconds")
+        return {"ok": ok, "sent": True, **self.snapshot(current)}
+
+    def stop(self) -> dict[str, Any]:
+        self._settings.enabled = False
+        self._last_minute_key = ""
+        self._save()
+        ok = self._led.stop_clock()
+        return {"ok": ok, "sent": True, **self.snapshot()}
+
+    def deactivate(self) -> None:
+        """Prevent a saved clock from reappearing after another LED feature wins."""
+        if self._settings.enabled:
+            self._settings.enabled = False
+            self._last_minute_key = ""
+            self._save()

--- a/lampgo/core/led.py
+++ b/lampgo/core/led.py
@@ -242,6 +242,38 @@ class LEDController:
         """Stop a composed eye/LED expression on the paired device."""
         return self._send_remote_path("/device/expressions/stop", {}, reason="expression_stop")
 
+    def show_clock(
+        self,
+        *,
+        hour: int,
+        minute: int,
+        color: str,
+        brightness: int,
+        effect: str,
+    ) -> bool:
+        """Render a backend-sourced local time on the S3 LED matrix."""
+        if self._serial is not None:
+            logger.warning("led.clock_requires_paired_esp32")
+            return False
+        return self._send_remote_path(
+            "/device/clock",
+            {
+                "enabled": True,
+                "hour": max(0, min(23, int(hour))),
+                "minute": max(0, min(59, int(minute))),
+                "color": str(color),
+                "brightness": max(1, min(96, int(brightness))),
+                "effect": str(effect),
+            },
+            reason="clock",
+        )
+
+    def stop_clock(self) -> bool:
+        """Disable the device clock renderer without changing eye playback."""
+        if self._serial is not None:
+            return self.off()
+        return self._send_remote_path("/device/clock", {"enabled": False}, reason="clock_stop")
+
     def _send(self, command: str) -> bool:
         if self._serial is None:
             logger.debug("led.send_skipped (not connected)", cmd=command.strip())

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -38,6 +38,7 @@ from lampgo.core.events import (
 )
 from lampgo.core.hal import HardwareAbstraction, MotorStartupState
 from lampgo.core.led import LEDController
+from lampgo.clock import ClockController
 from lampgo.core.motion import MotionRuntime
 from lampgo.core.safety import SafetyKernel
 from lampgo.core.virtual_motion import VirtualMotionRuntime
@@ -53,7 +54,7 @@ from lampgo.recordings import (
 )
 from lampgo.skills.base import SkillContext
 from lampgo.skills.builtin.cat_teaser import CatTeaserSkill
-from lampgo.skills.builtin.expression_skills import SetExpressionSkill
+from lampgo.skills.builtin.expression_skills import SetExpressionSkill, ShowClockSkill
 from lampgo.skills.builtin.motion_skills import EStopSkill, MoveToSkill, ReturnSafeSkill
 from lampgo.skills.builtin.music_skills import DanceToMusicSkill
 from lampgo.skills.builtin.parametric_skills import (
@@ -104,6 +105,10 @@ class LampgoServer:
         # the old serial config fields readable for legacy files, but do not
         # open a local LED serial port from the web runtime.
         self.led = LEDController(LEDConfig(port="", baud_rate=config.led.baud_rate), esp32_manager=self.esp32)
+        self.clock = ClockController(
+            self.led,
+            brightness_ceiling=lambda: getattr(self.config.device_esp32, "led_brightness", 96),
+        )
         self.fsm = StateMachine()
         self.registry = SkillRegistry()
         self.executor = SkillExecutor(self.registry, self.events)
@@ -168,6 +173,7 @@ class LampgoServer:
         self.registry.register(EStopSkill())
         self.registry.register(PlayRecordingSkill(recordings_dir))
         self.registry.register(SetExpressionSkill())
+        self.registry.register(ShowClockSkill())
         self.registry.register(NodSkill())
         self.registry.register(HeadShakeSkill())
         self.registry.register(LookAtSkill())
@@ -247,6 +253,7 @@ class LampgoServer:
             led=self.led,
             events=self.events,
             state=self.motion.current_state,
+            clock=self.clock,
         )
 
     async def _on_skill_started(self, event: SkillStarted) -> None:

--- a/lampgo/skills/base.py
+++ b/lampgo/skills/base.py
@@ -50,6 +50,7 @@ class SkillContext:
     led: LEDController
     events: EventBus
     state: JointState
+    clock: Any | None = None
 
     async def play_frames(
         self,

--- a/lampgo/skills/builtin/expression_skills.py
+++ b/lampgo/skills/builtin/expression_skills.py
@@ -64,3 +64,46 @@ class SetExpressionSkill(Skill):
                 "mode": LED_EXPRESSIONS[canonical],
             },
         )
+
+
+class ShowClockSkill(Skill):
+    """Show the backend's local time on the S3 LED matrix."""
+
+    skill_id = "show_clock"
+    description = "Show the backend local time on the S3 LED display and keep it updated once per minute."
+    parameters = {
+        "color": ParameterSpec(
+            name="color",
+            type="str",
+            required=False,
+            default="#37d6ff",
+            description="Clock color as #RRGGBB.",
+        ),
+        "brightness": ParameterSpec(
+            name="brightness",
+            type="int",
+            required=False,
+            default=32,
+            description="Clock brightness from 1 to 96.",
+        ),
+        "effect": ParameterSpec(
+            name="effect",
+            type="str",
+            required=False,
+            default="steady",
+            description="Clock effect: steady, blink, or orbit.",
+        ),
+    }
+
+    async def execute(self, ctx: SkillContext, **params: Any) -> SkillResult:
+        clock = ctx.clock
+        if clock is None:
+            return SkillResult(status="error", message="Clock controller unavailable")
+        result = clock.show(
+            color=params.get("color"),
+            brightness=params.get("brightness"),
+            effect=params.get("effect"),
+        )
+        if not result.get("ok"):
+            return SkillResult(status="error", message="LED clock could not reach the paired device", data=result)
+        return SkillResult(status="ok", data=result)

--- a/lampgo/skills/executor.py
+++ b/lampgo/skills/executor.py
@@ -28,6 +28,7 @@ _MOTION_SKILLS = {
 }
 _LED_SKILLS = {
     "set_expression",
+    "show_clock",
     "presence_react",
     "teleop_mouse", "teleop_gamepad",
 }
@@ -102,6 +103,8 @@ class SkillExecutor:
                 status="ok",
                 result={"note": "LED not connected, skipped"},
             )
+        if skill_id in _LED_SKILLS and skill_id != "show_clock" and ctx.clock is not None:
+            ctx.clock.deactivate()
 
         async with self._lock:
             # Cancel current skill if running. This gives rapid UI clicks

--- a/lampgo/web/gateway.py
+++ b/lampgo/web/gateway.py
@@ -201,6 +201,7 @@ class WebGateway:
         self.bridge = WsBridge(server.events)
         self._status_task: asyncio.Task | None = None
         self._pet_pose_task: asyncio.Task | None = None
+        self._clock_task: asyncio.Task | None = None
         self._active_request_tasks: dict[WebSocket, asyncio.Task] = {}
         self._background_ws_tasks: set[asyncio.Task[None]] = set()
         self._esp32_relay_tasks: dict[WebSocket, asyncio.Task] = {}
@@ -253,6 +254,9 @@ class WebGateway:
             Route("/api/expressions/play", self.api_expression_play, methods=["POST"]),
             Route("/api/expressions/stop", self.api_expression_stop, methods=["POST"]),
             Route("/api/device/expression-capabilities", self.api_expression_capabilities, methods=["GET"]),
+            Route("/api/clock", self.api_clock, methods=["GET"]),
+            Route("/api/clock/show", self.api_clock_show, methods=["POST"]),
+            Route("/api/clock/stop", self.api_clock_stop, methods=["POST"]),
             Route("/api/camera/snap", self.api_camera_snap),
             Route("/api/sensor/context", self.api_sensor_context),
             Route("/api/agent/ask", self.api_agent_ask, methods=["POST"]),
@@ -322,8 +326,9 @@ class WebGateway:
             app.state.lampgo_server = self.server
             self._status_task = asyncio.create_task(self._status_loop())
             self._pet_pose_task = asyncio.create_task(self._pet_pose_loop())
+            self._clock_task = asyncio.create_task(self._clock_loop())
             yield
-            for task in (self._status_task, self._pet_pose_task):
+            for task in (self._status_task, self._pet_pose_task, self._clock_task):
                 if not task:
                     continue
                 task.cancel()
@@ -359,6 +364,15 @@ class WebGateway:
                 await self.bridge.broadcast_status(status.get("result", {}))
             except Exception:
                 logger.exception("web.status_loop_error")
+
+    async def _clock_loop(self) -> None:
+        """Refresh an enabled LED clock once per backend minute."""
+        while True:
+            try:
+                await asyncio.to_thread(self.server.clock.refresh)
+            except Exception:
+                logger.exception("web.clock_refresh_failed")
+            await asyncio.sleep(1.0)
 
     async def _pet_pose_loop(self) -> None:
         """Broadcast joint poses at animation-friendly cadence for the Web pet."""
@@ -1074,6 +1088,7 @@ class WebGateway:
     async def _play_resolved_expression(self, composition: dict[str, Any]) -> tuple[int, Any]:
         if not self.server.esp32:
             return 503, {"ok": False, "error": "no_device"}
+        self.server.clock.deactivate()
         effect = composition.get("led_effect") or {}
         if effect.get("kind") == "pixel_clip" and composition.get("led_effect_id"):
             sync_status, sync_body, _ = await self._sync_led_effect_to_device(
@@ -1113,11 +1128,36 @@ class WebGateway:
         )
 
     async def api_expression_stop(self, request: Request) -> JSONResponse:
+        self.server.clock.deactivate()
         if not self.server.esp32:
             return JSONResponse({"ok": False, "error": "no_device"}, status_code=503)
         payload = self.server.esp32.with_owner_auth({}, reason="expression_stop")
         status, body, _ = await self.server.esp32.proxy_post("/device/expressions/stop", payload)
         return JSONResponse(body if isinstance(body, dict) else {"ok": False, "raw": str(body)}, status_code=status)
+
+    async def api_clock(self, request: Request) -> JSONResponse:
+        return JSONResponse({"ok": True, "result": self.server.clock.snapshot()})
+
+    async def api_clock_show(self, request: Request) -> JSONResponse:
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        if not isinstance(body, dict):
+            return JSONResponse({"ok": False, "error": "body must be object"}, status_code=400)
+        result = await asyncio.to_thread(
+            self.server.clock.show,
+            color=body.get("color"),
+            brightness=body.get("brightness"),
+            effect=body.get("effect"),
+        )
+        status = 200 if result.get("ok") else 503
+        return JSONResponse({"ok": bool(result.get("ok")), "result": result}, status_code=status)
+
+    async def api_clock_stop(self, request: Request) -> JSONResponse:
+        result = await asyncio.to_thread(self.server.clock.stop)
+        status = 200 if result.get("ok") else 503
+        return JSONResponse({"ok": bool(result.get("ok")), "result": result}, status_code=status)
 
     async def api_expression_capabilities(self, request: Request) -> JSONResponse:
         local = expression_capabilities()
@@ -2575,6 +2615,9 @@ class WebGateway:
                         "brightness": device_body.get("led_brightness"),
                         "last_command": device_body.get("led_last_command"),
                         "last_write_ms": device_body.get("led_last_write_ms"),
+                        "clock_active": bool(device_body.get("led_clock_active")),
+                        "clock_effect": device_body.get("led_clock_effect"),
+                        "clock_time": device_body.get("led_clock_time"),
                         "driver": device_body.get("led_driver"),
                         "pixel_pin": device_body.get("led_pixel_pin"),
                         "pixel_count": device_body.get("led_pixel_count"),
@@ -2686,6 +2729,8 @@ class WebGateway:
                 return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
             status, body = await self._play_resolved_expression(composition)
             return JSONResponse(self._with_expression_catalog(body), status_code=status)
+        if any(key in patch for key in ("mode", "expression", "name", "clip_id")):
+            self.server.clock.deactivate()
         if self.server.esp32 and hasattr(self.server.esp32, "with_owner_auth"):
             patch = self.server.esp32.with_owner_auth(patch, reason="led")
         status, body, _ = await self.server.esp32.proxy_post("/device/led", patch)

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -69,6 +69,13 @@
   const btnExpressionPlay = document.getElementById("btn-expression-play");
   const btnExpressionStop = document.getElementById("btn-expression-stop");
   const btnExpressionSave = document.getElementById("btn-expression-save");
+  const clockPreview = document.getElementById("clock-preview");
+  const clockColor = document.getElementById("clock-color");
+  const clockBrightness = document.getElementById("clock-brightness");
+  const clockEffect = document.getElementById("clock-effect");
+  const clockStatus = document.getElementById("clock-status");
+  const btnClockShow = document.getElementById("btn-clock-show");
+  const btnClockStop = document.getElementById("btn-clock-stop");
   const agentTaskList = document.getElementById("agent-task-list");
   const chipJoint = document.getElementById("chip-joint");
   const chipJointDot = document.getElementById("chip-joint-dot");
@@ -237,6 +244,7 @@
   let expressionPlayback = "loop";
   let expressionPreviewTimer = null;
   let expressionPreviewImage = null;
+  let clockPreviewTimer = null;
   const ledEffectSourceCache = new Map();
   const LED_EDITOR_WIDTH = 51;
   const LED_EDITOR_HEIGHT = 9;
@@ -3776,6 +3784,80 @@
     renderExpressionPresets();
   }
 
+  function renderClockPreview() {
+    if (!clockPreview) return;
+    const now = new Date();
+    clockPreview.textContent = now.toLocaleTimeString("zh-CN", {
+      hour12: false, hour: "2-digit", minute: "2-digit",
+    });
+    const color = (clockColor && clockColor.value) || "#37d6ff";
+    const effect = (clockEffect && clockEffect.value) || "steady";
+    clockPreview.style.color = color;
+    clockPreview.classList.toggle("is-blink", effect === "blink");
+    clockPreview.classList.toggle("is-orbit", effect === "orbit");
+  }
+
+  function startClockPreview() {
+    if (clockPreviewTimer) return;
+    renderClockPreview();
+    clockPreviewTimer = window.setInterval(renderClockPreview, 1000);
+  }
+
+  function applyClockState(state) {
+    if (!state || typeof state !== "object") return;
+    if (clockColor && state.color) clockColor.value = state.color;
+    if (clockBrightness && state.brightness) clockBrightness.value = String(state.brightness);
+    if (clockEffect && state.effect) clockEffect.value = state.effect;
+    renderClockPreview();
+    if (clockStatus) {
+      clockStatus.textContent = state.enabled
+        ? `已显示 ${state.time || "--:--"}，后端每分钟更新一次。`
+        : "显示后由本机后端每分钟更新一次。";
+    }
+  }
+
+  async function refreshClock() {
+    try {
+      const result = await fetchJson("/api/clock");
+      applyClockState(result);
+    } catch (error) {
+      if (clockStatus) clockStatus.textContent = `时钟状态加载失败：${error.message || error}`;
+    }
+  }
+
+  async function showClock() {
+    if (btnClockShow) btnClockShow.disabled = true;
+    try {
+      const result = await fetchJson("/api/clock/show", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          color: (clockColor && clockColor.value) || "#37d6ff",
+          brightness: Number((clockBrightness && clockBrightness.value) || 32),
+          effect: (clockEffect && clockEffect.value) || "steady",
+        }),
+      });
+      applyClockState(result);
+    } catch (error) {
+      if (clockStatus) clockStatus.textContent = `显示失败：${error.message || error}`;
+    } finally {
+      if (btnClockShow) btnClockShow.disabled = false;
+    }
+  }
+
+  async function stopClock() {
+    if (btnClockStop) btnClockStop.disabled = true;
+    try {
+      const result = await fetchJson("/api/clock/stop", { method: "POST" });
+      applyClockState(result);
+      if (clockStatus) clockStatus.textContent = "时钟已停止。";
+    } catch (error) {
+      if (clockStatus) clockStatus.textContent = `停止失败：${error.message || error}`;
+    } finally {
+      if (btnClockStop) btnClockStop.disabled = false;
+    }
+  }
+
   async function refreshExpressionStudio() {
     try {
       const [eyes, effects, presets, capacity] = await Promise.all([
@@ -3811,6 +3893,7 @@
           device ? `S3 可用 ${formatBytes(device.spiffs_free_bytes)}` : "设备未连接",
         ].join("  |  ");
       }
+      void refreshClock();
     } catch (error) {
       if (expressionCapacityEl) expressionCapacityEl.textContent = `表情库加载失败：${error.message || error}`;
     }
@@ -4287,6 +4370,10 @@
   if (btnExpressionPlay) btnExpressionPlay.addEventListener("click", () => { void playExpression(); });
   if (btnExpressionStop) btnExpressionStop.addEventListener("click", () => { void stopExpression(); });
   if (btnExpressionSave) btnExpressionSave.addEventListener("click", () => { void saveExpressionPresetFromComposer(); });
+  if (btnClockShow) btnClockShow.addEventListener("click", () => { void showClock(); });
+  if (btnClockStop) btnClockStop.addEventListener("click", () => { void stopClock(); });
+  if (clockColor) clockColor.addEventListener("input", renderClockPreview);
+  if (clockEffect) clockEffect.addEventListener("change", renderClockPreview);
   if (btnEyeUpload) btnEyeUpload.addEventListener("click", () => { void uploadExpressionEye(); });
   if (ledEffectForm) {
     ledEffectForm.addEventListener("submit", (event) => {
@@ -4313,6 +4400,7 @@
   if (btnLedEditorSave) btnLedEditorSave.addEventListener("click", () => { void saveLedEditor({ sync: false }); });
   initializeLedEditor();
   ensureLedPreviewCells();
+  startClockPreview();
   void refreshSkillsAndRecordings();
   void refreshExpressionStudio();
   if (btnUserSkillsReload) {

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>YareLampGo 控制台</title>
   <link rel="icon" href="/%E5%8F%B0%E7%81%AF%E8%99%BE%E5%A4%B4%E5%83%8F.jpeg">
-  <link rel="stylesheet" href="/style.css?v=led-pixel-clips-20260715">
+  <link rel="stylesheet" href="/style.css?v=clock-prominent-20260721">
   <link rel="stylesheet" href="/setup.css?v=secret-inputs-20260602">
 </head>
 <body>
@@ -348,6 +348,33 @@
               </div>
               <div class="skill-section-count" id="expression-count">0</div>
             </div>
+            <section class="clock-quick-panel" aria-labelledby="clock-quick-title">
+              <div class="clock-quick-head">
+                <div>
+                  <div id="clock-quick-title" class="clock-quick-title">LED 点阵时钟</div>
+                  <div class="clock-quick-desc">显示电脑当前时间，后端会在每个整分钟自动更新。</div>
+                </div>
+                <div id="clock-status" class="clock-status">显示后由本机后端每分钟更新一次。</div>
+              </div>
+              <div class="clock-workspace">
+                <div id="clock-preview" class="clock-preview" aria-live="polite">--:--</div>
+                <div class="clock-controls">
+                  <label>颜色<input id="clock-color" type="color" value="#37d6ff" /></label>
+                  <label>亮度<input id="clock-brightness" type="range" min="1" max="96" value="32" /></label>
+                  <label>特效
+                    <select id="clock-effect">
+                      <option value="steady">常亮</option>
+                      <option value="blink">闪烁</option>
+                      <option value="orbit">光效环绕</option>
+                    </select>
+                  </label>
+                  <div class="clock-command-row">
+                    <button id="btn-clock-show" class="primary-button" type="button">显示时钟</button>
+                    <button id="btn-clock-stop" class="ghost-button" type="button">停止</button>
+                  </div>
+                </div>
+              </div>
+            </section>
             <div class="expression-tabs" role="tablist" aria-label="表情工作区">
               <button type="button" class="expression-tab is-active" data-expression-tab="eyes" role="tab">眼睛素材</button>
               <button type="button" class="expression-tab" data-expression-tab="led" role="tab">LED 效果</button>
@@ -1438,7 +1465,7 @@
     </div>
   </dialog>
 
-  <script src="/app.js?v=led-frame-clipboard-20260715"></script>
+  <script src="/app.js?v=clock-prominent-20260721"></script>
   <script type="module" src="/pet.js?v=19"></script>
   <script src="/setup.js?v=secret-inputs-20260602"></script>
 </body>

--- a/lampgo/web/static/style.css
+++ b/lampgo/web/static/style.css
@@ -2584,6 +2584,36 @@ button.device-chip.is-active {
   color: #155f59;
 }
 
+.clock-quick-panel {
+  margin: 12px 0 14px;
+  padding: 14px 16px 16px;
+  border-top: 1px solid #9ecfc9;
+  border-bottom: 1px solid #9ecfc9;
+  border-left: 4px solid #227c75;
+  background: #f1f9f8;
+}
+
+.clock-quick-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.clock-quick-title {
+  color: #155f59;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.clock-quick-desc {
+  margin-top: 3px;
+  color: #596169;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .expression-capacity {
   min-height: 28px;
   margin-bottom: 12px;
@@ -3701,6 +3731,63 @@ button.device-chip.is-active {
   min-height: 92px;
   resize: vertical;
   line-height: 1.5;
+}
+
+.clock-workspace {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) minmax(260px, 0.85fr);
+  gap: 18px;
+  align-items: center;
+  padding: 8px 0 0;
+}
+
+.clock-preview {
+  min-height: 126px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #25343a;
+  border-radius: 8px;
+  background: #0d1316;
+  color: #37d6ff;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 58px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+  text-shadow: 0 0 14px currentColor;
+}
+
+.clock-preview.is-blink { animation: clock-preview-blink 1s steps(1, end) infinite; }
+.clock-preview.is-orbit { box-shadow: inset 0 0 0 1px currentColor, 0 0 14px currentColor; }
+
+@keyframes clock-preview-blink {
+  50% { opacity: 0.2; }
+}
+
+.clock-controls {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.clock-controls label {
+  display: grid;
+  gap: 5px;
+  color: var(--text-soft);
+  font-size: 12px;
+}
+
+.clock-controls input,
+.clock-controls select { width: 100%; min-width: 0; }
+.clock-controls input[type="color"] { height: 34px; padding: 2px; }
+.clock-command-row,
+.clock-status { grid-column: 1 / -1; }
+.clock-command-row { display: flex; gap: 8px; }
+.clock-status { color: var(--text-faint); font-size: 12px; }
+
+@media (max-width: 860px) {
+  .clock-workspace { grid-template-columns: 1fr; }
+  .clock-quick-head { display: grid; gap: 6px; }
 }
 
 .record-dialog-input:focus {

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from starlette.testclient import TestClient
+
+from lampgo.clock import ClockController
+from lampgo.core.config import DeviceConfig, LampgoConfig
+from lampgo.server import LampgoServer
+from lampgo.web.gateway import WebGateway
+
+
+class _FakeLed:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.stop_calls = 0
+
+    def show_clock(self, **payload) -> bool:
+        self.calls.append(payload)
+        return True
+
+    def stop_clock(self) -> bool:
+        self.stop_calls += 1
+        return True
+
+
+def test_clock_sends_current_minute_once_and_persists_style(tmp_path: Path) -> None:
+    current = datetime(2026, 7, 21, 9, 8, tzinfo=timezone.utc)
+    led = _FakeLed()
+    clock = ClockController(led, path=tmp_path / "clock.json", now=lambda: current, brightness_ceiling=lambda: 40)
+
+    shown = clock.show(color="#ff0088", brightness=80, effect="orbit")
+
+    assert shown["ok"] is True
+    assert shown["time"] == "09:08"
+    assert led.calls == [{"hour": 9, "minute": 8, "color": "#ff0088", "brightness": 40, "effect": "orbit"}]
+    assert clock.refresh()["sent"] is False
+
+    current = datetime(2026, 7, 21, 9, 9, tzinfo=timezone.utc)
+    assert clock.refresh()["sent"] is True
+    assert led.calls[-1]["minute"] == 9
+
+    restored = ClockController(_FakeLed(), path=tmp_path / "clock.json", now=lambda: current)
+    assert restored.snapshot()["enabled"] is True
+    assert restored.snapshot()["color"] == "#ff0088"
+    assert restored.snapshot()["effect"] == "orbit"
+
+
+def test_clock_stop_disables_future_updates(tmp_path: Path) -> None:
+    led = _FakeLed()
+    clock = ClockController(led, path=tmp_path / "clock.json", now=lambda: datetime(2026, 7, 21, 9, 8))
+    clock.show()
+
+    stopped = clock.stop()
+
+    assert stopped["ok"] is True
+    assert stopped["enabled"] is False
+    assert led.stop_calls == 1
+    assert clock.refresh()["sent"] is False
+
+
+def test_clock_http_routes_return_backend_owned_state(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path / "lampgo-home"))
+    config = LampgoConfig(device=DeviceConfig(motor_port="/dev/null"))
+    gateway = WebGateway(LampgoServer(config))
+    led = _FakeLed()
+    gateway.server.clock = ClockController(
+        led,
+        path=tmp_path / "clock.json",
+        now=lambda: datetime(2026, 7, 21, 18, 30),
+    )
+
+    with TestClient(gateway.app) as client:
+        gateway.server._register_builtin_skills()
+        assert gateway.server.registry.get("show_clock") is not None
+        shown = client.post("/api/clock/show", json={"color": "#00ffcc", "brightness": 25, "effect": "blink"})
+        state = client.get("/api/clock")
+        stopped = client.post("/api/clock/stop")
+
+    assert shown.status_code == 200
+    assert shown.json()["result"]["time"] == "18:30"
+    assert led.calls[-1]["effect"] == "blink"
+    assert state.json()["result"]["enabled"] is True
+    assert stopped.json()["result"]["enabled"] is False


### PR DESCRIPTION
Adds a backend-owned, minute-updated LED matrix clock with a prominent Expression Studio control panel and LLM skill.\n\nValidation: ============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /private/tmp/yarelampgo-clock
configfile: pyproject.toml
plugins: asyncio-1.4.0, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 3 items

tests/test_clock.py ...                                                  [100%]

=============================== warnings summary ===============================
tests/test_clock.py:6
  /private/tmp/yarelampgo-clock/tests/test_clock.py:6: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    from starlette.testclient import TestClient

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================= 3 passed, 1 warning in 0.68s =========================; ; .