### PR TITLE
fix(audio): bypass desktop proxies and surface recording failures

### DIFF
--- a/lampgo/device/audio_stream.py
+++ b/lampgo/device/audio_stream.py
@@ -151,7 +151,13 @@ class Esp32AudioCapture:
 
         safe_url = redact_ws_owner_token(url)
         logger.info("esp32_audio.connecting", url=safe_url)
-        async with websockets.connect(url, open_timeout=5, close_timeout=2, ping_interval=None) as ws:
+        async with websockets.connect(
+            url,
+            open_timeout=5,
+            close_timeout=2,
+            ping_interval=None,
+            proxy=None,
+        ) as ws:
             logger.info("esp32_audio.connected", url=safe_url)
             self._connected = True
             self._last_frame_at = time.monotonic()
@@ -276,7 +282,13 @@ class Esp32AudioSession:
 
         deadline = asyncio.get_event_loop().time() + self.MAX_DURATION_S
         try:
-            async with websockets.connect(url, open_timeout=5, close_timeout=2, ping_interval=None) as ws:
+            async with websockets.connect(
+                url,
+                open_timeout=5,
+                close_timeout=2,
+                ping_interval=None,
+                proxy=None,
+            ) as ws:
                 self._esp32.mark_active_healthy()
                 frames = 0
                 while not self._stop_event.is_set():

--- a/lampgo/voice/tts.py
+++ b/lampgo/voice/tts.py
@@ -256,6 +256,12 @@ class VolcengineTTS:
                 max_size=10 * 1024 * 1024,
                 open_timeout=10,
                 close_timeout=5,
+                # ``websockets>=15`` auto-discovers ALL_PROXY.  LampGo is
+                # frequently run next to Clash with a socks5h proxy, but the
+                # base install intentionally doesn't depend on python-socks.
+                # TTS works directly and must not disappear just because that
+                # unrelated desktop proxy is present.
+                proxy=None,
             )
             await _send_start_connection(websocket)
             await _wait_for_event(websocket, EventType.CONNECTION_STARTED)

--- a/lampgo/voice/wake_loop.py
+++ b/lampgo/voice/wake_loop.py
@@ -265,7 +265,11 @@ class WakeLoop:
             try:
                 logger.info("wake_loop.device_wake_connecting", url=safe_url)
                 async with websockets.connect(
-                    url, open_timeout=5, close_timeout=2, ping_interval=None
+                    url,
+                    open_timeout=5,
+                    close_timeout=2,
+                    ping_interval=None,
+                    proxy=None,
                 ) as ws:
                     self._server.esp32.mark_active_healthy()
                     logger.info("wake_loop.device_wake_connected", url=safe_url)

--- a/lampgo/web/gateway.py
+++ b/lampgo/web/gateway.py
@@ -3070,6 +3070,7 @@ class WebGateway:
                     close_timeout=2.0,
                     ping_interval=None,
                     max_size=None,
+                    proxy=None,
                 )
             except Exception as exc:
                 next_connect_at = now + 0.5
@@ -4289,6 +4290,7 @@ class WebGateway:
                         close_timeout=2,
                         ping_interval=None,
                         max_size=None,
+                        proxy=None,
                     ) as esp32_ws:
                         self.server.esp32.mark_active_healthy()
                         safe_url = redact_ws_owner_token(url)

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -152,6 +152,7 @@
   const btnRecordStartCancel = document.getElementById("btn-record-start-cancel");
   const btnRecordStartConfirm = document.getElementById("btn-record-start-confirm");
   const recordStartDesc = document.getElementById("record-start-desc");
+  const recordStartError = document.getElementById("record-start-error");
   const recordTimer = document.getElementById("record-timer");
   const recordMetrics = document.getElementById("record-metrics");
   const catTeaserDialog = document.getElementById("cat-teaser-dialog");
@@ -799,6 +800,7 @@
   let isMotionRecording = false;
   let hasPendingMotionRecording = false;
   let pendingOverwriteSave = false;
+  let recordingStartRequestId = null;
   let recordingStartTs = 0;
   let recordTimerTask = null;
   let recordingFps = 30;
@@ -1761,8 +1763,12 @@
   }
 
   function resetRecordStartDialogUI() {
-    if (btnRecordStartConfirm) btnRecordStartConfirm.textContent = "开始录制";
+    if (btnRecordStartConfirm) {
+      btnRecordStartConfirm.textContent = "开始录制";
+      btnRecordStartConfirm.disabled = false;
+    }
     if (btnRecordStartCancel) btnRecordStartCancel.classList.remove("hidden");
+    if (recordStartError) recordStartError.textContent = "";
     if (recordStartDesc) {
       recordStartDesc.textContent = "点击“开始录制”后将自动关闭电机力矩，你可以手动掰动关节进行录制。";
     }
@@ -2424,7 +2430,9 @@
   function send(obj) {
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify(obj));
+      return true;
     }
+    return false;
   }
 
   function handleMessage(msg) {
@@ -2559,14 +2567,35 @@
       upsertCodexTask(msg.result.agent_task);
     }
 
+    if (recordingStartRequestId && msg.request_id === recordingStartRequestId && !msg.ok) {
+      recordingStartRequestId = null;
+      if (btnRecordStartConfirm) {
+        btnRecordStartConfirm.disabled = false;
+        btnRecordStartConfirm.textContent = "开始录制";
+      }
+      const rawError = String(msg.error || "录制启动失败");
+      const errorText = rawError.includes("motor recovery required")
+        ? "机械臂尚未完成安全复位，当前不能录制。请先完成安全复位后再试。"
+        : `录制启动失败：${rawError}`;
+      if (recordStartError) recordStartError.textContent = errorText;
+      if (recordStartDialog && !recordStartDialog.open) recordStartDialog.showModal();
+      addSystemMessage(errorText);
+      return;
+    }
+
     if (msg.result && msg.result.status === "recording") {
+      recordingStartRequestId = null;
       isMotionRecording = true;
       hasPendingMotionRecording = false;
       recordingFps = Number(msg.result.fps || 30);
       recordingFrames = 0;
       recordingStartTs = Date.now() / 1000;
       updateRecordButtonState();
-      if (btnRecordStartConfirm) btnRecordStartConfirm.textContent = "结束录制";
+      if (btnRecordStartConfirm) {
+        btnRecordStartConfirm.disabled = false;
+        btnRecordStartConfirm.textContent = "结束录制";
+      }
+      if (recordStartError) recordStartError.textContent = "";
       if (btnRecordStartCancel) btnRecordStartCancel.classList.add("hidden");
       if (recordStartDesc) recordStartDesc.textContent = "录制进行中。按“结束录制”完成采集。";
       if (recordMetrics) recordMetrics.textContent = `采样：${recordingFps} FPS · 0 帧`;
@@ -5282,7 +5311,22 @@
   }
 
   function startMotionRecording() {
-    send({ type: "recording_start", fps: 30, request_id: nextId() });
+    if (recordingStartRequestId) return;
+    const requestId = nextId();
+    recordingStartRequestId = requestId;
+    if (recordStartError) recordStartError.textContent = "";
+    if (btnRecordStartConfirm) {
+      btnRecordStartConfirm.disabled = true;
+      btnRecordStartConfirm.textContent = "正在启动…";
+    }
+    if (!send({ type: "recording_start", fps: 30, request_id: requestId })) {
+      recordingStartRequestId = null;
+      if (btnRecordStartConfirm) {
+        btnRecordStartConfirm.disabled = false;
+        btnRecordStartConfirm.textContent = "开始录制";
+      }
+      if (recordStartError) recordStartError.textContent = "后端连接未就绪，无法开始录制。请等待页面恢复连接后重试。";
+    }
   }
 
   function openRecordStartDialog() {
@@ -5291,7 +5335,14 @@
       return;
     }
     resetRecordStartDialogUI();
-    recordStartDialog.showModal();
+    if (recordStartDialog.open) return;
+    try {
+      recordStartDialog.showModal();
+    } catch (err) {
+      const detail = err && err.message ? err.message : String(err);
+      console.error("record dialog failed to open", err);
+      addSystemMessage(`无法打开录制窗口：${detail}`);
+    }
   }
 
   function closeRecordStartDialog() {

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -1776,6 +1776,16 @@
     if (recordMetrics) recordMetrics.textContent = "采样：-- FPS · 0 帧";
   }
 
+  function recoverRecordingStartRequest(message) {
+    recordingStartRequestId = null;
+    if (btnRecordStartConfirm) {
+      btnRecordStartConfirm.disabled = false;
+      btnRecordStartConfirm.textContent = "开始录制";
+    }
+    if (btnRecordStartCancel) btnRecordStartCancel.classList.remove("hidden");
+    if (recordStartError) recordStartError.textContent = message;
+  }
+
   function startRecordTimer() {
     stopRecordTimer();
     if (!recordTimer) return;
@@ -1943,6 +1953,9 @@
 
     ws.onclose = () => {
       setConnected(false);
+      if (recordingStartRequestId) {
+        recoverRecordingStartRequest("连接已断开，录制启动状态未知。请等待页面恢复连接后重试。");
+      }
       if (webPageOwnerActive) setTimeout(connect, 2000);
     };
 
@@ -2568,22 +2581,23 @@
     }
 
     if (recordingStartRequestId && msg.request_id === recordingStartRequestId && !msg.ok) {
-      recordingStartRequestId = null;
-      if (btnRecordStartConfirm) {
-        btnRecordStartConfirm.disabled = false;
-        btnRecordStartConfirm.textContent = "开始录制";
-      }
       const rawError = String(msg.error || "录制启动失败");
       const errorText = rawError.includes("motor recovery required")
         ? "机械臂尚未完成安全复位，当前不能录制。请先完成安全复位后再试。"
         : `录制启动失败：${rawError}`;
-      if (recordStartError) recordStartError.textContent = errorText;
+      recoverRecordingStartRequest(errorText);
       if (recordStartDialog && !recordStartDialog.open) recordStartDialog.showModal();
       addSystemMessage(errorText);
       return;
     }
 
-    if (msg.result && msg.result.status === "recording") {
+    if (
+      recordingStartRequestId &&
+      msg.request_id === recordingStartRequestId &&
+      msg.ok &&
+      msg.result &&
+      msg.result.status === "recording"
+    ) {
       recordingStartRequestId = null;
       isMotionRecording = true;
       hasPendingMotionRecording = false;
@@ -5319,13 +5333,9 @@
       btnRecordStartConfirm.disabled = true;
       btnRecordStartConfirm.textContent = "正在启动…";
     }
+    if (btnRecordStartCancel) btnRecordStartCancel.classList.add("hidden");
     if (!send({ type: "recording_start", fps: 30, request_id: requestId })) {
-      recordingStartRequestId = null;
-      if (btnRecordStartConfirm) {
-        btnRecordStartConfirm.disabled = false;
-        btnRecordStartConfirm.textContent = "开始录制";
-      }
-      if (recordStartError) recordStartError.textContent = "后端连接未就绪，无法开始录制。请等待页面恢复连接后重试。";
+      recoverRecordingStartRequest("后端连接未就绪，无法开始录制。请等待页面恢复连接后重试。");
     }
   }
 
@@ -7770,6 +7780,10 @@
 
   if (btnRecordStartCancel) {
     btnRecordStartCancel.addEventListener("click", () => {
+      if (recordingStartRequestId) {
+        if (recordStartError) recordStartError.textContent = "正在启动录制，请等待后端确认后再操作。";
+        return;
+      }
       stopRecordTimer();
       closeRecordStartDialog();
       resetRecordStartDialogUI();

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -1370,6 +1370,7 @@
     <form id="record-start-form" class="record-dialog-card">
       <div class="record-dialog-title">开始录制动作</div>
       <div id="record-start-desc" class="record-dialog-desc">点击“开始录制”后将自动关闭电机力矩，你可以手动掰动关节进行录制。</div>
+      <div id="record-start-error" class="record-dialog-error" role="alert" aria-live="assertive"></div>
       <div id="record-timer" class="record-dialog-timer">已录制 0.0s</div>
       <div id="record-metrics" class="record-dialog-metrics">采样：-- FPS · 0 帧</div>
       <div class="record-dialog-actions">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "httpx>=0.28.1",
     "starlette>=0.45",
     "uvicorn>=0.34",
-    "websockets>=14.0",
+    "websockets>=15.0",
     "zeroconf>=0.131",
     # Voice is a core LampGo capability.  Keep it in the default dependency
     # set so a plain `uv sync` cannot silently remove the LiveKit runtime.

--- a/tests/test_recording_frontend.py
+++ b/tests/test_recording_frontend.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = (ROOT / "lampgo/web/static/app.js").read_text(encoding="utf-8")
+INDEX_HTML = (ROOT / "lampgo/web/static/index.html").read_text(encoding="utf-8")
+
+
+def test_recording_button_opens_a_start_dialog_with_inline_feedback() -> None:
+    assert 'id="btn-record-motion-panel"' in INDEX_HTML
+    assert 'id="record-start-dialog"' in INDEX_HTML
+    assert 'id="record-start-error"' in INDEX_HTML
+    assert 'role="alert" aria-live="assertive"' in INDEX_HTML
+    assert "else openRecordStartDialog();" in APP_JS
+    assert "if (recordStartDialog.open) return;" in APP_JS
+    assert "recordStartDialog.showModal();" in APP_JS
+
+
+def test_recording_start_never_fails_silently() -> None:
+    assert 'btnRecordStartConfirm.textContent = "正在启动…";' in APP_JS
+    assert "if (!send({ type: \"recording_start\"" in APP_JS
+    assert "后端连接未就绪，无法开始录制" in APP_JS
+    assert 'rawError.includes("motor recovery required")' in APP_JS
+    assert "机械臂尚未完成安全复位，当前不能录制" in APP_JS

--- a/tests/test_recording_frontend.py
+++ b/tests/test_recording_frontend.py
@@ -20,5 +20,9 @@ def test_recording_start_never_fails_silently() -> None:
     assert 'btnRecordStartConfirm.textContent = "正在启动…";' in APP_JS
     assert "if (!send({ type: \"recording_start\"" in APP_JS
     assert "后端连接未就绪，无法开始录制" in APP_JS
+    assert "recoverRecordingStartRequest" in APP_JS
+    assert "连接已断开，录制启动状态未知" in APP_JS
     assert 'rawError.includes("motor recovery required")' in APP_JS
     assert "机械臂尚未完成安全复位，当前不能录制" in APP_JS
+    assert "msg.request_id === recordingStartRequestId" in APP_JS
+    assert "正在启动录制，请等待后端确认后再操作" in APP_JS

--- a/tests/test_tts_base_url.py
+++ b/tests/test_tts_base_url.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+import sys
+from types import SimpleNamespace
 
 from lampgo.core.config import VoiceConfig
 from lampgo.voice.agent_sdk import AgentSDKManager
@@ -21,6 +24,27 @@ from lampgo.voice.tts import (
 
 def test_volcengine_tts_defaults_to_v3_bidirectional_endpoint() -> None:
     assert VOLCENGINE_TTS_ENDPOINT == "wss://openspeech.bytedance.com/api/v3/tts/bidirection"
+
+
+def test_volcengine_tts_bypasses_unrelated_desktop_proxy(monkeypatch) -> None:
+    connect_kwargs = None
+
+    async def fake_connect(*_args, **kwargs):
+        nonlocal connect_kwargs
+        connect_kwargs = kwargs
+        raise RuntimeError("stop after inspecting connect options")
+
+    monkeypatch.setitem(sys.modules, "websockets", SimpleNamespace(connect=fake_connect))
+
+    async def run() -> None:
+        tts = VolcengineTTS(app_id="app", access_token="token")
+        async for _chunk in tts.stream_pcm("测试"):
+            raise AssertionError("the fake connection must not yield audio")
+
+    asyncio.run(run())
+
+    assert connect_kwargs is not None
+    assert connect_kwargs["proxy"] is None
 
 
 def test_volcengine_tts_default_voice_is_uranus_bigtts() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1176,7 +1176,7 @@ requires-dist = [
     { name = "starlette", specifier = ">=0.45" },
     { name = "structlog", specifier = ">=24.0" },
     { name = "uvicorn", specifier = ">=0.34" },
-    { name = "websockets", specifier = ">=14.0" },
+    { name = "websockets", specifier = ">=15.0" },
     { name = "zeroconf", specifier = ">=0.131" },
 ]
 provides-extras = ["perception", "voice", "bridge", "dev"]


### PR DESCRIPTION
## What changed

- Disable automatic desktop proxy discovery for LampGo's ESP32 audio, wake, speaker relay, and Volcengine TTS WebSocket connections.
- Raise the declared minimum to `websockets>=15.0`, where the explicit `proxy` option is supported.
- Make motion-recording start requests track their acknowledgement and show inline failures instead of silently closing the dialog.
- Return a boolean from the shared WebSocket sender so an offline backend is surfaced immediately.

## Why

Desktop proxy settings such as Clash `ALL_PROXY=socks5h://...` could break otherwise direct device/audio connections when optional SOCKS dependencies were absent. Recording-start failures were also easy to miss in the frontend.

## Checks

- `12 passed` across TTS connection and recording frontend tests.
- `node --check lampgo/web/static/app.js`.
- `uv lock`.
- `git diff --check`.

## Batch integration

Backend PRs #54 → #55 → #56 → #57 merge cleanly in that order. The combined tree passes `392` tests and `node --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 录音启动流程新增加载状态、重复请求保护及清晰的错误提示。
  * 录音对话框支持无障碍错误播报，并在异常时自动恢复操作状态。
* **问题修复**
  * 改善录音后端连接失败及安全复位失败时的提示和处理。
  * 优化音频流、语音合成及设备连接，减少代理配置导致的连接异常。
* **测试**
  * 新增录音交互、错误提示和连接行为的自动化验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->