### PR TITLE
feat: add electronic ocean mode

### DIFF
--- a/lampgo/electronic_ocean.py
+++ b/lampgo/electronic_ocean.py
@@ -1,0 +1,253 @@
+"""Backend control plane for the S3-local electronic ocean renderer."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_OCEAN_COLOR = "#00b8e0"
+OCEAN_DYNAMICS_PRESETS: dict[str, dict[str, int]] = {
+    "soft": {
+        "sensitivity_percent": 80,
+        "tilt_percent": 70,
+        "impact_percent": 45,
+        "damping_percent": 170,
+        "edge_highlight_percent": 60,
+    },
+    "standard": {
+        "sensitivity_percent": 100,
+        "tilt_percent": 100,
+        "impact_percent": 100,
+        "damping_percent": 130,
+        "edge_highlight_percent": 75,
+    },
+    "violent": {
+        "sensitivity_percent": 125,
+        "tilt_percent": 135,
+        "impact_percent": 165,
+        "damping_percent": 100,
+        "edge_highlight_percent": 95,
+    },
+}
+
+
+def _ocean_path() -> Path:
+    root = Path(os.environ.get("LAMPGO_HOME", Path.home() / ".lampgo"))
+    return root / "electronic_ocean.json"
+
+
+def _integer(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        return max(minimum, min(maximum, int(value)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _color(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    if len(text) == 7 and text.startswith("#") and all(ch in "0123456789abcdef" for ch in text[1:]):
+        return text
+    return DEFAULT_OCEAN_COLOR
+
+
+def _dynamics(value: Any) -> str:
+    name = str(value or "").strip().lower()
+    return name if name in OCEAN_DYNAMICS_PRESETS else "standard"
+
+
+@dataclass
+class OceanSettings:
+    enabled: bool = False
+    dynamics: str = "standard"
+    color: str = DEFAULT_OCEAN_COLOR
+    brightness: int = 36
+    fill_percent: int = 55
+    sensitivity_percent: int = 100
+    edge_highlight_percent: int = 75
+    tilt_percent: int = 100
+    impact_percent: int = 100
+    damping_percent: int = 130
+
+    @classmethod
+    def from_mapping(cls, value: Any) -> OceanSettings:
+        data = value if isinstance(value, dict) else {}
+        dynamics = _dynamics(data.get("dynamics"))
+        preset = OCEAN_DYNAMICS_PRESETS[dynamics]
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            dynamics=dynamics,
+            color=_color(data.get("color")),
+            brightness=_integer(data.get("brightness"), 36, 1, 96),
+            fill_percent=_integer(data.get("fill_percent"), 55, 20, 80),
+            sensitivity_percent=_integer(
+                data.get("sensitivity_percent"), preset["sensitivity_percent"], 25, 200
+            ),
+            edge_highlight_percent=_integer(
+                data.get("edge_highlight_percent"), preset["edge_highlight_percent"], 0, 100
+            ),
+            tilt_percent=_integer(data.get("tilt_percent"), preset["tilt_percent"], 50, 160),
+            impact_percent=_integer(data.get("impact_percent"), preset["impact_percent"], 0, 200),
+            damping_percent=_integer(data.get("damping_percent"), preset["damping_percent"], 80, 200),
+        )
+
+
+class ElectronicOceanController:
+    """Samples joint 5 at 10 Hz while S3 owns simulation and pixel rendering."""
+
+    def __init__(
+        self,
+        esp32: Any,
+        angle_source: Callable[[], float | None],
+        *,
+        path: Path | None = None,
+        monotonic: Callable[[], float] | None = None,
+        brightness_ceiling: Callable[[], int] | None = None,
+    ) -> None:
+        self._esp32 = esp32
+        self._angle_source = angle_source
+        self._path = path or _ocean_path()
+        self._monotonic = monotonic or time.monotonic
+        self._brightness_ceiling = brightness_ceiling or (lambda: 96)
+        self._settings = self._load()
+        self._baseline_deg = 0.0
+        self._last_angle_deg = 0.0
+        self._last_sample_at = 0.0
+        self._filtered_velocity_dps = 0.0
+        self._sequence = 0
+        self._device_started = False
+        self._last_sent_at = 0.0
+        self._last_error: str | None = None
+        self._joint_available = False
+
+    def _load(self) -> OceanSettings:
+        try:
+            settings = OceanSettings.from_mapping(json.loads(self._path.read_text(encoding="utf-8")))
+            settings.enabled = False
+            return settings
+        except Exception:
+            return OceanSettings()
+
+    def _save(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(asdict(self._settings), ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def _read_angle(self) -> float | None:
+        try:
+            value = self._angle_source()
+            return float(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    def snapshot(self) -> dict[str, Any]:
+        now = self._monotonic()
+        return {
+            **asdict(self._settings),
+            "joint": "wrist_pitch",
+            "joint_available": self._joint_available,
+            "baseline_deg": round(self._baseline_deg, 3),
+            "angle_deg": round(self._last_angle_deg - self._baseline_deg, 3),
+            "angular_velocity_dps": round(self._filtered_velocity_dps, 3),
+            "sequence": self._sequence,
+            "telemetry_hz": 10,
+            "device_render_fps": 20,
+            "last_sent_age_ms": round(max(0.0, now - self._last_sent_at) * 1000) if self._last_sent_at else None,
+            "last_error": self._last_error,
+        }
+
+    def _start_payload(self) -> dict[str, Any]:
+        return {
+            "action": "start",
+            "color": self._settings.color,
+            "brightness": min(self._settings.brightness, _integer(self._brightness_ceiling(), 96, 1, 96)),
+            "fill_percent": self._settings.fill_percent,
+            "sensitivity_percent": self._settings.sensitivity_percent,
+            "edge_highlight_percent": self._settings.edge_highlight_percent,
+            "tilt_percent": self._settings.tilt_percent,
+            "impact_percent": self._settings.impact_percent,
+            "damping_percent": self._settings.damping_percent,
+        }
+
+    async def _post(self, payload: dict[str, Any], *, reason: str) -> tuple[bool, dict[str, Any]]:
+        body = self._esp32.with_owner_auth(payload, reason=reason)
+        status, response, _ = await self._esp32.proxy_post("/device/ocean", body)
+        data = response if isinstance(response, dict) else {"raw": str(response)}
+        ok = status < 400 and data.get("ok") is not False
+        self._last_error = None if ok else str(data.get("error") or f"device returned {status}")
+        return ok, data
+
+    async def start(self, **values: Any) -> dict[str, Any]:
+        current = asdict(self._settings)
+        if values.get("dynamics") is not None:
+            dynamics = _dynamics(values["dynamics"])
+            for key, value in OCEAN_DYNAMICS_PRESETS[dynamics].items():
+                if key not in values:
+                    current[key] = value
+        current.update({key: value for key, value in values.items() if value is not None})
+        self._settings = OceanSettings.from_mapping(current)
+        self._settings.enabled = True
+        angle = self._read_angle()
+        self._joint_available = angle is not None
+        self._baseline_deg = angle if angle is not None else 0.0
+        self._last_angle_deg = self._baseline_deg
+        self._last_sample_at = self._monotonic()
+        self._filtered_velocity_dps = 0.0
+        self._sequence = 0
+        self._device_started = False
+        self._save()
+        ok, device = await self._post(self._start_payload(), reason="electronic_ocean_start")
+        self._device_started = ok
+        if ok:
+            self._last_sent_at = self._monotonic()
+        return {"ok": ok, **self.snapshot(), "device": device}
+
+    async def refresh(self) -> dict[str, Any]:
+        if not self._settings.enabled:
+            return {"ok": True, "sent": False, **self.snapshot()}
+        if not self._device_started:
+            ok, _ = await self._post(self._start_payload(), reason="electronic_ocean_resume")
+            self._device_started = ok
+            if not ok:
+                return {"ok": False, "sent": False, **self.snapshot()}
+
+        now = self._monotonic()
+        angle = self._read_angle()
+        self._joint_available = angle is not None
+        if angle is None:
+            angle = self._last_angle_deg
+        elapsed = max(0.02, min(0.5, now - self._last_sample_at)) if self._last_sample_at else 0.1
+        raw_velocity = (angle - self._last_angle_deg) / elapsed
+        self._filtered_velocity_dps += (raw_velocity - self._filtered_velocity_dps) * 0.35
+        self._last_angle_deg = angle
+        self._last_sample_at = now
+        self._sequence += 1
+        payload = {
+            "action": "input",
+            "angle_deg": round(max(-35.0, min(35.0, angle - self._baseline_deg)), 3),
+            "angular_velocity_dps": round(max(-180.0, min(180.0, self._filtered_velocity_dps)), 3),
+            "sequence": self._sequence,
+        }
+        ok, device = await self._post(payload, reason="electronic_ocean_input")
+        if ok:
+            self._last_sent_at = now
+        else:
+            self._device_started = False
+        return {"ok": ok, "sent": True, **self.snapshot(), "device": device}
+
+    async def stop(self) -> dict[str, Any]:
+        self._settings.enabled = False
+        self._device_started = False
+        self._save()
+        ok, device = await self._post({"action": "stop"}, reason="electronic_ocean_stop")
+        return {"ok": ok, **self.snapshot(), "device": device}
+
+    def deactivate(self) -> None:
+        """Stop telemetry when another LED mode has already won on the device."""
+        if self._settings.enabled:
+            self._settings.enabled = False
+            self._device_started = False
+            self._save()

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -22,6 +22,7 @@ from typing import Any
 import structlog
 
 from lampgo.agent import AgentLedIndicator, AgentManager
+from lampgo.clock import ClockController
 from lampgo.core.config import LampgoConfig, LEDConfig
 from lampgo.core.events import (
     AgentAskRequested,
@@ -38,11 +39,11 @@ from lampgo.core.events import (
 )
 from lampgo.core.hal import HardwareAbstraction, MotorStartupState
 from lampgo.core.led import LEDController
-from lampgo.clock import ClockController
 from lampgo.core.motion import MotionRuntime
 from lampgo.core.safety import SafetyKernel
 from lampgo.core.virtual_motion import VirtualMotionRuntime
 from lampgo.device import Esp32DeviceManager
+from lampgo.electronic_ocean import ElectronicOceanController
 from lampgo.ipc import IPCServer
 from lampgo.perception.cat_teaser import CatTeaserFrameSource, is_supported_local_camera_port
 from lampgo.perception.router import IntentRouter, IntentType
@@ -54,7 +55,12 @@ from lampgo.recordings import (
 )
 from lampgo.skills.base import SkillContext
 from lampgo.skills.builtin.cat_teaser import CatTeaserSkill
-from lampgo.skills.builtin.expression_skills import SetExpressionSkill, ShowClockSkill
+from lampgo.skills.builtin.expression_skills import (
+    SetExpressionSkill,
+    ShowClockSkill,
+    StartElectronicOceanSkill,
+    StopElectronicOceanSkill,
+)
 from lampgo.skills.builtin.motion_skills import EStopSkill, MoveToSkill, ReturnSafeSkill
 from lampgo.skills.builtin.music_skills import DanceToMusicSkill
 from lampgo.skills.builtin.parametric_skills import (
@@ -107,6 +113,11 @@ class LampgoServer:
         self.led = LEDController(LEDConfig(port="", baud_rate=config.led.baud_rate), esp32_manager=self.esp32)
         self.clock = ClockController(
             self.led,
+            brightness_ceiling=lambda: self.config.device_esp32.led_brightness,
+        )
+        self.electronic_ocean = ElectronicOceanController(
+            self.esp32,
+            lambda: self.motion.current_state.get("wrist_pitch") if self.motion.current_state else None,
             brightness_ceiling=lambda: self.config.device_esp32.led_brightness,
         )
         self.fsm = StateMachine()
@@ -174,6 +185,8 @@ class LampgoServer:
         self.registry.register(PlayRecordingSkill(recordings_dir))
         self.registry.register(SetExpressionSkill())
         self.registry.register(ShowClockSkill())
+        self.registry.register(StartElectronicOceanSkill())
+        self.registry.register(StopElectronicOceanSkill())
         self.registry.register(NodSkill())
         self.registry.register(HeadShakeSkill())
         self.registry.register(LookAtSkill())
@@ -254,6 +267,7 @@ class LampgoServer:
             events=self.events,
             state=self.motion.current_state,
             clock=self.clock,
+            electronic_ocean=self.electronic_ocean,
         )
 
     async def _on_skill_started(self, event: SkillStarted) -> None:

--- a/lampgo/skills/base.py
+++ b/lampgo/skills/base.py
@@ -51,6 +51,7 @@ class SkillContext:
     events: EventBus
     state: JointState
     clock: Any | None = None
+    electronic_ocean: Any | None = None
 
     async def play_frames(
         self,

--- a/lampgo/skills/builtin/expression_skills.py
+++ b/lampgo/skills/builtin/expression_skills.py
@@ -107,3 +107,85 @@ class ShowClockSkill(Skill):
         if not result.get("ok"):
             return SkillResult(status="error", message="LED clock could not reach the paired device", data=result)
         return SkillResult(status="ok", data=result)
+
+
+class StartElectronicOceanSkill(Skill):
+    """Start the S3-local fluid renderer driven by wrist pitch feedback."""
+
+    skill_id = "start_electronic_ocean"
+    description = (
+        "Start electronic ocean on the S3 LED matrix. The current wrist_pitch pose becomes horizontal, "
+        "then joint 5 movement disturbs the locally simulated fluid."
+    )
+    parameters = {
+        "dynamics": ParameterSpec(
+            "dynamics",
+            "str",
+            required=False,
+            default="standard",
+            description="Fluid dynamics preset: soft, standard, or violent.",
+        ),
+        "color": ParameterSpec(
+            "color", "str", required=False, default="#00b8e0", description="Water color as #RRGGBB."
+        ),
+        "brightness": ParameterSpec("brightness", "int", required=False, default=36, description="Brightness 1 to 96."),
+        "fill_percent": ParameterSpec(
+            "fill_percent", "int", required=False, default=55, description="Water fill 20 to 80 percent."
+        ),
+        "sensitivity_percent": ParameterSpec(
+            "sensitivity_percent",
+            "int",
+            required=False,
+            default=100,
+            description="Motion sensitivity 25 to 200 percent.",
+        ),
+        "edge_highlight_percent": ParameterSpec(
+            "edge_highlight_percent",
+            "int",
+            required=False,
+            default=75,
+            description="Surface highlight 0 to 100 percent.",
+        ),
+        "tilt_percent": ParameterSpec(
+            "tilt_percent",
+            "int",
+            required=False,
+            default=100,
+            description="Whole-fluid tilt amplitude 50 to 160 percent.",
+        ),
+        "impact_percent": ParameterSpec(
+            "impact_percent",
+            "int",
+            required=False,
+            default=100,
+            description="Wall collision and splash strength 0 to 200 percent.",
+        ),
+    }
+
+    async def execute(self, ctx: SkillContext, **params: Any) -> SkillResult:
+        ocean = ctx.electronic_ocean
+        if ocean is None:
+            return SkillResult(status="error", message="Electronic ocean controller unavailable")
+        result = await ocean.start(**params)
+        if not result.get("ok"):
+            return SkillResult(
+                status="error",
+                message="Electronic ocean could not reach the paired device",
+                data=result,
+            )
+        return SkillResult(status="ok", data=result)
+
+
+class StopElectronicOceanSkill(Skill):
+    skill_id = "stop_electronic_ocean"
+    description = "Stop electronic ocean and clear the S3 LED matrix."
+    parameters = {}
+
+    async def execute(self, ctx: SkillContext, **params: Any) -> SkillResult:
+        ocean = ctx.electronic_ocean
+        if ocean is None:
+            return SkillResult(status="error", message="Electronic ocean controller unavailable")
+        result = await ocean.stop()
+        if not result.get("ok"):
+            return SkillResult(status="error", message="Electronic ocean stop failed", data=result)
+        return SkillResult(status="ok", data=result)

--- a/lampgo/skills/executor.py
+++ b/lampgo/skills/executor.py
@@ -29,6 +29,7 @@ _MOTION_SKILLS = {
 _LED_SKILLS = {
     "set_expression",
     "show_clock",
+    "start_electronic_ocean", "stop_electronic_ocean",
     "presence_react",
     "teleop_mouse", "teleop_gamepad",
 }
@@ -103,8 +104,15 @@ class SkillExecutor:
                 status="ok",
                 result={"note": "LED not connected, skipped"},
             )
-        if skill_id in _LED_SKILLS and skill_id != "show_clock" and ctx.clock is not None:
+        if (
+            skill_id in _LED_SKILLS
+            and skill_id not in {"show_clock", "stop_electronic_ocean"}
+            and ctx.clock is not None
+        ):
             ctx.clock.deactivate()
+        if skill_id in _LED_SKILLS and skill_id not in {"start_electronic_ocean", "stop_electronic_ocean"}:
+            if ctx.electronic_ocean is not None:
+                ctx.electronic_ocean.deactivate()
 
         async with self._lock:
             # Cancel current skill if running. This gives rapid UI clicks

--- a/lampgo/web/gateway.py
+++ b/lampgo/web/gateway.py
@@ -205,6 +205,7 @@ class WebGateway:
         self._status_task: asyncio.Task | None = None
         self._pet_pose_task: asyncio.Task | None = None
         self._clock_task: asyncio.Task | None = None
+        self._ocean_task: asyncio.Task | None = None
         self._active_request_tasks: dict[WebSocket, asyncio.Task] = {}
         self._background_ws_tasks: set[asyncio.Task[None]] = set()
         self._esp32_relay_tasks: dict[WebSocket, asyncio.Task] = {}
@@ -260,6 +261,9 @@ class WebGateway:
             Route("/api/clock", self.api_clock, methods=["GET"]),
             Route("/api/clock/show", self.api_clock_show, methods=["POST"]),
             Route("/api/clock/stop", self.api_clock_stop, methods=["POST"]),
+            Route("/api/electronic-ocean", self.api_electronic_ocean, methods=["GET"]),
+            Route("/api/electronic-ocean/start", self.api_electronic_ocean_start, methods=["POST"]),
+            Route("/api/electronic-ocean/stop", self.api_electronic_ocean_stop, methods=["POST"]),
             Route("/api/camera/snap", self.api_camera_snap),
             Route("/api/sensor/context", self.api_sensor_context),
             Route("/api/agent/ask", self.api_agent_ask, methods=["POST"]),
@@ -330,8 +334,9 @@ class WebGateway:
             self._status_task = asyncio.create_task(self._status_loop())
             self._pet_pose_task = asyncio.create_task(self._pet_pose_loop())
             self._clock_task = asyncio.create_task(self._clock_loop())
+            self._ocean_task = asyncio.create_task(self._ocean_loop())
             yield
-            for task in (self._status_task, self._pet_pose_task, self._clock_task):
+            for task in (self._status_task, self._pet_pose_task, self._clock_task, self._ocean_task):
                 if not task:
                     continue
                 task.cancel()
@@ -376,6 +381,15 @@ class WebGateway:
             except Exception:
                 logger.exception("web.clock_refresh_failed")
             await asyncio.sleep(1.0)
+
+    async def _ocean_loop(self) -> None:
+        """Send coalesced wrist telemetry while S3 renders the ocean locally."""
+        while True:
+            try:
+                await self.server.electronic_ocean.refresh()
+            except Exception:
+                logger.exception("web.electronic_ocean_refresh_failed")
+            await asyncio.sleep(0.1)
 
     async def _pet_pose_loop(self) -> None:
         """Broadcast joint poses at animation-friendly cadence for the Web pet."""
@@ -1130,6 +1144,7 @@ class WebGateway:
         if not self.server.esp32:
             return 503, {"ok": False, "error": "no_device"}
         self.server.clock.deactivate()
+        self.server.electronic_ocean.deactivate()
         effect = composition.get("led_effect") or {}
         if effect.get("kind") == "pixel_clip" and composition.get("led_effect_id"):
             sync_status, sync_body, _ = await self._sync_led_effect_to_device(
@@ -1174,6 +1189,7 @@ class WebGateway:
 
     async def api_expression_stop(self, request: Request) -> JSONResponse:
         self.server.clock.deactivate()
+        self.server.electronic_ocean.deactivate()
         if not self.server.esp32:
             return JSONResponse({"ok": False, "error": "no_device"}, status_code=503)
         payload = self.server.esp32.with_owner_auth({}, reason="expression_stop")
@@ -1190,6 +1206,7 @@ class WebGateway:
             body = {}
         if not isinstance(body, dict):
             return JSONResponse({"ok": False, "error": "body must be object"}, status_code=400)
+        self.server.electronic_ocean.deactivate()
         result = await asyncio.to_thread(
             self.server.clock.show,
             color=body.get("color"),
@@ -1201,6 +1218,26 @@ class WebGateway:
 
     async def api_clock_stop(self, request: Request) -> JSONResponse:
         result = await asyncio.to_thread(self.server.clock.stop)
+        status = 200 if result.get("ok") else 503
+        return JSONResponse({"ok": bool(result.get("ok")), "result": result}, status_code=status)
+
+    async def api_electronic_ocean(self, request: Request) -> JSONResponse:
+        return JSONResponse({"ok": True, "result": self.server.electronic_ocean.snapshot()})
+
+    async def api_electronic_ocean_start(self, request: Request) -> JSONResponse:
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        if not isinstance(body, dict):
+            return JSONResponse({"ok": False, "error": "body must be object"}, status_code=400)
+        self.server.clock.deactivate()
+        result = await self.server.electronic_ocean.start(**body)
+        status = 200 if result.get("ok") else 503
+        return JSONResponse({"ok": bool(result.get("ok")), "result": result}, status_code=status)
+
+    async def api_electronic_ocean_stop(self, request: Request) -> JSONResponse:
+        result = await self.server.electronic_ocean.stop()
         status = 200 if result.get("ok") else 503
         return JSONResponse({"ok": bool(result.get("ok")), "result": result}, status_code=status)
 
@@ -2805,6 +2842,7 @@ class WebGateway:
             patch["brightness"] = brightness_ceiling
         if any(key in patch for key in ("mode", "expression", "name", "clip_id")):
             self.server.clock.deactivate()
+            self.server.electronic_ocean.deactivate()
         if self.server.esp32 and hasattr(self.server.esp32, "with_owner_auth"):
             patch = self.server.esp32.with_owner_auth(patch, reason="led")
         status, body, _ = await self.server.esp32.proxy_post("/device/led", patch)

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -78,6 +78,23 @@
   const clockStatus = document.getElementById("clock-status");
   const btnClockShow = document.getElementById("btn-clock-show");
   const btnClockStop = document.getElementById("btn-clock-stop");
+  const oceanPreview = document.getElementById("ocean-preview");
+  const oceanColor = document.getElementById("ocean-color");
+  const oceanBrightness = document.getElementById("ocean-brightness");
+  const oceanFill = document.getElementById("ocean-fill");
+  const oceanSensitivity = document.getElementById("ocean-sensitivity");
+  const oceanTilt = document.getElementById("ocean-tilt");
+  const oceanImpact = document.getElementById("ocean-impact");
+  const oceanEdge = document.getElementById("ocean-edge");
+  const oceanBrightnessValue = document.getElementById("ocean-brightness-value");
+  const oceanFillValue = document.getElementById("ocean-fill-value");
+  const oceanSensitivityValue = document.getElementById("ocean-sensitivity-value");
+  const oceanTiltValue = document.getElementById("ocean-tilt-value");
+  const oceanImpactValue = document.getElementById("ocean-impact-value");
+  const oceanEdgeValue = document.getElementById("ocean-edge-value");
+  const oceanStatus = document.getElementById("ocean-status");
+  const btnOceanStart = document.getElementById("btn-ocean-start");
+  const btnOceanStop = document.getElementById("btn-ocean-stop");
   const agentTaskList = document.getElementById("agent-task-list");
   const chipJoint = document.getElementById("chip-joint");
   const chipJointDot = document.getElementById("chip-joint-dot");
@@ -255,6 +272,14 @@
   let expressionPreviewImage = null;
   let recordEditExpressionMode = "preset";
   let clockPreviewTimer = null;
+  let oceanPreviewTimer = null;
+  let oceanPreviewStartedAt = performance.now();
+  let oceanDynamics = "standard";
+  const OCEAN_DYNAMICS_PRESETS = Object.freeze({
+    soft: { sensitivity_percent: 80, tilt_percent: 70, impact_percent: 45, edge_highlight_percent: 60 },
+    standard: { sensitivity_percent: 100, tilt_percent: 100, impact_percent: 100, edge_highlight_percent: 75 },
+    violent: { sensitivity_percent: 125, tilt_percent: 135, impact_percent: 165, edge_highlight_percent: 95 },
+  });
   const ledEffectSourceCache = new Map();
   const LED_EDITOR_WIDTH = 51;
   const LED_EDITOR_HEIGHT = 9;
@@ -4019,6 +4044,153 @@
     }
   }
 
+  function oceanSettingsFromControls() {
+    return {
+      dynamics: oceanDynamics,
+      color: (oceanColor && oceanColor.value) || "#00b8e0",
+      brightness: Number((oceanBrightness && oceanBrightness.value) || 36),
+      fill_percent: Number((oceanFill && oceanFill.value) || 55),
+      sensitivity_percent: Number((oceanSensitivity && oceanSensitivity.value) || 100),
+      tilt_percent: Number((oceanTilt && oceanTilt.value) || 100),
+      impact_percent: Number((oceanImpact && oceanImpact.value) || 100),
+      edge_highlight_percent: Number((oceanEdge && oceanEdge.value) || 75),
+    };
+  }
+
+  function setOceanDynamics(name, applyValues = true) {
+    const preset = OCEAN_DYNAMICS_PRESETS[name] || OCEAN_DYNAMICS_PRESETS.standard;
+    oceanDynamics = OCEAN_DYNAMICS_PRESETS[name] ? name : "standard";
+    document.querySelectorAll("[data-ocean-dynamics]").forEach((button) => {
+      button.classList.toggle("is-active", button.dataset.oceanDynamics === oceanDynamics);
+    });
+    if (applyValues) {
+      if (oceanSensitivity) oceanSensitivity.value = String(preset.sensitivity_percent);
+      if (oceanTilt) oceanTilt.value = String(preset.tilt_percent);
+      if (oceanImpact) oceanImpact.value = String(preset.impact_percent);
+      if (oceanEdge) oceanEdge.value = String(preset.edge_highlight_percent);
+    }
+    renderOceanPreview();
+  }
+
+  function hexToRgb(value) {
+    const match = /^#([0-9a-f]{6})$/i.exec(String(value || ""));
+    if (!match) return null;
+    const parsed = Number.parseInt(match[1], 16);
+    return { r: (parsed >> 16) & 255, g: (parsed >> 8) & 255, b: parsed & 255 };
+  }
+
+  function renderOceanPreview() {
+    if (!oceanPreview) return;
+    const ctx = oceanPreview.getContext("2d");
+    const settings = oceanSettingsFromControls();
+    const elapsed = (performance.now() - oceanPreviewStartedAt) / 1000;
+    const rgb = hexToRgb(settings.color) || { r: 0, g: 184, b: 224 };
+    const brightness = settings.brightness / 96;
+    const baseHeight = 1.2 + 6.3 * settings.fill_percent / 100;
+    const demoTiltBase = oceanDynamics === "violent" ? 3.2 : oceanDynamics === "soft" ? 0.7 : 1.8;
+    const demoTilt = Math.min(4.2, demoTiltBase * settings.tilt_percent / 100) * Math.sin(elapsed * 1.1);
+    ctx.fillStyle = "#0d1316";
+    ctx.fillRect(0, 0, oceanPreview.width, oceanPreview.height);
+    for (let col = 0; col < 51; col += 1) {
+      const columnPosition = col / 25 - 1;
+      const height = baseHeight
+        + demoTilt * columnPosition
+        + Math.sin(elapsed * 1.7 + col * 0.28) * 0.18
+        + Math.sin(elapsed * 0.9 - col * 0.13) * 0.11;
+      const surface = 9 - height;
+      const edgeRow = Math.round(surface);
+      for (let row = 0; row < 9; row += 1) {
+        const coverage = Math.max(0, Math.min(1, row + 1 - surface));
+        const x = col * 10 + 5;
+        const y = row * 10 + 5;
+        ctx.beginPath();
+        ctx.arc(x, y, 3.7, 0, Math.PI * 2);
+        if (coverage <= 0) {
+          ctx.fillStyle = "#30383d";
+        } else if (row === edgeRow) {
+          const mix = settings.edge_highlight_percent / 100;
+          const r = Math.round((rgb.r + (255 - rgb.r) * mix) * brightness);
+          const g = Math.round((rgb.g + (255 - rgb.g) * mix) * brightness);
+          const b = Math.round((rgb.b + (255 - rgb.b) * mix) * brightness);
+          ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
+        } else {
+          const depth = Math.min(1, Math.max(0, (row + 0.5 - surface) / 4));
+          const level = coverage * (0.42 + depth * 0.48) * brightness;
+          ctx.fillStyle = `rgb(${Math.round(rgb.r * level)}, ${Math.round(rgb.g * level)}, ${Math.round(rgb.b * level)})`;
+        }
+        ctx.fill();
+      }
+    }
+    if (oceanBrightnessValue) oceanBrightnessValue.value = String(settings.brightness);
+    if (oceanFillValue) oceanFillValue.value = `${settings.fill_percent}%`;
+    if (oceanSensitivityValue) oceanSensitivityValue.value = `${settings.sensitivity_percent}%`;
+    if (oceanTiltValue) oceanTiltValue.value = `${settings.tilt_percent}%`;
+    if (oceanImpactValue) oceanImpactValue.value = `${settings.impact_percent}%`;
+    if (oceanEdgeValue) oceanEdgeValue.value = `${settings.edge_highlight_percent}%`;
+  }
+
+  function startOceanPreview() {
+    if (!oceanPreview || oceanPreviewTimer) return;
+    renderOceanPreview();
+    oceanPreviewTimer = window.setInterval(renderOceanPreview, 50);
+  }
+
+  function applyOceanState(state) {
+    if (!state || typeof state !== "object") return;
+    if (oceanColor && state.color) oceanColor.value = state.color;
+    if (oceanBrightness && state.brightness) oceanBrightness.value = String(state.brightness);
+    if (oceanFill && state.fill_percent) oceanFill.value = String(state.fill_percent);
+    if (oceanSensitivity && state.sensitivity_percent) oceanSensitivity.value = String(state.sensitivity_percent);
+    if (oceanTilt && state.tilt_percent) oceanTilt.value = String(state.tilt_percent);
+    if (oceanImpact && state.impact_percent !== undefined) oceanImpact.value = String(state.impact_percent);
+    if (oceanEdge && state.edge_highlight_percent !== undefined) oceanEdge.value = String(state.edge_highlight_percent);
+    setOceanDynamics(state.dynamics || "standard", false);
+    renderOceanPreview();
+    if (oceanStatus) {
+      oceanStatus.textContent = state.enabled
+        ? `运行中 · 舵机${state.joint_available ? "已连接" : "无反馈"} · ${state.telemetry_hz || 10} Hz 遥测 / ${state.device_render_fps || 20} FPS 渲染`
+        : "待启动";
+    }
+  }
+
+  async function refreshOcean() {
+    try {
+      const result = await fetchJson("/api/electronic-ocean");
+      applyOceanState(result);
+    } catch (error) {
+      if (oceanStatus) oceanStatus.textContent = `状态加载失败：${error.message || error}`;
+    }
+  }
+
+  async function startOcean() {
+    if (btnOceanStart) btnOceanStart.disabled = true;
+    try {
+      const result = await fetchJson("/api/electronic-ocean/start", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(oceanSettingsFromControls()),
+      });
+      applyOceanState(result);
+    } catch (error) {
+      if (oceanStatus) oceanStatus.textContent = `启动失败：${error.message || error}`;
+    } finally {
+      if (btnOceanStart) btnOceanStart.disabled = false;
+    }
+  }
+
+  async function stopOcean() {
+    if (btnOceanStop) btnOceanStop.disabled = true;
+    try {
+      const result = await fetchJson("/api/electronic-ocean/stop", { method: "POST" });
+      applyOceanState(result);
+      if (oceanStatus) oceanStatus.textContent = "电子海洋已停止。";
+    } catch (error) {
+      if (oceanStatus) oceanStatus.textContent = `停止失败：${error.message || error}`;
+    } finally {
+      if (btnOceanStop) btnOceanStop.disabled = false;
+    }
+  }
+
   async function refreshExpressionStudio() {
     try {
       const [eyes, effects, presets, capacity] = await Promise.all([
@@ -4055,6 +4227,7 @@
         ].join("  |  ");
       }
       void refreshClock();
+      void refreshOcean();
     } catch (error) {
       if (expressionCapacityEl) expressionCapacityEl.textContent = `表情库加载失败：${error.message || error}`;
     }
@@ -4535,6 +4708,14 @@
   if (btnClockStop) btnClockStop.addEventListener("click", () => { void stopClock(); });
   if (clockColor) clockColor.addEventListener("input", renderClockPreview);
   if (clockEffect) clockEffect.addEventListener("change", renderClockPreview);
+  if (btnOceanStart) btnOceanStart.addEventListener("click", () => { void startOcean(); });
+  if (btnOceanStop) btnOceanStop.addEventListener("click", () => { void stopOcean(); });
+  document.querySelectorAll("[data-ocean-dynamics]").forEach((button) => {
+    button.addEventListener("click", () => setOceanDynamics(button.dataset.oceanDynamics || "standard"));
+  });
+  [oceanColor, oceanBrightness, oceanFill, oceanSensitivity, oceanTilt, oceanImpact, oceanEdge].forEach((control) => {
+    if (control) control.addEventListener("input", renderOceanPreview);
+  });
   if (btnEyeUpload) btnEyeUpload.addEventListener("click", () => { void uploadExpressionEye(); });
   if (ledEffectForm) {
     ledEffectForm.addEventListener("submit", (event) => {
@@ -4565,6 +4746,7 @@
   initializeLedEditor();
   ensureLedPreviewCells();
   startClockPreview();
+  startOceanPreview();
   void refreshSkillsAndRecordings();
   void refreshExpressionStudio();
   if (btnUserSkillsReload) {

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -380,6 +380,36 @@
                 </div>
               </div>
             </section>
+            <section class="ocean-quick-panel" aria-labelledby="ocean-quick-title">
+              <div class="ocean-quick-head">
+                <div>
+                  <div id="ocean-quick-title" class="ocean-quick-title">电子海洋</div>
+                  <div class="ocean-quick-desc">启动时以 5 号舵机当前位置为水平面，运动会实时扰动 S3 本地流体。</div>
+                </div>
+                <div id="ocean-status" class="ocean-status">待启动</div>
+              </div>
+              <div class="ocean-workspace">
+                <canvas id="ocean-preview" class="ocean-preview" width="510" height="90" aria-label="电子海洋 LED 点阵预览"></canvas>
+                <div class="ocean-controls">
+                  <div class="ocean-dynamics-presets" role="group" aria-label="流体动态预设">
+                    <button type="button" data-ocean-dynamics="soft">柔和</button>
+                    <button type="button" class="is-active" data-ocean-dynamics="standard">标准</button>
+                    <button type="button" data-ocean-dynamics="violent">剧烈</button>
+                  </div>
+                  <label>水色<input id="ocean-color" type="color" value="#00b8e0" /></label>
+                  <label>亮度 <output id="ocean-brightness-value">36</output><input id="ocean-brightness" type="range" min="1" max="96" value="36" /></label>
+                  <label>液位 <output id="ocean-fill-value">55%</output><input id="ocean-fill" type="range" min="20" max="80" value="55" /></label>
+                  <label>响应灵敏度 <output id="ocean-sensitivity-value">100%</output><input id="ocean-sensitivity" type="range" min="25" max="200" value="100" /></label>
+                  <label>倾斜幅度 <output id="ocean-tilt-value">100%</output><input id="ocean-tilt" type="range" min="50" max="160" value="100" /></label>
+                  <label>碰撞强度 <output id="ocean-impact-value">100%</output><input id="ocean-impact" type="range" min="0" max="200" value="100" /></label>
+                  <label>边缘高光 <output id="ocean-edge-value">75%</output><input id="ocean-edge" type="range" min="0" max="100" value="75" /></label>
+                  <div class="ocean-command-row">
+                    <button id="btn-ocean-start" class="primary-button" type="button">进入电子海洋</button>
+                    <button id="btn-ocean-stop" class="ghost-button" type="button">停止</button>
+                  </div>
+                </div>
+              </div>
+            </section>
             <div class="expression-tabs" role="tablist" aria-label="表情工作区">
               <button type="button" class="expression-tab is-active" data-expression-tab="eyes" role="tab">眼睛素材</button>
               <button type="button" class="expression-tab" data-expression-tab="led" role="tab">LED 效果</button>
@@ -1493,7 +1523,7 @@
     </div>
   </dialog>
 
-  <script src="/app.js?v=clock-prominent-20260721"></script>
+  <script src="/app.js?v=electronic-ocean-impact-20260721"></script>
   <script type="module" src="/pet.js?v=19"></script>
   <script src="/setup.js?v=secret-inputs-20260602"></script>
 </body>

--- a/lampgo/web/static/style.css
+++ b/lampgo/web/static/style.css
@@ -2614,6 +2614,36 @@ button.device-chip.is-active {
   line-height: 1.45;
 }
 
+.ocean-quick-panel {
+  margin: 0 0 14px;
+  padding: 14px 16px 16px;
+  border-top: 1px solid #87c5d2;
+  border-bottom: 1px solid #87c5d2;
+  border-left: 4px solid #087f9b;
+  background: #eef8fa;
+}
+
+.ocean-quick-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+
+.ocean-quick-title {
+  color: #09647a;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.ocean-quick-desc {
+  margin-top: 3px;
+  color: #596169;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .expression-capacity {
   min-height: 28px;
   margin-bottom: 12px;
@@ -3840,9 +3870,71 @@ button.device-chip.is-active {
 .clock-command-row { display: flex; gap: 8px; }
 .clock-status { color: var(--text-faint); font-size: 12px; }
 
+.ocean-workspace {
+  display: grid;
+  grid-template-columns: minmax(360px, 1.35fr) minmax(320px, 1fr);
+  gap: 18px;
+  align-items: center;
+}
+
+.ocean-preview {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 51 / 9;
+  border: 1px solid #25343a;
+  border-radius: 6px;
+  background: #0d1316;
+}
+
+.ocean-controls {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px 12px;
+}
+
+.ocean-controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 4px 8px;
+  color: var(--text-soft);
+  font-size: 12px;
+}
+
+.ocean-dynamics-presets {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid #87c5d2;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.ocean-dynamics-presets button {
+  min-height: 32px;
+  border: 0;
+  border-right: 1px solid #87c5d2;
+  background: #f7fbfc;
+  color: #41616a;
+  font-weight: 600;
+}
+
+.ocean-dynamics-presets button:last-child { border-right: 0; }
+.ocean-dynamics-presets button.is-active { background: #087f9b; color: #fff; }
+
+.ocean-controls input { grid-column: 1 / -1; width: 100%; min-width: 0; }
+.ocean-controls input[type="color"] { height: 30px; padding: 2px; }
+.ocean-controls output { color: #09647a; font-variant-numeric: tabular-nums; }
+.ocean-command-row { display: flex; align-items: end; gap: 8px; }
+.ocean-status { color: #596169; font-size: 12px; text-align: right; }
+
 @media (max-width: 860px) {
   .clock-workspace { grid-template-columns: 1fr; }
   .clock-quick-head { display: grid; gap: 6px; }
+  .ocean-workspace { grid-template-columns: 1fr; }
+  .ocean-quick-head { display: grid; gap: 6px; }
+  .ocean-status { text-align: left; }
 }
 
 .record-dialog-input:focus {

--- a/tests/test_electronic_ocean.py
+++ b/tests/test_electronic_ocean.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from starlette.testclient import TestClient
+
+from lampgo.core.config import DeviceConfig, LampgoConfig
+from lampgo.electronic_ocean import ElectronicOceanController
+from lampgo.server import LampgoServer
+from lampgo.web.gateway import WebGateway
+
+
+class _FakeEsp32:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.fail_next = False
+
+    def with_owner_auth(self, payload: dict | None = None, *, reason: str = "") -> dict:
+        return {**(payload or {}), "owner_id": "test-owner", "reason": reason}
+
+    async def proxy_post(self, path: str, payload: dict):
+        self.calls.append({"path": path, "payload": payload})
+        if self.fail_next:
+            self.fail_next = False
+            return 502, {"ok": False, "error": "offline"}, "application/json"
+        return 200, {"ok": True, "action": payload["action"]}, "application/json"
+
+
+async def test_ocean_calibrates_current_wrist_and_sends_small_telemetry(tmp_path: Path) -> None:
+    angle = 12.0
+    now = 100.0
+    esp32 = _FakeEsp32()
+    ocean = ElectronicOceanController(
+        esp32,
+        lambda: angle,
+        path=tmp_path / "ocean.json",
+        monotonic=lambda: now,
+        brightness_ceiling=lambda: 40,
+    )
+
+    started = await ocean.start(
+        color="#12abef",
+        brightness=80,
+        fill_percent=60,
+        sensitivity_percent=125,
+        edge_highlight_percent=90,
+    )
+    assert started["ok"] is True
+    assert started["baseline_deg"] == 12.0
+    assert esp32.calls[0]["path"] == "/device/ocean"
+    assert esp32.calls[0]["payload"] == {
+        "action": "start",
+        "color": "#12abef",
+        "brightness": 40,
+        "fill_percent": 60,
+        "sensitivity_percent": 125,
+        "edge_highlight_percent": 90,
+        "tilt_percent": 100,
+        "impact_percent": 100,
+        "damping_percent": 130,
+        "owner_id": "test-owner",
+        "reason": "electronic_ocean_start",
+    }
+
+    angle = 17.0
+    now = 100.1
+    refreshed = await ocean.refresh()
+    payload = esp32.calls[-1]["payload"]
+    assert refreshed["ok"] is True
+    assert payload["action"] == "input"
+    assert payload["angle_deg"] == 5.0
+    assert payload["angular_velocity_dps"] == 17.5
+    assert payload["sequence"] == 1
+
+
+async def test_ocean_violent_preset_applies_complete_dynamics_profile(tmp_path: Path) -> None:
+    esp32 = _FakeEsp32()
+    ocean = ElectronicOceanController(
+        esp32,
+        lambda: 0.0,
+        path=tmp_path / "ocean.json",
+    )
+
+    started = await ocean.start(dynamics="violent")
+
+    assert started["ok"] is True
+    assert started["dynamics"] == "violent"
+    assert esp32.calls[0]["payload"] == {
+        "action": "start",
+        "color": "#00b8e0",
+        "brightness": 36,
+        "fill_percent": 55,
+        "sensitivity_percent": 125,
+        "edge_highlight_percent": 95,
+        "tilt_percent": 135,
+        "impact_percent": 165,
+        "damping_percent": 100,
+        "owner_id": "test-owner",
+        "reason": "electronic_ocean_start",
+    }
+
+
+async def test_ocean_coalesces_state_and_recovers_device_session(tmp_path: Path) -> None:
+    angle = 0.0
+    now = 10.0
+    esp32 = _FakeEsp32()
+    ocean = ElectronicOceanController(
+        esp32,
+        lambda: angle,
+        path=tmp_path / "ocean.json",
+        monotonic=lambda: now,
+    )
+    await ocean.start()
+
+    esp32.fail_next = True
+    angle = 2.0
+    now += 0.1
+    failed = await ocean.refresh()
+    assert failed["ok"] is False
+    assert failed["last_error"] == "offline"
+
+    now += 0.1
+    resumed = await ocean.refresh()
+    assert resumed["ok"] is True
+    assert [call["payload"]["action"] for call in esp32.calls[-2:]] == ["start", "input"]
+
+    stopped = await ocean.stop()
+    assert stopped["enabled"] is False
+    assert esp32.calls[-1]["payload"]["action"] == "stop"
+
+    restored = ElectronicOceanController(esp32, lambda: 0.0, path=tmp_path / "ocean.json")
+    assert restored.snapshot()["enabled"] is False
+    assert restored.snapshot()["color"] == "#00b8e0"
+
+
+class _RouteOcean:
+    def __init__(self) -> None:
+        self.state = {"enabled": False, "color": "#00b8e0"}
+
+    def snapshot(self) -> dict:
+        return dict(self.state)
+
+    async def refresh(self) -> dict:
+        return {"ok": True, "sent": False, **self.state}
+
+    async def start(self, **values) -> dict:
+        self.state = {**self.state, **values, "enabled": True}
+        return {"ok": True, **self.state}
+
+    async def stop(self) -> dict:
+        self.state["enabled"] = False
+        return {"ok": True, **self.state}
+
+    def deactivate(self) -> None:
+        self.state["enabled"] = False
+
+
+def test_ocean_http_routes_and_llm_skills_are_exposed(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path / "lampgo-home"))
+    server = LampgoServer(LampgoConfig(device=DeviceConfig(motor_port="/dev/null")))
+    ocean = _RouteOcean()
+    server.electronic_ocean = ocean
+    gateway = WebGateway(server)
+
+    with TestClient(gateway.app) as client:
+        server._register_builtin_skills()
+        started = client.post(
+            "/api/electronic-ocean/start",
+            json={"color": "#22ccff", "fill_percent": 62},
+        )
+        state = client.get("/api/electronic-ocean")
+        stopped = client.post("/api/electronic-ocean/stop")
+
+    assert started.status_code == 200
+    assert started.json()["result"]["enabled"] is True
+    assert state.json()["result"]["fill_percent"] == 62
+    assert stopped.json()["result"]["enabled"] is False
+    assert server.registry.get("start_electronic_ocean") is not None
+    assert server.registry.get("stop_electronic_ocean") is not None


### PR DESCRIPTION
## Summary
- add backend API, Web controls, and LLM skills for the S3-local electronic ocean mode
- sample wrist pitch at 10 Hz while S3 renders local fluid at 20 FPS
- add soft, standard, and violent dynamics presets with tilt and impact controls

## Validation
- uv run pytest -q (332 passed)
- targeted Ruff passed; repository-wide Ruff has pre-existing findings outside this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增“电子海洋”灯效，支持柔和、标准、剧烈等动态预设。
  * 可调节颜色、亮度、液位、灵敏度、倾角、冲击和边缘高光等参数。
  * Web 界面提供实时预览、启动/停止控制及运行状态展示。
  * 新增电子海洋状态查询与启停接口，并支持与其他灯效模式自动切换。

* **测试**
  * 新增覆盖控制器、设备恢复、接口及技能调用的测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->