### PR TITLE
feat(web): harden LED brightness controls

### DIFF
--- a/lampgo/core/led.py
+++ b/lampgo/core/led.py
@@ -11,6 +11,7 @@ fall back to the paired lampgo-cam ESP32 firmware's /device/led Wi-Fi endpoint.
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from typing import Any
 
 import structlog
@@ -128,15 +129,43 @@ def led_expression_catalog() -> list[dict[str, Any]]:
 class LEDController:
     """Manages LED expressions through serial or the ESP32 Wi-Fi endpoint."""
 
-    def __init__(self, config: LEDConfig, esp32_manager: Any | None = None) -> None:
+    def __init__(
+        self,
+        config: LEDConfig,
+        esp32_manager: Any | None = None,
+        *,
+        brightness_ceiling: Callable[[], int] | None = None,
+    ) -> None:
         self._config = config
         self._esp32_manager = esp32_manager
+        self._brightness_ceiling = brightness_ceiling or (lambda: 96)
         self._serial = None
         self._connected = False
         self._remote_last_ok = False
 
     def bind_esp32_manager(self, esp32_manager: Any | None) -> None:
         self._esp32_manager = esp32_manager
+
+    def _brightness_ceiling_value(self) -> int:
+        try:
+            return max(1, min(255, int(self._brightness_ceiling())))
+        except (TypeError, ValueError):
+            return 96
+
+    def _clamp_brightness(self, brightness: Any) -> int:
+        return max(1, min(self._brightness_ceiling_value(), int(brightness)))
+
+    def _cap_payload_brightness(self, payload: dict[str, Any]) -> dict[str, Any]:
+        capped = dict(payload)
+        if "brightness" in capped:
+            capped["brightness"] = self._clamp_brightness(capped["brightness"])
+        if isinstance(capped.get("led_params"), dict):
+            led_params = dict(capped["led_params"])
+            led_params["brightness"] = self._clamp_brightness(
+                led_params.get("brightness", self._brightness_ceiling_value())
+            )
+            capped["led_params"] = led_params
+        return capped
 
     def connect(self) -> None:
         if not self._config.port:
@@ -202,7 +231,7 @@ class LEDController:
 
     def set_brightness(self, brightness: int) -> bool:
         """Set LED brightness (1-255)."""
-        brightness = max(1, min(255, brightness))
+        brightness = self._clamp_brightness(brightness)
         if self._serial is None:
             return self._send_remote({"brightness": brightness})
         return self._send(f"b{brightness}\n")
@@ -222,11 +251,17 @@ class LEDController:
             logger.warning("led.expression_resolve_failed", expression_id=expression_id, error=str(exc))
             return False, None
 
+        composition = dict(composition)
+        led_params = dict(composition.get("led_params") or {})
+        led_params["brightness"] = self._clamp_brightness(
+            led_params.get("brightness", self._brightness_ceiling_value())
+        )
+        composition["led_params"] = led_params
         effect = composition.get("led_effect") or {}
         payload: dict[str, Any] = {
             "eye_clip_id": composition.get("eye_storage_clip_id"),
             "led_effect_id": composition.get("led_effect_id"),
-            "led_params": composition.get("led_params") or {},
+            "led_params": led_params,
             "playback": composition.get("playback") or "loop",
             "duration_ms": int(composition.get("duration_ms") or 3000),
         }
@@ -262,7 +297,7 @@ class LEDController:
                 "hour": max(0, min(23, int(hour))),
                 "minute": max(0, min(59, int(minute))),
                 "color": str(color),
-                "brightness": max(1, min(96, int(brightness))),
+                "brightness": self._clamp_brightness(brightness),
                 "effect": str(effect),
             },
             reason="clock",
@@ -298,6 +333,7 @@ class LEDController:
         return self._send_remote_path("/device/led", payload, reason="led")
 
     def _send_remote_path(self, path: str, payload: dict[str, Any], *, reason: str) -> bool:
+        payload = self._cap_payload_brightness(payload)
         manager = self._esp32_manager
         if manager is None:
             logger.debug("led.remote_send_skipped (no esp32 manager)", payload=payload)

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -110,7 +110,11 @@ class LampgoServer:
         # LED expressions now go through the paired ESP32 Wi-Fi endpoint. Keep
         # the old serial config fields readable for legacy files, but do not
         # open a local LED serial port from the web runtime.
-        self.led = LEDController(LEDConfig(port="", baud_rate=config.led.baud_rate), esp32_manager=self.esp32)
+        self.led = LEDController(
+            LEDConfig(port="", baud_rate=config.led.baud_rate),
+            esp32_manager=self.esp32,
+            brightness_ceiling=lambda: self.config.device_esp32.led_brightness,
+        )
         self.clock = ClockController(
             self.led,
             brightness_ceiling=lambda: self.config.device_esp32.led_brightness,

--- a/lampgo/skills/builtin/expression_skills.py
+++ b/lampgo/skills/builtin/expression_skills.py
@@ -22,7 +22,11 @@ class SetExpressionSkill(Skill):
             ),
         ),
         "brightness": ParameterSpec(
-            name="brightness", type="int", required=False, default=200, description="Brightness 1-255"
+            name="brightness",
+            type="int",
+            required=False,
+            default=64,
+            description="Brightness request from 1 to 96; the global LED ceiling still applies.",
         ),
         "playback": ParameterSpec(
             name="playback", type="str", required=False, default="once", description="once or loop"

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -58,6 +58,7 @@
   const composerColor = document.getElementById("composer-color");
   const composerColorOverride = document.getElementById("composer-color-override");
   const composerBrightness = document.getElementById("composer-brightness");
+  const composerBrightnessValue = document.getElementById("composer-brightness-value");
   const composerIntensity = document.getElementById("composer-intensity");
   const composerPresetId = document.getElementById("composer-preset-id");
   const composerPresetLabel = document.getElementById("composer-preset-label");
@@ -110,6 +111,8 @@
   const esp32LedBrightnessControl = document.getElementById("esp32-led-brightness-control");
   const esp32LedBrightnessSlider = document.getElementById("esp32-led-brightness-slider");
   const esp32LedBrightnessValue = document.getElementById("esp32-led-brightness-value");
+  const esp32LedBrightnessStatus = document.getElementById("esp32-led-brightness-status");
+  const esp32LedBrightnessQuickButtons = Array.from(document.querySelectorAll("[data-led-brightness-quick]"));
   const btnRefreshAgent = document.getElementById("btn-refresh-agent");
   const btnAgentHealth = document.getElementById("btn-agent-health-details");
   const agentHealthCard = document.getElementById("agent-health-card");
@@ -543,7 +546,11 @@
   let esp32VolumeInitialSyncDone = false;
   let esp32LedBrightnessTimer = null;
   let esp32LedBrightnessPending = false;
-  let esp32LedBrightnessInitialSyncDone = false;
+  let esp32LedBrightnessDesired = null;
+  let esp32LedBrightnessSyncing = false;
+  let esp32LedBrightnessConfigLoaded = false;
+  let esp32LedBrightnessUserEdited = false;
+  let esp32LedBrightnessDeviceOnline = false;
   let voiceCallMode = "stable";
   let voiceEchoGateHangoverMs = 1000;
   let voiceEchoTextFilterEnabled = true;
@@ -629,18 +636,39 @@
     const level = clampEsp32LedBrightness(value);
     if (esp32LedBrightnessSlider) esp32LedBrightnessSlider.value = String(level);
     if (esp32LedBrightnessValue) esp32LedBrightnessValue.textContent = String(level);
+    esp32LedBrightnessQuickButtons.forEach((button) => {
+      const active = Number(button.dataset.ledBrightnessQuick) === level;
+      button.classList.toggle("is-active", active);
+      button.setAttribute("aria-pressed", String(active));
+    });
     if (persist) {
       try { localStorage.setItem(ESP32_LED_BRIGHTNESS_KEY, String(level)); } catch (_) { /* ignore */ }
     }
     return level;
   }
 
+  function setEsp32LedBrightnessStatus(state, message) {
+    if (esp32LedBrightnessControl) {
+      esp32LedBrightnessControl.classList.toggle("is-syncing", state === "syncing");
+      esp32LedBrightnessControl.classList.toggle("is-error", state === "error");
+      esp32LedBrightnessControl.dataset.syncState = state;
+      if (message) esp32LedBrightnessControl.title = message;
+    }
+    if (esp32LedBrightnessStatus) {
+      esp32LedBrightnessStatus.textContent = state === "syncing"
+        ? "应用中"
+        : state === "error"
+          ? "待应用"
+          : state === "success"
+            ? "已应用"
+            : "";
+      esp32LedBrightnessStatus.title = message || "";
+    }
+  }
+
   async function syncEsp32LedBrightness(value) {
     const level = clampEsp32LedBrightness(value);
-    if (esp32LedBrightnessControl) {
-      esp32LedBrightnessControl.classList.add("is-syncing");
-      esp32LedBrightnessControl.classList.remove("is-error");
-    }
+    setEsp32LedBrightnessStatus("syncing", `正在应用灯板亮度 ${level}`);
     try {
       const resp = await fetch("/api/config/device_esp32", {
         method: "POST",
@@ -652,26 +680,63 @@
         throw new Error(body.error || `HTTP ${resp.status}`);
       }
       if (body.result && body.result.led_brightness_sync && !body.result.led_brightness_sync.ok) {
-        throw new Error("设备暂时离线，亮度已保存，恢复连接后会自动应用");
+        throw new Error("亮度已保存，但设备暂时离线；设备上线后会再次应用");
       }
+      esp32LedBrightnessDeviceOnline = true;
+      setEsp32LedBrightnessStatus("success", `灯板亮度 ${level} 已应用`);
       return true;
     } catch (err) {
       console.warn("[esp32] LED brightness sync failed:", err);
-      if (esp32LedBrightnessControl) esp32LedBrightnessControl.classList.add("is-error");
+      setEsp32LedBrightnessStatus("error", err.message || "亮度已保存，但尚未应用到设备");
+      esp32LedBrightnessDeviceOnline = false;
       return false;
-    } finally {
-      if (esp32LedBrightnessControl) esp32LedBrightnessControl.classList.remove("is-syncing");
-      esp32LedBrightnessPending = false;
     }
   }
 
-  function scheduleEsp32LedBrightnessSync(value) {
+  async function flushEsp32LedBrightnessSync() {
+    if (esp32LedBrightnessSyncing) return;
+    esp32LedBrightnessSyncing = true;
+    try {
+      while (esp32LedBrightnessDesired != null) {
+        const level = esp32LedBrightnessDesired;
+        esp32LedBrightnessDesired = null;
+        await syncEsp32LedBrightness(level);
+      }
+    } finally {
+      esp32LedBrightnessSyncing = false;
+      esp32LedBrightnessPending = esp32LedBrightnessDesired != null;
+    }
+  }
+
+  function scheduleEsp32LedBrightnessSync(value, { userEdited = true, immediate = false } = {}) {
     const level = setEsp32LedBrightnessUi(value, { persist: true });
+    if (userEdited) esp32LedBrightnessUserEdited = true;
+    esp32LedBrightnessDesired = level;
     esp32LedBrightnessPending = true;
     if (esp32LedBrightnessTimer) clearTimeout(esp32LedBrightnessTimer);
     esp32LedBrightnessTimer = setTimeout(() => {
-      syncEsp32LedBrightness(level);
-    }, 150);
+      esp32LedBrightnessTimer = null;
+      void flushEsp32LedBrightnessSync();
+    }, immediate ? 0 : 150);
+  }
+
+  async function loadEsp32LedBrightnessFromServer() {
+    if (esp32LedBrightnessConfigLoaded) return true;
+    try {
+      const resp = await fetch("/api/config");
+      const body = await resp.json().catch(() => ({}));
+      if (!resp.ok || body.ok === false) throw new Error(body.error || `HTTP ${resp.status}`);
+      const sections = (body.result && body.result.sections) || {};
+      const cell = sections.device_esp32 && sections.device_esp32["device_esp32.led_brightness"];
+      if (cell && cell.value != null && !esp32LedBrightnessUserEdited && !esp32LedBrightnessPending) {
+        setEsp32LedBrightnessUi(cell.value, { persist: true });
+      }
+      esp32LedBrightnessConfigLoaded = true;
+      return true;
+    } catch (err) {
+      console.warn("[esp32] LED brightness config load failed:", err);
+      return false;
+    }
   }
 
   function initEsp32LedBrightnessControl() {
@@ -685,14 +750,34 @@
     esp32LedBrightnessSlider.addEventListener("input", () => {
       scheduleEsp32LedBrightnessSync(esp32LedBrightnessSlider.value);
     });
+    esp32LedBrightnessQuickButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        scheduleEsp32LedBrightnessSync(button.dataset.ledBrightnessQuick);
+      });
+    });
+    void loadEsp32LedBrightnessFromServer();
   }
 
   function maybeSyncInitialEsp32LedBrightness() {
-    if (esp32LedBrightnessInitialSyncDone || !esp32LedBrightnessSlider) return;
+    if (!esp32LedBrightnessSlider) return;
     const esp = cameraCache && cameraCache.esp32 ? cameraCache.esp32 : null;
-    if (!esp || esp.enabled === false || esp.online === false) return;
-    syncEsp32LedBrightness(esp32LedBrightnessSlider.value).then((ok) => {
-      esp32LedBrightnessInitialSyncDone = ok;
+    const online = Boolean(esp && esp.enabled !== false && esp.online !== false);
+    if (!online) {
+      esp32LedBrightnessDeviceOnline = false;
+      return;
+    }
+    if (esp32LedBrightnessDeviceOnline) return;
+    esp32LedBrightnessDeviceOnline = true;
+    loadEsp32LedBrightnessFromServer().then((loaded) => {
+      if (!loaded) {
+        esp32LedBrightnessDeviceOnline = false;
+        return;
+      }
+      if (esp32LedBrightnessPending) return;
+      scheduleEsp32LedBrightnessSync(esp32LedBrightnessSlider.value, {
+        userEdited: false,
+        immediate: true,
+      });
     });
   }
 
@@ -4250,9 +4335,16 @@
     const params = preset.led_params || {};
     if (composerColorOverride) composerColorOverride.checked = Boolean(params.color);
     if (params.color && composerColor) composerColor.value = params.color;
-    if (params.brightness && composerBrightness) composerBrightness.value = String(params.brightness);
+    setComposerBrightnessUi(params.brightness == null ? 64 : params.brightness);
     if (params.intensity && composerIntensity) composerIntensity.value = String(Math.round(params.intensity * 100));
     if (params.direction) setExpressionDirection(params.direction);
+  }
+
+  function setComposerBrightnessUi(value) {
+    const level = clampEsp32LedBrightness(value);
+    if (composerBrightness) composerBrightness.value = String(level);
+    if (composerBrightnessValue) composerBrightnessValue.textContent = String(level);
+    return level;
   }
 
   function setExpressionDirection(direction) {
@@ -4365,6 +4457,9 @@
     if (!expressionLedPreview) return;
     const color = (composerColor && composerColor.value) || "#ffffff";
     const intensity = Number((composerIntensity && composerIntensity.value) || 100) / 100;
+    const requestedBrightness = clampEsp32LedBrightness((composerBrightness && composerBrightness.value) || 64);
+    const brightnessCeiling = clampEsp32LedBrightness((esp32LedBrightnessSlider && esp32LedBrightnessSlider.value) || 32);
+    const brightness = Math.min(requestedBrightness, brightnessCeiling) / 96;
     const pixelClipReady = effect && effect.kind === "pixel_clip" && ledEffectSourceCache.has(effect.effect_id);
     Array.from(expressionLedPreview.children).forEach((cell, index) => {
       const row = Math.floor(index / 51);
@@ -4696,6 +4791,12 @@
       });
     });
   });
+  setComposerBrightnessUi((composerBrightness && composerBrightness.value) || 64);
+  if (composerBrightness) {
+    composerBrightness.addEventListener("input", () => {
+      setComposerBrightnessUi(composerBrightness.value);
+    });
+  }
   if (btnExpressionPreview) btnExpressionPreview.addEventListener("click", () => { void previewExpression(); });
   if (btnExpressionSync) btnExpressionSync.addEventListener("click", () => { void syncExpressionResources(); });
   if (btnExpressionSetDefault) {

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -131,11 +131,18 @@
             <input id="esp32-volume-slider" class="volume-slider" type="range" min="0" max="100" value="70" step="1" />
             <span id="esp32-volume-value" class="volume-value">70%</span>
           </label>
-          <label id="esp32-led-brightness-control" class="volume-control" title="调节 S3 LED 灯板亮度（安全上限 96）">
-            <span class="volume-label">灯板</span>
-            <input id="esp32-led-brightness-slider" class="volume-slider" type="range" min="1" max="96" value="32" step="1" />
-            <span id="esp32-led-brightness-value" class="volume-value">32</span>
-          </label>
+          <div id="esp32-led-brightness-control" class="volume-control led-brightness-control" role="group" aria-label="S3 LED 灯板亮度" title="立即调节当前及后续 S3 LED 效果的亮度上限">
+            <label class="volume-label" for="esp32-led-brightness-slider">灯板亮度</label>
+            <input id="esp32-led-brightness-slider" class="volume-slider" type="range" min="1" max="96" value="32" step="1" aria-label="灯板亮度精确值" />
+            <output id="esp32-led-brightness-value" class="volume-value" for="esp32-led-brightness-slider" aria-live="polite">32</output>
+            <div class="led-brightness-quick" role="group" aria-label="快速亮度档位">
+              <button type="button" data-led-brightness-quick="8" aria-pressed="false" title="低亮：8">8</button>
+              <button type="button" data-led-brightness-quick="16" aria-pressed="false" title="柔和：16">16</button>
+              <button type="button" data-led-brightness-quick="24" aria-pressed="false" title="日常：24">24</button>
+              <button type="button" data-led-brightness-quick="32" aria-pressed="true" title="明亮：32">32</button>
+            </div>
+            <span id="esp32-led-brightness-status" class="led-brightness-status" aria-live="polite"></span>
+          </div>
         </div>
 
         <div class="topbar-right">
@@ -487,7 +494,8 @@
                   <label>眼睛<select id="composer-eye"><option value="">无眼睛</option></select></label>
                   <label>LED<select id="composer-led"><option value="">无 LED</option></select></label>
                   <label class="expression-color-control"><input id="composer-color-override" type="checkbox" />覆盖主色<input id="composer-color" type="color" value="#ffffff" /></label>
-                  <label>亮度<input id="composer-brightness" type="range" min="1" max="96" value="64" /></label>
+                  <label>表情亮度<span class="expression-range-control"><input id="composer-brightness" type="range" min="1" max="96" value="64" aria-label="当前组合表情亮度" /><output id="composer-brightness-value" for="composer-brightness">64</output></span></label>
+                  <small class="expression-brightness-hint">实际亮度不会超过顶部“灯板亮度”上限。</small>
                   <label>强度<input id="composer-intensity" type="range" min="10" max="100" value="100" /></label>
                   <div class="expression-direction" role="group" aria-label="方向">
                     <button type="button" data-direction="left" title="向左">←</button>

--- a/lampgo/web/static/style.css
+++ b/lampgo/web/static/style.css
@@ -1095,6 +1095,54 @@ button.device-chip.is-active {
   accent-color: var(--accent, #be7c72);
 }
 
+.led-brightness-control {
+  height: auto;
+  min-height: 28px;
+  padding-right: 7px;
+}
+
+.led-brightness-quick {
+  display: inline-flex;
+  gap: 2px;
+  margin-left: 1px;
+}
+
+.led-brightness-quick button {
+  min-width: 25px;
+  height: 20px;
+  padding: 0 4px;
+  border: 1px solid #d7dde1;
+  border-radius: 999px;
+  background: #f7f8f9;
+  color: var(--text-soft);
+  font: inherit;
+  font-size: 10px;
+  line-height: 18px;
+}
+
+.led-brightness-quick button:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.led-brightness-quick button.is-active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.led-brightness-status {
+  min-width: 0;
+  color: var(--success);
+  font-size: 10px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.led-brightness-control.is-syncing .led-brightness-status { color: #b77a24; }
+.led-brightness-control.is-error .led-brightness-status { color: var(--danger); }
+
 .joint-popover {
   position: fixed;
   z-index: 1000;
@@ -2954,6 +3002,28 @@ button.device-chip.is-active {
   font-size: 12px;
 }
 
+.expression-range-control {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 28px;
+  align-items: center;
+  gap: 8px;
+}
+
+.expression-range-control input { width: 100%; min-width: 0; }
+
+.expression-range-control output {
+  color: #227c75;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.expression-brightness-hint {
+  margin-top: -5px;
+  padding-left: 62px;
+  color: #7b858d;
+  font-size: 10.5px;
+}
+
 .expression-direction,
 .expression-playback {
   display: grid;
@@ -4083,6 +4153,15 @@ button.device-chip.is-active {
 
   .music-mode-label {
     display: none;
+  }
+
+  .led-brightness-control {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .led-brightness-control .volume-slider {
+    flex: 1 1 90px;
   }
 
   .view {

--- a/tests/test_led_brightness.py
+++ b/tests/test_led_brightness.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from lampgo.core.config import LEDConfig
+from lampgo.core.led import LEDController
+from lampgo.skills.builtin.expression_skills import SetExpressionSkill
+
+
+def _controller_with_capture(ceiling: dict[str, int]):
+    sent: list[tuple[str, dict, str]] = []
+    controller = LEDController(
+        LEDConfig(port=""),
+        brightness_ceiling=lambda: ceiling["value"],
+    )
+
+    def capture(path: str, payload: dict, *, reason: str) -> bool:
+        sent.append((path, payload, reason))
+        return True
+
+    controller._send_remote_path = capture  # type: ignore[method-assign]
+    return controller, sent
+
+
+def test_led_controller_caps_direct_and_dynamic_expression_brightness(monkeypatch):
+    ceiling = {"value": 16}
+    controller, sent = _controller_with_capture(ceiling)
+
+    assert controller.set_brightness(96) is True
+    assert sent[-1][1]["brightness"] == 16
+    assert controller.set_brightness(8) is True
+    assert sent[-1][1]["brightness"] == 8
+
+    def fake_resolve(_request: dict):
+        return {
+            "eye_storage_clip_id": "cat-eyes",
+            "led_effect_id": "blue-pixel-cat",
+            "led_params": {"brightness": 64},
+            "playback": "once",
+            "duration_ms": 3000,
+            "led_effect": {"kind": "pixel_clip"},
+        }
+
+    monkeypatch.setattr("lampgo.expression_library.resolve_expression", fake_resolve)
+
+    ok, composition = controller.play_expression("pixel-cat")
+    assert ok is True
+    assert composition is not None
+    assert composition["led_params"]["brightness"] == 16
+    assert sent[-1][0] == "/device/expressions/play"
+    assert sent[-1][1]["led_params"]["brightness"] == 16
+
+    ceiling["value"] = 8
+    ok, composition = controller.play_expression("pixel-cat")
+    assert ok is True
+    assert composition is not None
+    assert composition["led_params"]["brightness"] == 8
+    assert sent[-1][1]["led_params"]["brightness"] == 8
+
+
+@pytest.mark.asyncio
+async def test_set_expression_builtin_route_uses_runtime_brightness_ceiling():
+    ceiling = {"value": 16}
+    controller, sent = _controller_with_capture(ceiling)
+    context = SimpleNamespace(led=controller)
+
+    result = await SetExpressionSkill().execute(
+        context,
+        expression="smiley",
+        brightness=96,
+    )
+
+    assert result.status == "ok"
+    assert sent[0][0] == "/device/led"
+    assert sent[0][1]["brightness"] == 16
+    assert sent[1][0] == "/device/led"
+    assert sent[1][1]["mode"] == 21

--- a/tests/test_led_brightness_frontend.py
+++ b/tests/test_led_brightness_frontend.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+def test_frontend_exposes_quick_led_brightness_levels_and_status():
+    html = Path("lampgo/web/static/index.html").read_text(encoding="utf-8")
+
+    assert 'id="esp32-led-brightness-slider"' in html
+    assert 'id="esp32-led-brightness-value"' in html
+    assert 'id="esp32-led-brightness-status"' in html
+    for level in (8, 16, 24, 32):
+        assert f'data-led-brightness-quick="{level}"' in html
+
+
+def test_frontend_brightness_uses_server_config_and_serial_latest_value_sync():
+    source = Path("lampgo/web/static/app.js").read_text(encoding="utf-8")
+
+    assert 'const resp = await fetch("/api/config");' in source
+    assert 'sections.device_esp32["device_esp32.led_brightness"]' in source
+    assert 'body: JSON.stringify({ "device_esp32.led_brightness": level })' in source
+    assert "esp32LedBrightnessDesired = level;" in source
+    assert "while (esp32LedBrightnessDesired != null)" in source
+    assert 'setEsp32LedBrightnessStatus("error"' in source

--- a/tests/test_web_config.py
+++ b/tests/test_web_config.py
@@ -1,6 +1,7 @@
 """End-to-end smoke tests for the generic web config endpoints (PR-C)."""
 from __future__ import annotations
 
+import pytest
 from starlette.testclient import TestClient
 
 from lampgo import personastore
@@ -161,6 +162,8 @@ def test_led_brightness_is_persisted_and_caps_direct_led_commands(monkeypatch, t
     with TestClient(gateway.app) as client:
         saved = client.post("/api/config/device_esp32", json={"led_brightness": 24})
         direct = client.post("/api/device/led", json={"expression": "heart", "brightness": 96})
+        direct_low = client.post("/api/device/led", json={"expression": "heart", "brightness": 8})
+        loaded = client.get("/api/config")
 
     assert saved.status_code == 200
     assert saved.json()["result"]["led_brightness_sync"] == {"ok": True, "level": 24}
@@ -171,6 +174,41 @@ def test_led_brightness_is_persisted_and_caps_direct_led_commands(monkeypatch, t
     assert sent[0][1]["brightness"] == 24
     assert sent[1][0] == "/device/led"
     assert sent[1][1]["brightness"] == 24
+    assert direct_low.status_code == 200
+    assert sent[2][0] == "/device/led"
+    assert sent[2][1]["brightness"] == 8
+    assert loaded.status_code == 200
+    assert (
+        loaded.json()["result"]["sections"]["device_esp32"]["device_esp32.led_brightness"]["value"]
+        == 24
+    )
+
+
+@pytest.mark.parametrize("value", [0, 97, "bright"])
+def test_led_brightness_rejects_invalid_values(monkeypatch, tmp_path, value):
+    gateway = _make_gateway(monkeypatch, tmp_path)
+
+    with TestClient(gateway.app) as client:
+        response = client.post("/api/config/device_esp32", json={"led_brightness": value})
+
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+
+
+def test_led_brightness_is_saved_when_device_sync_is_unavailable(monkeypatch, tmp_path):
+    gateway = _make_gateway(monkeypatch, tmp_path)
+
+    async def fake_proxy_post(_path: str, _payload: dict):
+        return 503, {"ok": False, "error": "offline"}, "application/json"
+
+    monkeypatch.setattr(gateway.server.esp32, "proxy_post", fake_proxy_post)
+
+    with TestClient(gateway.app) as client:
+        response = client.post("/api/config/device_esp32", json={"led_brightness": 16})
+
+    assert response.status_code == 200
+    assert response.json()["result"]["led_brightness_sync"] == {"ok": False, "level": 16}
+    assert gateway.server.config.device_esp32.led_brightness == 16
 
 
 def test_api_config_post_rejects_unknown_fields(monkeypatch, tmp_path):


### PR DESCRIPTION
## What changed

- Enforce the configured LED brightness ceiling across direct LED commands, saved compositions, presets, and skill invocations.
- Load the persisted server value before applying device state and serialize rapid slider updates with latest-value-wins behavior.
- Add quick 8/16/24/32 brightness levels, visible sync status, and an accurate composer/preview brightness indicator.
- Preserve lower per-expression brightness requests instead of forcing every command to the ceiling.

## Why

The previous control could race local storage against server configuration and some expression paths could bypass the global safety ceiling. The UI also provided little feedback when the S3 was offline.

## Checks

- `16 passed` across LED brightness and web config tests.
- `node --check lampgo/web/static/app.js`.
- `git diff --check`.

## Batch integration

Backend PRs #54 → #55 → #56 → #57 merge cleanly in that order. The combined tree passes `392` tests and `node --check`.
