### PR TITLE
feat: enhance LED expression controls

### DIFF
--- a/lampgo/core/config.py
+++ b/lampgo/core/config.py
@@ -407,6 +407,12 @@ class DeviceEsp32Config(BaseModel):
         default=False,
         description="Enable ESP32 PDM microphone stream (still falls back to sounddevice when offline).",
     )
+    led_brightness: int = Field(
+        default=32,
+        ge=1,
+        le=96,
+        description="Global S3 LED brightness ceiling. Expression brightness may be lower but never higher.",
+    )
     http_timeout_s: float = Field(
         default=5.0,
         gt=0,

--- a/lampgo/recordings.py
+++ b/lampgo/recordings.py
@@ -3,7 +3,8 @@
 Recorded motions are data, not code: a ``.csv`` file means the action exists,
 and an optional sibling ``.txt`` file describes when the LLM should use it.
 User recordings live in ``user/`` and shadow built-in recordings of the same
-name.
+name. Users can also keep local metadata overrides for built-in recordings
+without changing the shipped motion CSV files.
 """
 
 from __future__ import annotations
@@ -115,6 +116,11 @@ def recording_description_path(csv_path: Path) -> Path:
     return csv_path.with_suffix(".txt")
 
 
+def recording_override_path(recordings_dir: Path, name: str) -> Path:
+    """Return the user-owned metadata sidecar for a built-in recording."""
+    return recordings_dir / "user" / "overrides" / f"{name}.txt"
+
+
 def parse_recording_metadata(text: str) -> dict[str, str]:
     """Parse optional recording sidecar metadata, preserving old plain text files."""
     description_parts: list[str] = []
@@ -143,8 +149,7 @@ def parse_recording_metadata(text: str) -> dict[str, str]:
     }
 
 
-def read_recording_metadata(csv_path: Path) -> dict[str, str]:
-    path = recording_description_path(csv_path)
+def read_recording_metadata_path(path: Path) -> dict[str, str]:
     if not path.exists():
         return {"description": "", "expression": "", "expression_preset": ""}
     try:
@@ -153,12 +158,16 @@ def read_recording_metadata(csv_path: Path) -> dict[str, str]:
         return {"description": "", "expression": "", "expression_preset": ""}
 
 
+def read_recording_metadata(csv_path: Path) -> dict[str, str]:
+    return read_recording_metadata_path(recording_description_path(csv_path))
+
+
 def read_recording_description(csv_path: Path) -> str:
     return read_recording_metadata(csv_path)["description"]
 
 
-def write_recording_description(
-    csv_path: Path,
+def write_recording_metadata_path(
+    path: Path,
     description: str,
     expression: str = "",
     expression_preset: str = "",
@@ -166,7 +175,6 @@ def write_recording_description(
     text = normalize_recording_description(description)
     expression = _normalize_expression(expression)
     expression_preset = _normalize_expression_preset(expression_preset)
-    path = recording_description_path(csv_path)
     lines = []
     if expression_preset:
         lines.append(f"expression_preset={expression_preset}")
@@ -175,9 +183,24 @@ def write_recording_description(
     if text:
         lines.append(f"prompt={text}")
     if lines:
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     elif path.exists():
         path.unlink()
+
+
+def write_recording_description(
+    csv_path: Path,
+    description: str,
+    expression: str = "",
+    expression_preset: str = "",
+) -> None:
+    write_recording_metadata_path(
+        recording_description_path(csv_path),
+        description,
+        expression,
+        expression_preset,
+    )
 
 
 def _stable_name_index(name: str) -> int:
@@ -217,7 +240,12 @@ def list_recording_catalog(recordings_dir: Path) -> list[dict[str, str]]:
         return []
     entries: dict[str, dict[str, str]] = {}
     for csv_path in recordings_dir.glob("*.csv"):
-        metadata = read_recording_metadata(csv_path)
+        override_path = recording_override_path(recordings_dir, csv_path.stem)
+        metadata = (
+            read_recording_metadata_path(override_path)
+            if override_path.exists()
+            else read_recording_metadata(csv_path)
+        )
         entries[csv_path.stem] = {
             "name": csv_path.stem,
             "source": "builtin",

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -107,7 +107,7 @@ class LampgoServer:
         self.led = LEDController(LEDConfig(port="", baud_rate=config.led.baud_rate), esp32_manager=self.esp32)
         self.clock = ClockController(
             self.led,
-            brightness_ceiling=lambda: getattr(self.config.device_esp32, "led_brightness", 96),
+            brightness_ceiling=lambda: self.config.device_esp32.led_brightness,
         )
         self.fsm = StateMachine()
         self.registry = SkillRegistry()

--- a/lampgo/web/gateway.py
+++ b/lampgo/web/gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import hmac
 import ipaddress
 import json
@@ -71,7 +72,9 @@ from lampgo.recordings import (
     list_recording_catalog,
     normalize_recording_name,
     recording_description_path,
+    recording_override_path,
     write_recording_description,
+    write_recording_metadata_path,
 )
 from lampgo.web.ws_bridge import WsBridge
 
@@ -762,24 +765,61 @@ class WebGateway:
         )
 
     async def api_recordings_update(self, request: Request) -> JSONResponse:
-        """POST /api/recordings/update — edit metadata for a user-created recording."""
+        """POST /api/recordings/update — edit a recording's local metadata."""
         body = await request.json()
         name = normalize_recording_name(body.get("name", ""))
         description = str(body.get("description", "") or body.get("prompt", "")).strip()
         expression = str(body.get("expression", "")).strip()
         expression_preset = str(body.get("expression_preset", "") or body.get("preset_id", "")).strip()
+        has_custom_expression = "eye_clip_id" in body or "led_effect_id" in body
         if not name:
             return JSONResponse({"ok": False, "error": RECORDING_NAME_ERROR}, status_code=400)
 
         recordings_dir = Path(self.server.config.recordings_dir)
         user_dir = recordings_dir / "user"
-        csv_path = user_dir / f"{name}.csv"
-        if not csv_path.exists():
-            if (recordings_dir / f"{name}.csv").exists():
-                return JSONResponse({"ok": False, "error": "built-in recording cannot be edited"}, status_code=400)
-            return JSONResponse({"ok": False, "error": "user recording not found"}, status_code=404)
+        user_csv_path = user_dir / f"{name}.csv"
+        builtin_csv_path = recordings_dir / f"{name}.csv"
+        if user_csv_path.exists():
+            csv_path = user_csv_path
+            metadata_path = recording_description_path(csv_path)
+            source = "user"
+        elif builtin_csv_path.exists():
+            csv_path = builtin_csv_path
+            metadata_path = recording_override_path(recordings_dir, name)
+            source = "builtin"
+        else:
+            return JSONResponse({"ok": False, "error": "recording not found"}, status_code=404)
 
-        write_recording_description(csv_path, description, expression, expression_preset)
+        if has_custom_expression:
+            eye_clip_id = str(body.get("eye_clip_id") or "").strip().lower() or None
+            led_effect_id = str(body.get("led_effect_id") or "").strip().lower() or None
+            if not eye_clip_id and not led_effect_id:
+                return JSONResponse(
+                    {"ok": False, "error": "custom expression requires an eye or LED effect"},
+                    status_code=400,
+                )
+            preset_id = f"motion_{hashlib.sha256(name.encode('utf-8')).hexdigest()[:16]}"
+            try:
+                preset = save_expression_preset(
+                    {
+                        "preset_id": preset_id,
+                        "label": f"动作：{name}",
+                        "description": "录制动作专用组合",
+                        "eye_clip_id": eye_clip_id,
+                        "led_effect_id": led_effect_id,
+                        "playback": "loop",
+                        "duration_ms": 3000,
+                    }
+                )
+            except (ExpressionLibraryError, ValueError, TypeError) as exc:
+                return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+            expression_preset = str(preset["preset_id"])
+            expression = ""
+
+        if source == "builtin":
+            write_recording_metadata_path(metadata_path, description, expression, expression_preset)
+        else:
+            write_recording_description(csv_path, description, expression, expression_preset)
         self.server._refresh_llm_skill_tools()
         return JSONResponse(
             {
@@ -788,6 +828,7 @@ class WebGateway:
                     "status": "updated",
                     "name": name,
                     "path": str(csv_path),
+                    "source": source,
                     "description": description or None,
                     "expression": expression or None,
                     "expression_preset": expression_preset or None,
@@ -1096,10 +1137,14 @@ class WebGateway:
             )
             if sync_status >= 400 or (isinstance(sync_body, dict) and sync_body.get("ok") is False):
                 return sync_status, sync_body
+        brightness_ceiling = int(self.server.config.device_esp32.led_brightness)
+        led_params = dict(composition.get("led_params") or {})
+        requested_brightness = led_params.get("brightness", brightness_ceiling)
+        led_params["brightness"] = min(int(requested_brightness), brightness_ceiling)
         payload: dict[str, Any] = {
             "eye_clip_id": composition.get("eye_storage_clip_id"),
             "led_effect_id": composition.get("led_effect_id"),
-            "led_params": composition.get("led_params") or {},
+            "led_params": led_params,
             "playback": composition.get("playback") or "loop",
             "duration_ms": int(composition.get("duration_ms") or 3000),
         }
@@ -1783,6 +1828,7 @@ class WebGateway:
             "device_esp32.jpeg_quality",
             "device_esp32.framesize",
             "device_esp32.mic_enabled",
+            "device_esp32.led_brightness",
             "device_esp32.http_timeout_s",
         ),
     }
@@ -1932,6 +1978,11 @@ class WebGateway:
                 self._derive_voice_mode_fields(flat)
             if section == "safety":
                 self._validate_safety_fields(flat)
+            if "device_esp32.led_brightness" in flat:
+                level = int(flat["device_esp32.led_brightness"])
+                if not 1 <= level <= 96:
+                    raise ValueError("device_esp32.led_brightness must be 1-96")
+                flat["device_esp32.led_brightness"] = level
         except Exception as exc:  # noqa: BLE001
             return JSONResponse({"ok": False, "error": f"invalid value: {exc}"}, status_code=400)
 
@@ -2056,7 +2107,22 @@ class WebGateway:
                 self.server.esp32.reset_session()
         except Exception:
             logger.exception("web.device_esp32_toggle_failed")
-        return response
+        try:
+            payload = json.loads(response.body.decode("utf-8"))
+        except Exception:
+            return response
+        saved = set((payload.get("result") or {}).get("saved") or [])
+        if "device_esp32.led_brightness" in saved and self.server.esp32:
+            level = int(self.server.config.device_esp32.led_brightness)
+            status, body, _ = await self.server.esp32.proxy_post(
+                "/device/led",
+                self.server.esp32.with_owner_auth({"brightness": level}, reason="led_brightness_config"),
+            )
+            payload.setdefault("result", {})["led_brightness_sync"] = {
+                "ok": 200 <= status < 300 and not (isinstance(body, dict) and body.get("ok") is False),
+                "level": level,
+            }
+        return JSONResponse(payload, status_code=response.status_code)
 
     async def api_config_detect(self, request: Request) -> JSONResponse:
         """Run hardware autodetect on demand (used by the 硬件 tab button)."""
@@ -2729,6 +2795,14 @@ class WebGateway:
                 return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
             status, body = await self._play_resolved_expression(composition)
             return JSONResponse(self._with_expression_catalog(body), status_code=status)
+        brightness_ceiling = int(self.server.config.device_esp32.led_brightness)
+        if "brightness" in patch:
+            try:
+                patch["brightness"] = min(int(patch["brightness"]), brightness_ceiling)
+            except (TypeError, ValueError):
+                return JSONResponse({"ok": False, "error": "brightness must be an integer"}, status_code=400)
+        else:
+            patch["brightness"] = brightness_ceiling
         if any(key in patch for key in ("mode", "expression", "name", "clip_id")):
             self.server.clock.deactivate()
         if self.server.esp32 and hasattr(self.server.esp32, "with_owner_auth"):

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -49,6 +49,8 @@
   const btnLedPasteFrame = document.getElementById("btn-led-paste-frame");
   const btnLedMirrorFrame = document.getElementById("btn-led-mirror-frame");
   const btnLedClearFrame = document.getElementById("btn-led-clear-frame");
+  const btnLedCopyFrameToAll = document.getElementById("btn-led-copy-frame-to-all");
+  const btnLedClearAllFrames = document.getElementById("btn-led-clear-all-frames");
   const btnLedEditorPreview = document.getElementById("btn-led-editor-preview");
   const btnLedEditorSave = document.getElementById("btn-led-editor-save");
   const composerEye = document.getElementById("composer-eye");
@@ -88,6 +90,9 @@
   const esp32VolumeControl = document.getElementById("esp32-volume-control");
   const esp32VolumeSlider = document.getElementById("esp32-volume-slider");
   const esp32VolumeValue = document.getElementById("esp32-volume-value");
+  const esp32LedBrightnessControl = document.getElementById("esp32-led-brightness-control");
+  const esp32LedBrightnessSlider = document.getElementById("esp32-led-brightness-slider");
+  const esp32LedBrightnessValue = document.getElementById("esp32-led-brightness-value");
   const btnRefreshAgent = document.getElementById("btn-refresh-agent");
   const btnAgentHealth = document.getElementById("btn-agent-health-details");
   const agentHealthCard = document.getElementById("agent-health-card");
@@ -114,6 +119,10 @@
   const recordEditDesc = document.getElementById("record-edit-desc");
   const recordEditDescriptionInput = document.getElementById("record-edit-description-input");
   const recordEditExpressionSelect = document.getElementById("record-edit-expression-select");
+  const recordEditPresetField = document.getElementById("record-edit-preset-field");
+  const recordEditCustomFields = document.getElementById("record-edit-custom-fields");
+  const recordEditEyeSelect = document.getElementById("record-edit-eye-select");
+  const recordEditLedSelect = document.getElementById("record-edit-led-select");
   const recordEditError = document.getElementById("record-edit-error");
   const btnRecordEditCancel = document.getElementById("btn-record-edit-cancel");
   const recordNameError = document.getElementById("record-name-error");
@@ -244,6 +253,7 @@
   let expressionPlayback = "loop";
   let expressionPreviewTimer = null;
   let expressionPreviewImage = null;
+  let recordEditExpressionMode = "preset";
   let clockPreviewTimer = null;
   const ledEffectSourceCache = new Map();
   const LED_EDITOR_WIDTH = 51;
@@ -263,6 +273,7 @@
   let ledEditorPreviewTimer = null;
   let ledEditorClipboard = null;
   let ledEditorClipboardSource = -1;
+  let ledEditorNotice = "";
   let latestStatusData = {};
 
   function expressionMeta(name) {
@@ -401,6 +412,41 @@
     populateExpressionSelect(recordExpressionSelect, preferred);
   }
 
+  function populateRecordEditCustomExpressionSelects(recording) {
+    const preset = expressionPresetById(getRecordingExpressionPreset(recording));
+    const selectedEye = String((preset && preset.eye_clip_id) || "");
+    const selectedLed = String((preset && preset.led_effect_id) || "");
+    if (recordEditEyeSelect) {
+      recordEditEyeSelect.innerHTML = '<option value="">无眼睛</option>';
+      expressionEyes.forEach((eye) => {
+        const option = document.createElement("option");
+        option.value = eye.eye_clip_id;
+        option.textContent = `${eye.label || eye.eye_clip_id}（${eye.eye_clip_id}）`;
+        recordEditEyeSelect.appendChild(option);
+      });
+      recordEditEyeSelect.value = expressionEyes.some((eye) => eye.eye_clip_id === selectedEye) ? selectedEye : "";
+    }
+    if (recordEditLedSelect) {
+      recordEditLedSelect.innerHTML = '<option value="">无 LED</option>';
+      expressionLedEffects.forEach((effect) => {
+        const option = document.createElement("option");
+        option.value = effect.effect_id;
+        option.textContent = `${effect.label || effect.effect_id}（${effect.effect_id} · ${effect.role || "accent"}）`;
+        recordEditLedSelect.appendChild(option);
+      });
+      recordEditLedSelect.value = expressionLedEffects.some((effect) => effect.effect_id === selectedLed) ? selectedLed : "";
+    }
+  }
+
+  function setRecordEditExpressionMode(mode) {
+    recordEditExpressionMode = mode === "custom" ? "custom" : "preset";
+    document.querySelectorAll("[data-record-edit-expression-mode]").forEach((button) => {
+      button.classList.toggle("is-active", button.dataset.recordEditExpressionMode === recordEditExpressionMode);
+    });
+    if (recordEditPresetField) recordEditPresetField.classList.toggle("hidden", recordEditExpressionMode !== "preset");
+    if (recordEditCustomFields) recordEditCustomFields.classList.toggle("hidden", recordEditExpressionMode !== "custom");
+  }
+
   function recordingLabel(name) {
     return RECORDING_LABELS_CN[name] || name;
   }
@@ -454,6 +500,7 @@
   const AGENT_TASK_SESSION_KEY = "lampgo.agentTaskSessions";
   const AGENT_FOLLOWUP_KEY = "lampgo.agentFollowups";
   const ESP32_VOLUME_KEY = "lampgo.esp32SpeakerVolume";
+  const ESP32_LED_BRIGHTNESS_KEY = "lampgo.esp32LedBrightness";
   const MAX_SESSIONS = 40;
   const DEFAULT_SIDEBAR_WIDTH = 232;
   const MIN_SIDEBAR_WIDTH = 200;
@@ -469,6 +516,9 @@
   let esp32VolumeTimer = null;
   let esp32VolumePending = false;
   let esp32VolumeInitialSyncDone = false;
+  let esp32LedBrightnessTimer = null;
+  let esp32LedBrightnessPending = false;
+  let esp32LedBrightnessInitialSyncDone = false;
   let voiceCallMode = "stable";
   let voiceEchoGateHangoverMs = 1000;
   let voiceEchoTextFilterEnabled = true;
@@ -542,6 +592,83 @@
     if (!esp || esp.enabled === false || esp.online === false) return;
     esp32VolumeInitialSyncDone = true;
     syncEsp32Volume(esp32VolumeSlider.value);
+  }
+
+  function clampEsp32LedBrightness(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return 32;
+    return Math.max(1, Math.min(96, Math.round(n)));
+  }
+
+  function setEsp32LedBrightnessUi(value, { persist = false } = {}) {
+    const level = clampEsp32LedBrightness(value);
+    if (esp32LedBrightnessSlider) esp32LedBrightnessSlider.value = String(level);
+    if (esp32LedBrightnessValue) esp32LedBrightnessValue.textContent = String(level);
+    if (persist) {
+      try { localStorage.setItem(ESP32_LED_BRIGHTNESS_KEY, String(level)); } catch (_) { /* ignore */ }
+    }
+    return level;
+  }
+
+  async function syncEsp32LedBrightness(value) {
+    const level = clampEsp32LedBrightness(value);
+    if (esp32LedBrightnessControl) {
+      esp32LedBrightnessControl.classList.add("is-syncing");
+      esp32LedBrightnessControl.classList.remove("is-error");
+    }
+    try {
+      const resp = await fetch("/api/config/device_esp32", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ "device_esp32.led_brightness": level }),
+      });
+      const body = await resp.json().catch(() => ({}));
+      if (!resp.ok || body.ok === false) {
+        throw new Error(body.error || `HTTP ${resp.status}`);
+      }
+      if (body.result && body.result.led_brightness_sync && !body.result.led_brightness_sync.ok) {
+        throw new Error("设备暂时离线，亮度已保存，恢复连接后会自动应用");
+      }
+      return true;
+    } catch (err) {
+      console.warn("[esp32] LED brightness sync failed:", err);
+      if (esp32LedBrightnessControl) esp32LedBrightnessControl.classList.add("is-error");
+      return false;
+    } finally {
+      if (esp32LedBrightnessControl) esp32LedBrightnessControl.classList.remove("is-syncing");
+      esp32LedBrightnessPending = false;
+    }
+  }
+
+  function scheduleEsp32LedBrightnessSync(value) {
+    const level = setEsp32LedBrightnessUi(value, { persist: true });
+    esp32LedBrightnessPending = true;
+    if (esp32LedBrightnessTimer) clearTimeout(esp32LedBrightnessTimer);
+    esp32LedBrightnessTimer = setTimeout(() => {
+      syncEsp32LedBrightness(level);
+    }, 150);
+  }
+
+  function initEsp32LedBrightnessControl() {
+    if (!esp32LedBrightnessSlider) return;
+    let initial = 32;
+    try {
+      const stored = localStorage.getItem(ESP32_LED_BRIGHTNESS_KEY);
+      if (stored != null) initial = clampEsp32LedBrightness(stored);
+    } catch (_) { /* ignore */ }
+    setEsp32LedBrightnessUi(initial);
+    esp32LedBrightnessSlider.addEventListener("input", () => {
+      scheduleEsp32LedBrightnessSync(esp32LedBrightnessSlider.value);
+    });
+  }
+
+  function maybeSyncInitialEsp32LedBrightness() {
+    if (esp32LedBrightnessInitialSyncDone || !esp32LedBrightnessSlider) return;
+    const esp = cameraCache && cameraCache.esp32 ? cameraCache.esp32 : null;
+    if (!esp || esp.enabled === false || esp.online === false) return;
+    syncEsp32LedBrightness(esp32LedBrightnessSlider.value).then((ok) => {
+      esp32LedBrightnessInitialSyncDone = ok;
+    });
   }
 
   function clampSidebarWidth(width) {
@@ -2318,6 +2445,7 @@
         }));
         repopulateCameraPortSelect();
         maybeSyncInitialEsp32Volume();
+        maybeSyncInitialEsp32LedBrightness();
         if (isCameraPopoverOpen()) renderCameraPopover(false);
       }
       return;
@@ -2331,6 +2459,7 @@
         const displayPort = msg.result.active === "esp32" ? "" : (msg.result.active || "");
         repopulateCameraPortSelect(displayPort);
         maybeSyncInitialEsp32Volume();
+        maybeSyncInitialEsp32LedBrightness();
         if (isCameraPopoverOpen()) renderCameraPopover(false);
         send({ type: "status", request_id: `cam_refresh_${Date.now()}` });
       } else {
@@ -3286,19 +3415,23 @@
           : `播放录制动作：${labelCn}（${name}） · 配套表情：${expressionMeta}`,
         onClick: () => invokeRecording(name),
       });
+      card.classList.add("skill-card--recording");
+      const edit = document.createElement("button");
+      edit.className = "skill-card-action skill-card-action--edit";
+      edit.type = "button";
+      edit.title = isUserRecording
+        ? "编辑配套表情和动作说明"
+        : "编辑本机的配套表情和动作说明，不会改动出厂动作轨迹";
+      edit.setAttribute("aria-label", edit.title);
+      edit.textContent = "✎";
+      edit.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+        ev.preventDefault();
+        openEditRecordingDialog(recording);
+      });
+      card.appendChild(edit);
       if (isUserRecording) {
         card.classList.add("skill-card--recording-user");
-        const edit = document.createElement("button");
-        edit.className = "skill-card-action skill-card-action--edit";
-        edit.type = "button";
-        edit.title = "编辑配套表情和动作说明";
-        edit.textContent = "✎";
-        edit.addEventListener("click", (ev) => {
-          ev.stopPropagation();
-          ev.preventDefault();
-          openEditRecordingDialog(recording);
-        });
-        card.appendChild(edit);
         const del = document.createElement("button");
         del.className = "skill-card-action skill-card-action--delete";
         del.type = "button";
@@ -3321,10 +3454,14 @@
     if (!recordEditDialog || !recording || !recording.name) return;
     recordEditDialog.dataset.recordingName = recording.name;
     if (recordEditDesc) {
-      recordEditDesc.textContent = `编辑 ${recordingLabel(recording.name)}（${recording.name}）的绑定表情和动作说明；不会改动录制动作轨迹。`;
+      recordEditDesc.textContent = recording.source === "builtin"
+        ? `编辑 ${recordingLabel(recording.name)}（${recording.name}）的本机配套表情和动作说明；不会改动出厂动作轨迹。`
+        : `编辑 ${recordingLabel(recording.name)}（${recording.name}）的绑定表情和动作说明；不会改动录制动作轨迹。`;
     }
     if (recordEditDescriptionInput) recordEditDescriptionInput.value = recording.description || "";
     populateExpressionSelect(recordEditExpressionSelect, recordingExpressionChoiceValue(recording));
+    populateRecordEditCustomExpressionSelects(recording);
+    setRecordEditExpressionMode("preset");
     if (recordEditError) recordEditError.textContent = "";
     recordEditDialog.showModal();
     if (recordEditDescriptionInput) recordEditDescriptionInput.focus();
@@ -3336,8 +3473,7 @@
     recordEditDialog.close();
   }
 
-  async function updateRecordingMetadata(name, description, expressionChoice) {
-    const pairing = splitRecordingExpressionChoice(expressionChoice);
+  async function updateRecordingMetadata(name, description, pairing) {
     const resp = await fetch("/api/recordings/update", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -3461,7 +3597,8 @@
     context.shadowBlur = 0;
     if (ledEditorStatus) {
       const copied = ledEditorClipboard ? ` · 已复制第 ${ledEditorClipboardSource + 1} 帧` : "";
-      ledEditorStatus.textContent = `第 ${ledEditorFrame + 1} / ${LED_EDITOR_FRAMES} 帧 · 10 FPS${copied}`;
+      const notice = ledEditorNotice ? ` · ${ledEditorNotice}` : "";
+      ledEditorStatus.textContent = `第 ${ledEditorFrame + 1} / ${LED_EDITOR_FRAMES} 帧 · 10 FPS${copied}${notice}`;
     }
     if (btnLedPasteFrame) {
       btnLedPasteFrame.disabled = !ledEditorClipboard;
@@ -3479,6 +3616,7 @@
 
   function setLedEditorFrame(index) {
     ledEditorFrame = Math.max(0, Math.min(LED_EDITOR_FRAMES - 1, Number(index) || 0));
+    ledEditorNotice = "";
     drawLedEditor();
   }
 
@@ -3536,6 +3674,7 @@
     if (!cell) return;
     ledEditorFrames[ledEditorFrame][cell.row * LED_EDITOR_WIDTH + cell.col] =
       ledEditorTool === "erase" ? 0 : ledEditorSymbol;
+    ledEditorNotice = "";
     drawLedEditor();
   }
 
@@ -3548,18 +3687,40 @@
       }
     }
     ledEditorFrames[ledEditorFrame] = mirrored;
+    ledEditorNotice = "已镜像当前帧";
     drawLedEditor();
   }
 
   function copyLedEditorFrame() {
     ledEditorClipboard = new Uint8Array(ledEditorFrames[ledEditorFrame]);
     ledEditorClipboardSource = ledEditorFrame;
+    ledEditorNotice = "已复制当前帧";
     drawLedEditor();
   }
 
   function pasteLedEditorFrame() {
     if (!ledEditorClipboard) return;
     ledEditorFrames[ledEditorFrame] = new Uint8Array(ledEditorClipboard);
+    ledEditorNotice = `已粘贴第 ${ledEditorClipboardSource + 1} 帧`;
+    drawLedEditor();
+  }
+
+  function copyLedEditorFrameToAll() {
+    const sourceFrame = new Uint8Array(ledEditorFrames[ledEditorFrame]);
+    const sourceNumber = ledEditorFrame + 1;
+    if (!window.confirm(`用第 ${sourceNumber} 帧覆盖全部 ${LED_EDITOR_FRAMES} 帧？其他帧的内容会被替换。`)) return;
+    ledEditorFrames = Array.from(
+      { length: LED_EDITOR_FRAMES },
+      () => new Uint8Array(sourceFrame),
+    );
+    ledEditorNotice = `已用第 ${sourceNumber} 帧覆盖全部帧`;
+    drawLedEditor();
+  }
+
+  function clearAllLedEditorFrames() {
+    if (!window.confirm(`清空全部 ${LED_EDITOR_FRAMES} 帧？此操作会移除当前未保存的全部画面。`)) return;
+    ledEditorFrames.forEach((frame) => frame.fill(0));
+    ledEditorNotice = "已清空全部帧";
     drawLedEditor();
   }
 
@@ -4394,8 +4555,11 @@
   if (btnLedMirrorFrame) btnLedMirrorFrame.addEventListener("click", mirrorLedEditorFrame);
   if (btnLedClearFrame) btnLedClearFrame.addEventListener("click", () => {
     ledEditorFrames[ledEditorFrame].fill(0);
+    ledEditorNotice = "已清空当前帧";
     drawLedEditor();
   });
+  if (btnLedCopyFrameToAll) btnLedCopyFrameToAll.addEventListener("click", copyLedEditorFrameToAll);
+  if (btnLedClearAllFrames) btnLedClearAllFrames.addEventListener("click", clearAllLedEditorFrames);
   if (btnLedEditorPreview) btnLedEditorPreview.addEventListener("click", toggleLedEditorPreview);
   if (btnLedEditorSave) btnLedEditorSave.addEventListener("click", () => { void saveLedEditor({ sync: false }); });
   initializeLedEditor();
@@ -7413,32 +7577,48 @@
       e.preventDefault();
       const name = (recordEditDialog && recordEditDialog.dataset.recordingName) || "";
       const description = ((recordEditDescriptionInput && recordEditDescriptionInput.value) || "").trim();
-      const expressionChoice = ((recordEditExpressionSelect && recordEditExpressionSelect.value) || "").trim();
       if (!name) {
         if (recordEditError) recordEditError.textContent = "缺少动作名称";
         return;
       }
-      if (!description) {
-        if (recordEditError) recordEditError.textContent = "请输入动作说明，AI 会根据它判断什么时候播放这个动作";
-        if (recordEditDescriptionInput) recordEditDescriptionInput.focus();
-        return;
-      }
-      if (!expressionChoice) {
-        if (recordEditError) recordEditError.textContent = "请选择配套表情";
-        if (recordEditExpressionSelect) recordEditExpressionSelect.focus();
-        return;
+      let pairing;
+      if (recordEditExpressionMode === "custom") {
+        const eyeClipId = ((recordEditEyeSelect && recordEditEyeSelect.value) || "").trim();
+        const ledEffectId = ((recordEditLedSelect && recordEditLedSelect.value) || "").trim();
+        if (!eyeClipId && !ledEffectId) {
+          if (recordEditError) recordEditError.textContent = "至少选择一个眼睛动画或 LED 效果";
+          if (recordEditEyeSelect) recordEditEyeSelect.focus();
+          return;
+        }
+        pairing = { eye_clip_id: eyeClipId, led_effect_id: ledEffectId };
+      } else {
+        const expressionChoice = ((recordEditExpressionSelect && recordEditExpressionSelect.value) || "").trim();
+        if (!expressionChoice) {
+          if (recordEditError) recordEditError.textContent = "请选择配套表情";
+          if (recordEditExpressionSelect) recordEditExpressionSelect.focus();
+          return;
+        }
+        pairing = splitRecordingExpressionChoice(expressionChoice);
       }
       if (recordEditError) recordEditError.textContent = "";
-      updateRecordingMetadata(name, description, expressionChoice)
-        .then(() => {
+      updateRecordingMetadata(name, description, pairing)
+        .then((data) => {
           closeEditRecordingDialog();
-          addSystemMessage(`录制动作已更新：${recordingLabel(name)}（${name}） · ${recordingExpressionChoiceLabel({ name, ...splitRecordingExpressionChoice(expressionChoice) })}`);
+          const result = (data && data.result) || {};
+          addSystemMessage(`录制动作已更新：${recordingLabel(name)}（${name}） · ${recordingExpressionChoiceLabel({
+            name,
+            expression: result.expression || "",
+            expression_preset: result.expression_preset || "",
+          })}`);
         })
         .catch((err) => {
           if (recordEditError) recordEditError.textContent = `保存失败：${err && err.message ? err.message : err}`;
         });
     });
   }
+  document.querySelectorAll("[data-record-edit-expression-mode]").forEach((button) => {
+    button.addEventListener("click", () => setRecordEditExpressionMode(button.dataset.recordEditExpressionMode));
+  });
 
   if (catTeaserForm) {
     catTeaserForm.addEventListener("submit", (e) => {
@@ -10121,6 +10301,7 @@
   ensureIdleTimer();
   updateRecordButtonState();
   initEsp32VolumeControl();
+  initEsp32LedBrightnessControl();
   startWebPageOwnerHeartbeat();
   connect();
 })();

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -131,6 +131,11 @@
             <input id="esp32-volume-slider" class="volume-slider" type="range" min="0" max="100" value="70" step="1" />
             <span id="esp32-volume-value" class="volume-value">70%</span>
           </label>
+          <label id="esp32-led-brightness-control" class="volume-control" title="调节 S3 LED 灯板亮度（安全上限 96）">
+            <span class="volume-label">灯板</span>
+            <input id="esp32-led-brightness-slider" class="volume-slider" type="range" min="1" max="96" value="32" step="1" />
+            <span id="esp32-led-brightness-value" class="volume-value">32</span>
+          </label>
         </div>
 
         <div class="topbar-right">
@@ -427,6 +432,10 @@
                       <button id="btn-led-mirror-frame" type="button" title="左右镜像">镜像</button>
                       <button id="btn-led-clear-frame" type="button" title="清空当前帧">清空</button>
                     </div>
+                    <div class="led-editor-bulk-row" role="group" aria-label="批量帧操作">
+                      <button id="btn-led-copy-frame-to-all" type="button" title="用当前帧覆盖全部 30 帧">当前帧复制到全部</button>
+                      <button id="btn-led-clear-all-frames" class="is-danger" type="button" title="清空全部 30 帧">清空全部帧</button>
+                    </div>
                     <div class="led-editor-command-row">
                       <button id="btn-led-editor-preview" class="ghost-button" type="button">播放预览</button>
                       <button id="btn-led-editor-save" class="ghost-button" type="button">仅保存</button>
@@ -476,6 +485,7 @@
               </div>
               <div id="expression-preset-grid" class="expression-resource-list"></div>
             </div>
+
           </div>
         </div>
       </section>
@@ -1295,11 +1305,29 @@
         maxlength="500"
         placeholder="例如：开心打招呼、看见用户靠近时挥动灯头，适合回应问候或活跃气氛。"
       ></textarea>
-      <label class="record-dialog-field">
+      <div class="record-dialog-field">
+        <span class="record-dialog-label">配套表情</span>
+        <div class="record-expression-mode" role="group" aria-label="配套表情来源">
+          <button type="button" class="is-active" data-record-edit-expression-mode="preset">已有组合</button>
+          <button type="button" data-record-edit-expression-mode="custom">自定义组合</button>
+        </div>
+      </div>
+      <label id="record-edit-preset-field" class="record-dialog-field">
         <span class="record-dialog-label">绑定组合表情（眼睛 + LED）</span>
         <select id="record-edit-expression-select" class="record-dialog-input record-dialog-select"></select>
         <span class="record-dialog-hint">组合表情会在整个动作期间循环播放；“仅 LED 灯板”分组不会改变当前眼睛画面。</span>
       </label>
+      <div id="record-edit-custom-fields" class="record-expression-custom hidden">
+        <label class="record-dialog-field">
+          <span class="record-dialog-label">眼睛动画</span>
+          <select id="record-edit-eye-select" class="record-dialog-input record-dialog-select"></select>
+        </label>
+        <label class="record-dialog-field">
+          <span class="record-dialog-label">LED 效果</span>
+          <select id="record-edit-led-select" class="record-dialog-input record-dialog-select"></select>
+        </label>
+        <span class="record-dialog-hint">保存后会为这个动作维护一个专用组合；动作播放期间会循环它，不复制眼睛或 LED 资源。</span>
+      </div>
       <div id="record-edit-error" class="record-dialog-error"></div>
       <div class="record-dialog-actions">
         <button id="btn-record-edit-cancel" class="ghost-button" type="button">取消</button>

--- a/lampgo/web/static/style.css
+++ b/lampgo/web/static/style.css
@@ -2654,7 +2654,8 @@ button.device-chip.is-active {
 
 .led-editor-head,
 .led-editor-command-row,
-.led-editor-tool-row {
+.led-editor-tool-row,
+.led-editor-bulk-row {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -2768,6 +2769,18 @@ button.device-chip.is-active {
   border-color: #176d68;
   background: #e3f3f0;
   color: #125b57;
+}
+.led-editor-bulk-row button {
+  flex: 1 1 82px;
+  min-height: 30px;
+  border: 1px solid #ccd3d8;
+  border-radius: 5px;
+  background: #fff;
+  color: #4f5b63;
+}
+.led-editor-bulk-row button.is-danger {
+  border-color: #d9918d;
+  color: #a4514d;
 }
 .led-editor-command-row { align-items: stretch; }
 .led-editor-command-row button { flex: 1 1 80px; }
@@ -2939,6 +2952,7 @@ button.device-chip.is-active {
 
 @media (max-width: 860px) {
   .expression-composer { grid-template-columns: 1fr; }
+  .clock-workspace { grid-template-columns: 1fr; }
   .expression-toolbar input[type="file"] { width: 100%; }
   .expression-resource-list { grid-template-columns: 1fr; }
   .led-editor-workspace { grid-template-columns: 1fr; }
@@ -2963,6 +2977,7 @@ button.device-chip.is-active {
     width: 100%;
     min-width: 0;
   }
+  .record-expression-custom { grid-template-columns: 1fr; }
   .led-editor-status { margin-left: 0; }
 }
 
@@ -2976,8 +2991,12 @@ button.device-chip.is-active {
   background: linear-gradient(180deg, #fbf9ff 0%, #ffffff 40%);
 }
 
+.skill-card--recording,
 .skill-card--recording-user {
   position: relative;
+}
+
+.skill-card--recording-user {
   border-left: 3px solid #e5a15b;
 }
 
@@ -3003,6 +3022,10 @@ button.device-chip.is-active {
 
 .skill-card-action--edit {
   right: 32px;
+}
+
+.skill-card--recording:not(.skill-card--recording-user) .skill-card-action--edit {
+  right: 6px;
 }
 
 .skill-card-action:hover {
@@ -3725,6 +3748,38 @@ button.device-chip.is-active {
 
 .record-dialog-select {
   width: 100%;
+}
+
+.record-expression-mode {
+  display: inline-flex;
+  align-self: flex-start;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.record-expression-mode button {
+  min-height: 30px;
+  padding: 0 10px;
+  border: 0;
+  border-right: 1px solid var(--border);
+  background: #fff;
+  color: var(--text-soft);
+}
+
+.record-expression-mode button:last-child {
+  border-right: 0;
+}
+
+.record-expression-mode button.is-active {
+  background: #e4f3f1;
+  color: #155f59;
+}
+
+.record-expression-custom {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
 }
 
 .record-dialog-textarea {

--- a/tests/test_expression_library.py
+++ b/tests/test_expression_library.py
@@ -206,6 +206,7 @@ def test_preset_api_requires_confirmation_and_transient_play_does_not_save(monke
     assert sent[0][1]["eye_clip_id"] == "focused_eyes"
     assert sent[0][1]["led_effect_id"] == "soft_mouth"
     assert sent[0][1]["led_program"]["template"] == "mouth"
+    assert sent[0][1]["led_params"]["brightness"] == 32
     assert [item["preset_id"] for item in list_expression_presets()] == ["focus"]
 
 

--- a/tests/test_recording_name_api.py
+++ b/tests/test_recording_name_api.py
@@ -5,7 +5,12 @@ from pathlib import Path
 from starlette.testclient import TestClient
 
 from lampgo.core.config import DeviceConfig, LampgoConfig
-from lampgo.recordings import normalize_recording_name
+from lampgo.recordings import (
+    list_recording_catalog,
+    normalize_recording_name,
+    read_recording_metadata,
+    recording_override_path,
+)
 from lampgo.server import LampgoServer
 from lampgo.web.gateway import WebGateway
 
@@ -54,3 +59,86 @@ def test_recordings_api_rejects_path_like_names(monkeypatch, tmp_path: Path) -> 
         )
     assert response.status_code == 400
     assert "中文" in response.json()["error"]
+
+
+def test_recording_update_can_create_an_action_specific_expression_preset(monkeypatch, tmp_path: Path) -> None:
+    gateway = _gateway(monkeypatch, tmp_path)
+    csv_path = tmp_path / "recordings" / "user" / "开心挥手.csv"
+    csv_path.parent.mkdir(parents=True)
+    csv_text = "timestamp,base_yaw.pos\n0.0,0\n"
+    csv_path.write_text(csv_text, encoding="utf-8")
+    created: list[dict] = []
+
+    def fake_save_expression_preset(payload: dict) -> dict:
+        created.append(payload)
+        return {"preset_id": payload["preset_id"]}
+
+    monkeypatch.setattr("lampgo.web.gateway.save_expression_preset", fake_save_expression_preset)
+
+    with TestClient(gateway.app) as client:
+        response = client.post(
+            "/api/recordings/update",
+            json={
+                "name": "开心挥手",
+                "description": "抬头挥手回应问候",
+                "eye_clip_id": "happy_eyes",
+                "led_effect_id": "heart",
+            },
+        )
+
+    assert response.status_code == 200
+    preset_id = response.json()["result"]["expression_preset"]
+    assert preset_id.startswith("motion_")
+    assert created == [
+        {
+            "preset_id": preset_id,
+            "label": "动作：开心挥手",
+            "description": "录制动作专用组合",
+            "eye_clip_id": "happy_eyes",
+            "led_effect_id": "heart",
+            "playback": "loop",
+            "duration_ms": 3000,
+        }
+    ]
+    assert csv_path.read_text(encoding="utf-8") == csv_text
+    assert read_recording_metadata(csv_path)["expression_preset"] == preset_id
+
+
+def test_recording_update_overrides_builtin_metadata_without_changing_factory_files(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    gateway = _gateway(monkeypatch, tmp_path)
+    csv_path = tmp_path / "recordings" / "开心挥手.csv"
+    csv_path.parent.mkdir(parents=True)
+    csv_path.write_text("timestamp,base_yaw.pos\n0.0,0\n", encoding="utf-8")
+    factory_metadata = "expression=smiley\nprompt=出厂挥手动作\n"
+    csv_path.with_suffix(".txt").write_text(factory_metadata, encoding="utf-8")
+
+    def fake_save_expression_preset(payload: dict) -> dict:
+        return {"preset_id": payload["preset_id"]}
+
+    monkeypatch.setattr("lampgo.web.gateway.save_expression_preset", fake_save_expression_preset)
+
+    with TestClient(gateway.app) as client:
+        response = client.post(
+            "/api/recordings/update",
+            json={
+                "name": "开心挥手",
+                "description": "开心地挥手回应用户",
+                "eye_clip_id": "happy_eyes",
+                "led_effect_id": "heart",
+            },
+        )
+
+    assert response.status_code == 200
+    preset_id = response.json()["result"]["expression_preset"]
+    assert response.json()["result"]["source"] == "builtin"
+    assert csv_path.with_suffix(".txt").read_text(encoding="utf-8") == factory_metadata
+    override = recording_override_path(tmp_path / "recordings", "开心挥手")
+    assert read_recording_metadata(override.with_suffix(".csv")) == {
+        "description": "开心地挥手回应用户",
+        "expression": "",
+        "expression_preset": preset_id,
+    }
+    assert list_recording_catalog(tmp_path / "recordings")[0]["expression_preset"] == preset_id

--- a/tests/test_web_config.py
+++ b/tests/test_web_config.py
@@ -148,6 +148,31 @@ def test_api_config_post_device_bare_field_name_is_accepted(monkeypatch, tmp_pat
     assert gateway.server.config.device.lamp_id == "AL42"
 
 
+def test_led_brightness_is_persisted_and_caps_direct_led_commands(monkeypatch, tmp_path):
+    gateway = _make_gateway(monkeypatch, tmp_path)
+    sent: list[tuple[str, dict]] = []
+
+    async def fake_proxy_post(path: str, payload: dict):
+        sent.append((path, payload))
+        return 200, {"ok": True}, "application/json"
+
+    monkeypatch.setattr(gateway.server.esp32, "proxy_post", fake_proxy_post)
+
+    with TestClient(gateway.app) as client:
+        saved = client.post("/api/config/device_esp32", json={"led_brightness": 24})
+        direct = client.post("/api/device/led", json={"expression": "heart", "brightness": 96})
+
+    assert saved.status_code == 200
+    assert saved.json()["result"]["led_brightness_sync"] == {"ok": True, "level": 24}
+    assert gateway.server.config.device_esp32.led_brightness == 24
+    assert personastore.get_overrides_toml()["device_esp32"]["led_brightness"] == 24
+    assert direct.status_code == 200
+    assert sent[0][0] == "/device/led"
+    assert sent[0][1]["brightness"] == 24
+    assert sent[1][0] == "/device/led"
+    assert sent[1][1]["brightness"] == 24
+
+
 def test_api_config_post_rejects_unknown_fields(monkeypatch, tmp_path):
     gateway = _make_gateway(monkeypatch, tmp_path)
 


### PR DESCRIPTION
## What
- Add a persisted LED brightness ceiling (1–96) that caps direct effects and composed expression playback.
- Let users attach a dedicated eye-and-LED combination to a recorded motion.
- Allow local metadata overrides for built-in recordings, without editing their shipped CSV or sidecar files.
- Add bulk copy-all and clear-all operations to the LED frame editor.

## Why
LED expression authoring needed per-motion control and a hardware-safe brightness limit, while factory recordings must remain immutable.

## Impact
Users can tune a local actions expression without overwriting factory motion assets; brightness is persisted and synchronised to the paired device when available.

## Checks
- uv run pytest -q: 328 passed, 1 existing deprecation warning
- ruff check on touched Python files, excluding existing repository-wide E501/UP041/I001 findings: passed
- node --check lampgo/web/static/app.js: passed
- git diff --check: passed