### PR TITLE
feat(expressions): polish long-form eye and LED assets

### DIFF
--- a/docs/guides/expression-authoring.md
+++ b/docs/guides/expression-authoring.md
@@ -7,8 +7,8 @@ LampGo expressions are reusable compositions, not a single animation file:
   uploaded to the S3 for a mouth, symbol, direction, or accent.
 - `ExpressionPreset` references one optional eye and one optional LED effect.
 
-At least one channel must be present. The two channels start at `t=0` and use
-the same 0-1 phase over a default three-second duration. Expressions loop by
+At least one channel must be present. The two channels start at `t=0`; the eye
+clip duration is authoritative when it is selected. Expressions loop by
 default and keep looping for the full action; callers must explicitly request
 `once` when they want a one-shot micro-expression.
 
@@ -23,11 +23,14 @@ default and keep looping for the full action; callers must explicitly request
    10fps, up to 16 RGB colors including the off color, and no executable code.
 4. For energetic expressions, keep the 30fps render cadence while holding
    readable key poses. A useful default is 60 eye frames over 2.0 seconds.
-   Slower expressions remain supported. The accepted range is 8-30fps and
-   1.0-3.5 seconds.
+   Slower source clips remain supported. The accepted range is 8-30fps and
+   1.0-6.0 seconds, subject to the 256KiB C6 package cap.
 5. A transient composition may be previewed or played without being saved.
    An LLM must receive explicit user confirmation before saving a preset.
-6. Do not emit arbitrary code, jumps, unbounded loops, or device allocations.
+6. A 6-second eye clip can outlast the current 3-second custom LED pixel clip.
+   Do not present that pairing as frame-synchronous: use an eye-only scene, a
+   looping LED accent, or author a matching LED format before claiming sync.
+7. Do not emit arbitrary code, jumps, unbounded loops, or device allocations.
    Repeated frames use `ticks`; their sum must be exactly 30. Firmware v1
    templates remain available only for official and backward-compatible assets.
 
@@ -38,6 +41,7 @@ default and keep looping for the full action; callers must explicitly request
   "effect_id": "rainbow_smile",
   "label": "Rainbow smile",
   "role": "mouth",
+  "default_playback": "once",
   "program": {
     "version": 2,
     "type": "pixel_clip",
@@ -66,6 +70,8 @@ Palette symbols are `.123456789ABCDEF`; `.` is always off. The backend maps
 the logical grid to physical wiring, deduplicates frames, compiles LEF1, and
 rejects packages over 8KiB. `primary`, `secondary`, and `accent` palette roles
 may be recolored by a preset without copying the animation.
+`default_playback` may be `once` or `loop`; omit it to retain the legacy
+`loop` default.
 
 ## Capacity Contract
 
@@ -98,6 +104,10 @@ The same catalog is atomically written to
 `~/.lampgo/expression_library/llm-catalog.json` for local agents that cannot
 call the HTTP API. It is a generated read-only projection, not a second source
 of truth.
+
+Keep eye `clip_id` values to 13 characters or fewer. The S3 stages each eye
+package in SPIFFS as `/ec_<clip_id>_manifest.json`; longer ids exceed the
+device's 31-character filename limit and cannot be synchronized.
 
 Play a saved preset:
 

--- a/docs/schemas/expression-preset.schema.json
+++ b/docs/schemas/expression-preset.schema.json
@@ -24,7 +24,7 @@
     "led_effect_id": {"type": ["string", "null"]},
     "led_params": {"type": "object"},
     "playback": {"enum": ["once", "loop"], "default": "loop"},
-    "duration_ms": {"type": "integer", "minimum": 2500, "maximum": 3500},
+    "duration_ms": {"type": "integer", "minimum": 1000, "maximum": 6000},
     "confirmed": {"const": true}
   }
 }

--- a/docs/schemas/eye-clip.schema.json
+++ b/docs/schemas/eye-clip.schema.json
@@ -5,10 +5,10 @@
   "type": "object",
   "required": ["eye_clip_id", "fps", "duration_ms", "frame_count", "lcd"],
   "properties": {
-    "eye_clip_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]{0,31}$"},
+    "eye_clip_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9_-]{0,12}$"},
     "default_led_effect_id": {"type": ["string", "null"]},
-    "fps": {"type": "integer", "minimum": 8, "maximum": 12},
-    "duration_ms": {"type": "integer", "minimum": 2500, "maximum": 3500},
+    "fps": {"type": "integer", "minimum": 8, "maximum": 30},
+    "duration_ms": {"type": "integer", "minimum": 1000, "maximum": 6000},
     "frame_count": {"type": "integer", "minimum": 1},
     "lcd": {
       "type": "object",

--- a/lampgo/expression_clips.py
+++ b/lampgo/expression_clips.py
@@ -19,19 +19,22 @@ from lampgo import personastore
 
 TARGET_DURATION_S = 1.0
 MIN_DURATION_S = 1.0
-MAX_DURATION_S = 3.5
+# Keep a finite composition window while allowing a complete short source
+# sequence without silently truncating it to the legacy 3.5-second limit.
+MAX_DURATION_S = 6.0
 MIN_FPS = 8
 MAX_FPS = 30
 DEFAULT_FPS = 30
 MAX_CLIPS = 10
 MAX_LCD_BYTES = 256 * 1024
+MAX_DEVICE_CLIP_ID_LENGTH = 13
 
 LCD_WIDTH = 320
 LCD_HEIGHT = 172
 
 LCD_MAGIC = b"LGLCD1"
 
-_SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,32}$")
+_SAFE_ID_RE = re.compile(rf"^[a-zA-Z0-9_-]{{1,{MAX_DEVICE_CLIP_ID_LENGTH}}}$")
 
 
 class ExpressionClipError(ValueError):
@@ -105,7 +108,10 @@ def sanitize_clip_id(value: str) -> str:
     if not clip_id:
         raise ExpressionClipError("clip_id is required")
     if not _SAFE_ID_RE.match(clip_id):
-        raise ExpressionClipError("clip_id must be 1-32 chars: letters, numbers, dash, underscore")
+        raise ExpressionClipError(
+            f"clip_id must be 1-{MAX_DEVICE_CLIP_ID_LENGTH} chars: "
+            "letters, numbers, dash, underscore (S3 SPIFFS filename limit)"
+        )
     return clip_id
 
 
@@ -270,6 +276,13 @@ def create_expression_clip(
             "converted LCD clip exceeds device cache budget "
             f"(lcd={len(lcd_payload)} bytes)"
         )
+    normalized_default_led_effect_id = (default_led_effect_id or "").strip().lower() or None
+    existing_manifest: dict[str, Any] | None = None
+    if _manifest_path(clip_id).is_file():
+        try:
+            existing_manifest = load_expression_clip(clip_id)
+        except Exception:
+            existing_manifest = None
 
     clip_dir = _clip_dir(clip_id)
     clip_dir.mkdir(parents=True, exist_ok=True)
@@ -291,14 +304,19 @@ def create_expression_clip(
         source_content_type=content_type,
         lcd_bytes=len(lcd_payload),
         lcd_sha256=_sha256(lcd_payload),
-        led_effect=expression,
-        default_led_effect_id=(default_led_effect_id or "").strip().lower() or None,
+        led_effect=normalized_default_led_effect_id or expression,
+        default_led_effect_id=normalized_default_led_effect_id,
         source_stored_filename=source_stored_filename,
         grid_rows=grid_rows,
         grid_cols=grid_cols,
         path=clip_dir,
     )
     manifest = package.to_manifest()
+    if (
+        existing_manifest
+        and str((existing_manifest.get("lcd") or {}).get("sha256") or "") == package.lcd_sha256
+    ):
+        manifest["sync"] = dict(existing_manifest.get("sync") or manifest["sync"])
     (clip_dir / "manifest.json").write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return manifest
 

--- a/lampgo/expression_library.py
+++ b/lampgo/expression_library.py
@@ -17,7 +17,12 @@ from typing import Any
 
 from lampgo import personastore
 from lampgo.core.led import led_expression_catalog
-from lampgo.expression_clips import list_expression_clips, load_expression_clip
+from lampgo.expression_clips import (
+    MAX_DEVICE_CLIP_ID_LENGTH,
+    MAX_DURATION_S,
+    list_expression_clips,
+    load_expression_clip,
+)
 from lampgo.led_effects import (
     LED_EFFECT_BUDGET_BYTES,
     MAX_CUSTOM_LED_EFFECTS,
@@ -36,6 +41,7 @@ C6_STAGING_BYTES = 256 * 1024
 MAX_PRESETS = 64
 MAX_PRESET_BYTES = 1024
 PRESET_BUDGET_BYTES = 64 * 1024
+MAX_EXPRESSION_DURATION_MS = int(MAX_DURATION_S * 1000)
 
 ALLOWED_ROLES = {"mouth", "symbol", "direction", "accent"}
 ALLOWED_TEMPLATES = {"mouth", "arrow", "heart", "pulse", "codex"}
@@ -43,6 +49,7 @@ ALLOWED_PLAYBACK = {"once", "loop"}
 ALLOWED_DIRECTIONS = {"left", "right", "up", "down"}
 ALLOWED_MOUTH_VARIANTS = {"smile", "open", "flat", "dizzy"}
 _SAFE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+_EYE_CLIP_ID_RE = re.compile(rf"^[a-z0-9][a-z0-9_-]{{0,{MAX_DEVICE_CLIP_ID_LENGTH - 1}}}$")
 _HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
 
 
@@ -525,8 +532,8 @@ def save_expression_preset(raw: dict[str, Any]) -> dict[str, Any]:
     if playback not in ALLOWED_PLAYBACK:
         raise ExpressionLibraryError("playback must be once or loop")
     duration_ms = int(raw.get("duration_ms") or (eye or {}).get("duration_ms") or 3000)
-    if not 1000 <= duration_ms <= 3500:
-        raise ExpressionLibraryError("duration_ms must be 1000-3500")
+    if not 1000 <= duration_ms <= MAX_EXPRESSION_DURATION_MS:
+        raise ExpressionLibraryError(f"duration_ms must be 1000-{MAX_EXPRESSION_DURATION_MS}")
     label = str(raw.get("name") or raw.get("label") or preset_id).strip()[:64] or preset_id
     item = {
         "preset_id": preset_id,
@@ -602,14 +609,19 @@ def resolve_expression(raw: dict[str, Any]) -> dict[str, Any]:
 
     merged_params = dict((preset or {}).get("led_params") or {})
     merged_params.update(raw.get("led_params") or {})
-    playback = str(raw.get("playback") or (preset or {}).get("playback") or "loop").strip().lower()
+    playback = str(
+        raw.get("playback")
+        or (preset or {}).get("playback")
+        or (effect or {}).get("default_playback")
+        or "loop"
+    ).strip().lower()
     if playback not in ALLOWED_PLAYBACK:
         raise ExpressionLibraryError("playback must be once or loop")
     duration_ms = int(
         raw.get("duration_ms") or (preset or {}).get("duration_ms") or (eye or {}).get("duration_ms") or 3000
     )
-    if not 1000 <= duration_ms <= 3500:
-        raise ExpressionLibraryError("duration_ms must be 1000-3500")
+    if not 1000 <= duration_ms <= MAX_EXPRESSION_DURATION_MS:
+        raise ExpressionLibraryError(f"duration_ms must be 1000-{MAX_EXPRESSION_DURATION_MS}")
     return {
         "preset_id": (preset or {}).get("preset_id"),
         "eye_clip_id": eye_id,
@@ -709,10 +721,10 @@ def expression_schemas() -> dict[str, Any]:
             "type": "object",
             "required": ["eye_clip_id", "fps", "duration_ms", "frame_count", "lcd"],
             "properties": {
-                "eye_clip_id": {"type": "string", "pattern": _SAFE_ID_RE.pattern},
+                "eye_clip_id": {"type": "string", "pattern": _EYE_CLIP_ID_RE.pattern},
                 "default_led_effect_id": {"type": ["string", "null"]},
                 "fps": {"type": "integer", "minimum": 8, "maximum": 30},
-                "duration_ms": {"type": "integer", "minimum": 1000, "maximum": 3500},
+                "duration_ms": {"type": "integer", "minimum": 1000, "maximum": MAX_EXPRESSION_DURATION_MS},
             },
         },
         "led_effect": {
@@ -721,6 +733,7 @@ def expression_schemas() -> dict[str, Any]:
             "properties": {
                 "effect_id": {"type": "string", "pattern": _SAFE_ID_RE.pattern},
                 "role": {"enum": sorted(ALLOWED_ROLES)},
+                "default_playback": {"enum": sorted(ALLOWED_PLAYBACK)},
                 "program": {
                     "type": "object",
                     "oneOf": [
@@ -751,7 +764,7 @@ def expression_schemas() -> dict[str, Any]:
                 "eye_clip_id": {"type": ["string", "null"]},
                 "led_effect_id": {"type": ["string", "null"]},
                 "playback": {"enum": sorted(ALLOWED_PLAYBACK), "default": "loop"},
-                "duration_ms": {"type": "integer", "minimum": 1000, "maximum": 3500},
+                "duration_ms": {"type": "integer", "minimum": 1000, "maximum": MAX_EXPRESSION_DURATION_MS},
             },
         },
     }

--- a/lampgo/led_effects.py
+++ b/lampgo/led_effects.py
@@ -326,6 +326,9 @@ def save_pixel_led_effect(
 ) -> dict[str, Any]:
     effect_id = _safe_effect_id(effect_id)
     normalized_program, package = compile_led_program(raw.get("program"))
+    default_playback = str(raw.get("default_playback") or "loop").strip().lower()
+    if default_playback not in {"once", "loop"}:
+        raise LedEffectError("default_playback must be once or loop")
     existing = list_pixel_led_effects()
     current = next((item for item in existing if item.get("effect_id") == effect_id), None)
     if current is None and len(existing) + external_count >= MAX_CUSTOM_LED_EFFECTS:
@@ -342,6 +345,7 @@ def save_pixel_led_effect(
         "effect_id": effect_id,
         "label": label,
         "role": role,
+        "default_playback": default_playback,
         "program": normalized_program,
     }
     manifest = {
@@ -351,7 +355,7 @@ def save_pixel_led_effect(
         "source": "custom",
         "kind": "pixel_clip",
         "animated": True,
-        "default_playback": "loop",
+        "default_playback": default_playback,
         "duration_ms": 3000,
         "program": {
             "version": 2,

--- a/lampgo/web/gateway.py
+++ b/lampgo/web/gateway.py
@@ -2895,10 +2895,21 @@ class WebGateway:
         if status >= 400 or (isinstance(last_body, dict) and last_body.get("ok") is False) or not c6_confirmed:
             device = self.server.esp32.get_status().get("device")
             update_expression_clip_sync(clip_id, status="sync_failed", device=device)
+            device_error = (
+                str(last_body.get("error") or "").strip()
+                if isinstance(last_body, dict)
+                else ""
+            )
+            if status >= 400 or (isinstance(last_body, dict) and last_body.get("ok") is False):
+                error = "device sync failed"
+                if device_error:
+                    error = f"{error}: {device_error}"
+            else:
+                error = "C6 did not confirm clip sync"
             return JSONResponse(
                 {
                     "ok": False,
-                    "error": "device sync failed" if status >= 400 else "C6 did not confirm clip sync",
+                    "error": error,
                     "result": {
                         "transfer_mode": "bulk",
                         "sent_chunks": 1,

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -41,6 +41,7 @@
   const ledEffectId = document.getElementById("led-effect-id");
   const ledEffectLabel = document.getElementById("led-effect-label");
   const ledEffectRole = document.getElementById("led-effect-role");
+  const ledEffectDefaultPlayback = document.getElementById("led-effect-default-playback");
   const ledEditorCanvas = document.getElementById("led-editor-canvas");
   const ledFrameTimeline = document.getElementById("led-frame-timeline");
   const ledEditorPalette = document.getElementById("led-editor-palette");
@@ -385,6 +386,16 @@
       names.push(name);
     });
     return names;
+  }
+
+  function ledEffectExpressionEntries(effects) {
+    if (!Array.isArray(effects)) return [];
+    return effects.map((effect) => ({
+      name: effect.effect_id,
+      label: effect.label,
+      mode: effect.mode,
+      animated: effect.animated,
+    }));
   }
 
   function populateExpressionSelect(selectEl, preferred) {
@@ -2544,9 +2555,22 @@
       return;
     }
 
-    if (msg.ok && msg.result && (msg.result.expression_catalog || msg.result.expressions)) {
+    if (
+      msg.ok &&
+      msg.result &&
+      (
+        Array.isArray(msg.result.led_effects) ||
+        msg.result.expression_catalog ||
+        msg.result.expressions
+      )
+    ) {
+      const hasFullLedEffectCatalog = Array.isArray(msg.result.led_effects);
       hydrateExpressionStudio(msg.result);
-      renderExpressions(msg.result.expression_catalog || msg.result.expressions);
+      renderExpressions(
+        hasFullLedEffectCatalog
+          ? ledEffectExpressionEntries(msg.result.led_effects)
+          : (msg.result.expression_catalog || msg.result.expressions),
+      );
       return;
     }
 
@@ -3787,6 +3811,7 @@
       effect_id: String((ledEffectId && ledEffectId.value) || "").trim(),
       label: String((ledEffectLabel && ledEffectLabel.value) || "").trim(),
       role: (ledEffectRole && ledEffectRole.value) || "mouth",
+      default_playback: (ledEffectDefaultPlayback && ledEffectDefaultPlayback.value) || "loop",
       program: {
         version: 2,
         type: "pixel_clip",
@@ -3833,6 +3858,7 @@
     if (ledEffectId) ledEffectId.value = source.effect_id || "";
     if (ledEffectLabel) ledEffectLabel.value = source.label || "";
     if (ledEffectRole) ledEffectRole.value = source.role || "mouth";
+    if (ledEffectDefaultPlayback) ledEffectDefaultPlayback.value = source.default_playback === "once" ? "once" : "loop";
     LED_EDITOR_SYMBOLS.forEach((symbol, index) => {
       if (program.palette && program.palette[symbol]) ledEditorColors[index] = program.palette[symbol];
     });
@@ -4203,12 +4229,7 @@
       expressionLedEffects = effects.led_effects || [];
       expressionPresets = presets.presets || [];
       renderExpressionStudio();
-      renderExpressions(expressionLedEffects.map((effect) => ({
-        name: effect.effect_id,
-        label: effect.label,
-        mode: effect.mode,
-        animated: effect.animated,
-      })));
+      renderExpressions(ledEffectExpressionEntries(expressionLedEffects));
       renderRecordings();
       const library = capacity.library;
       const device = capacity.device;
@@ -4262,7 +4283,25 @@
     });
   }
 
+  function eyeDurationMs(eyeId) {
+    const eye = expressionEyes.find((item) => item.eye_clip_id === eyeId);
+    const durationMs = Number(eye && eye.duration_ms);
+    return Number.isFinite(durationMs) && durationMs >= 1000 && durationMs <= 6000 ? durationMs : 3000;
+  }
+
+  function ledPreviewDurationMs(effect, fallbackDurationMs) {
+    const program = (effect && effect.program) || {};
+    if (program.type !== "pixel_clip") return fallbackDurationMs;
+    const fps = Math.max(1, Number(program.fps || 10));
+    const ticks = (program.frames || []).reduce(
+      (total, frame) => total + Math.max(1, Number(frame && frame.ticks || 1)),
+      0,
+    );
+    return ticks ? Math.round(ticks * 1000 / fps) : fallbackDurationMs;
+  }
+
   function currentExpressionBody() {
+    const eyeClipId = (composerEye && composerEye.value) || null;
     const ledParams = {
       brightness: Number((composerBrightness && composerBrightness.value) || 64),
       intensity: Number((composerIntensity && composerIntensity.value) || 100) / 100,
@@ -4272,11 +4311,11 @@
       ledParams.color = (composerColor && composerColor.value) || "#ffffff";
     }
     return {
-      eye_clip_id: (composerEye && composerEye.value) || null,
+      eye_clip_id: eyeClipId,
       led_effect_id: (composerLed && composerLed.value) || null,
       led_params: ledParams,
       playback: expressionPlayback,
-      duration_ms: 3000,
+      duration_ms: eyeDurationMs(eyeClipId),
     };
   }
 
@@ -4440,13 +4479,19 @@
       await Promise.all([loadEyePreviewImage(eye), loadLedPreviewSource(effect)]);
       if (expressionPreviewTimer) cancelAnimationFrame(expressionPreviewTimer);
       const started = Date.now();
+      const durationMs = Math.max(1000, Number(composition.duration_ms || (eye && eye.duration_ms) || 3000));
+      const ledDurationMs = ledPreviewDurationMs(effect, durationMs);
+      const looping = composition.playback === "loop";
       const tick = () => {
         const elapsed = Date.now() - started;
-        const phase = (elapsed % 3000) / 3000;
-        renderEyePreview(eye, phase);
-        renderLedPreview(effect, phase);
-        if (expressionPreviewStatus) expressionPreviewStatus.textContent = `${Math.min(3, elapsed / 1000).toFixed(1)} / 3.0 秒`;
-        if (expressionPlayback === "loop" || elapsed < 3000) {
+        const eyeElapsed = looping ? elapsed % durationMs : Math.min(elapsed, durationMs - 1);
+        const ledElapsed = looping ? elapsed % ledDurationMs : Math.min(elapsed, ledDurationMs - 1);
+        renderEyePreview(eye, eyeElapsed / durationMs);
+        renderLedPreview(effect, ledElapsed / ledDurationMs);
+        if (expressionPreviewStatus) {
+          expressionPreviewStatus.textContent = `${(Math.min(durationMs, elapsed) / 1000).toFixed(1)} / ${(durationMs / 1000).toFixed(1)} 秒`;
+        }
+        if (looping || elapsed < durationMs) {
           expressionPreviewTimer = requestAnimationFrame(tick);
         } else if (expressionPreviewStatus) {
           expressionPreviewStatus.textContent = "预览完成";
@@ -4474,10 +4519,11 @@
   }
 
   async function playLedEffect(name) {
+    const effect = expressionLedEffects.find((item) => item.effect_id === name);
     await playExpression({
       eye_clip_id: null,
       led_effect_id: name,
-      playback: "loop",
+      playback: (effect && effect.default_playback) || "loop",
       duration_ms: 3000,
     });
   }
@@ -4616,11 +4662,37 @@
           const labelCn = expressionLabel(name);
           return (
             name.toLowerCase().includes(q) ||
-            labelCn.includes(q)
+            labelCn.toLowerCase().includes(q)
           );
         })
       : latestExpressions;
+
+    const groups = { added: [], factory: [] };
     filtered.forEach((name) => {
+      const effect = expressionLedEffects.find((item) => item.effect_id === name);
+      const group = effect && effect.source !== "builtin" ? "added" : "factory";
+      groups[group].push(name);
+    });
+    const visibleGroups = [
+      { id: "added", label: "后续新增", names: groups.added },
+      { id: "factory", label: "出厂默认", names: groups.factory },
+    ].filter((group) => group.names.length);
+
+    const appendGroupHeading = (group, separated) => {
+      const heading = document.createElement("div");
+      heading.className = `expression-effect-group-title${separated ? " expression-group-divider" : ""}`;
+      heading.dataset.effectGroup = group.id;
+      heading.setAttribute("role", "heading");
+      heading.setAttribute("aria-level", "3");
+      const title = document.createElement("span");
+      title.textContent = group.label;
+      const count = document.createElement("small");
+      count.textContent = `${group.names.length} 个`;
+      heading.append(title, count);
+      expressionGrid.appendChild(heading);
+    };
+
+    const appendExpressionCard = (name, groupId) => {
       const meta = expressionMeta(name);
       const effect = expressionLedEffects.find((item) => item.effect_id === name);
       const labelCn = expressionLabel(name);
@@ -4639,7 +4711,11 @@
         tooltip: `单独播放 LED 效果：${labelCn}（${name}），眼睛保持当前画面`,
         onClick: () => { void playLedEffect(name); },
       });
+      card.dataset.expressionId = name;
+      card.dataset.expressionSource = (effect && effect.source) || "builtin";
+      card.dataset.effectGroup = groupId;
       if (effect && effect.kind === "pixel_clip" && effect.source === "custom") {
+        card.classList.add("expression-effect-card--custom");
         const actions = document.createElement("div");
         actions.className = "expression-card-actions";
         [
@@ -4660,6 +4736,11 @@
         card.appendChild(actions);
       }
       expressionGrid.appendChild(card);
+    };
+
+    visibleGroups.forEach((group, index) => {
+      appendGroupHeading(group, index > 0);
+      group.names.forEach((name) => appendExpressionCard(name, group.id));
     });
     if (!filtered.length) renderEmptyCell(expressionGrid, q ? `无匹配「${q}」的灯光表情` : "暂无灯光表情");
     updateCount(expressionCountEl, filtered.length, latestExpressions.length);

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>YareLampGo 控制台</title>
   <link rel="icon" href="/%E5%8F%B0%E7%81%AF%E8%99%BE%E5%A4%B4%E5%83%8F.jpeg">
-  <link rel="stylesheet" href="/style.css?v=expression-library-polish-20260803">
+  <link rel="stylesheet" href="/style.css?v=feature-batch-20260803">
   <link rel="stylesheet" href="/setup.css?v=secret-inputs-20260602">
 </head>
 <body>
@@ -1527,7 +1527,7 @@
     </div>
   </dialog>
 
-  <script src="/app.js?v=expression-library-polish-20260803"></script>
+  <script src="/app.js?v=feature-batch-20260803"></script>
   <script type="module" src="/pet.js?v=19"></script>
   <script src="/setup.js?v=secret-inputs-20260602"></script>
 </body>

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>YareLampGo 控制台</title>
   <link rel="icon" href="/%E5%8F%B0%E7%81%AF%E8%99%BE%E5%A4%B4%E5%83%8F.jpeg">
-  <link rel="stylesheet" href="/style.css?v=clock-prominent-20260721">
+  <link rel="stylesheet" href="/style.css?v=expression-library-polish-20260803">
   <link rel="stylesheet" href="/setup.css?v=secret-inputs-20260602">
 </head>
 <body>
@@ -420,7 +420,7 @@
             <div class="expression-panel" data-expression-panel="eyes">
               <div class="expression-toolbar">
                 <input id="eye-upload-file" type="file" accept="image/png,image/gif,image/jpeg,video/mp4,application/zip" />
-                <input id="eye-upload-id" type="text" placeholder="素材 ID" maxlength="32" />
+                <input id="eye-upload-id" type="text" placeholder="素材 ID（13 字符以内）" maxlength="13" />
                 <label>行 <input id="eye-upload-rows" type="number" min="1" max="30" value="6" /></label>
                 <label>列 <input id="eye-upload-cols" type="number" min="1" max="30" value="5" /></label>
                 <label>FPS <input id="eye-upload-fps" type="number" min="8" max="30" value="30" /></label>
@@ -444,6 +444,10 @@
                     <option value="symbol">符号</option>
                     <option value="direction">方向</option>
                     <option value="accent">气氛</option>
+                  </select>
+                  <select id="led-effect-default-playback" aria-label="默认播放方式">
+                    <option value="once">单次</option>
+                    <option value="loop" selected>循环</option>
                   </select>
                   <span id="led-editor-status" class="led-editor-status">新动画</span>
                 </div>
@@ -1523,7 +1527,7 @@
     </div>
   </dialog>
 
-  <script src="/app.js?v=electronic-ocean-impact-20260721"></script>
+  <script src="/app.js?v=expression-library-polish-20260803"></script>
   <script type="module" src="/pet.js?v=19"></script>
   <script src="/setup.js?v=secret-inputs-20260602"></script>
 </body>

--- a/lampgo/web/static/style.css
+++ b/lampgo/web/static/style.css
@@ -2827,6 +2827,16 @@ button.device-chip.is-active {
   gap: 4px;
   margin-top: 8px;
 }
+.expression-effect-card--custom {
+  flex-wrap: wrap;
+}
+.expression-effect-card--custom .expression-card-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  flex: 1 0 100%;
+  width: 100%;
+  margin-top: 2px;
+}
 .expression-card-actions button {
   min-height: 26px;
   padding: 3px 7px;
@@ -2835,6 +2845,31 @@ button.device-chip.is-active {
   background: #fff;
   color: #59656d;
   font-size: 11px;
+}
+
+.expression-effect-group-title {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  min-width: 0;
+  color: #47535c;
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+}
+
+.expression-effect-group-title small {
+  color: #8a949b;
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.expression-effect-group-title.expression-group-divider {
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid #dce3e7;
 }
 
 .expression-toolbar input[type="text"],

--- a/tests/test_expression_clips.py
+++ b/tests/test_expression_clips.py
@@ -9,7 +9,11 @@ import pytest
 from starlette.testclient import TestClient
 
 from lampgo.core.config import DeviceConfig, LampgoConfig
-from lampgo.expression_clips import create_expression_clip, list_expression_clips
+from lampgo.expression_clips import (
+    create_expression_clip,
+    list_expression_clips,
+    update_expression_clip_sync,
+)
 from lampgo.server import LampgoServer
 from lampgo.web.gateway import WebGateway
 
@@ -74,6 +78,21 @@ def test_expression_clip_rejects_short_duration(monkeypatch, tmp_path):
         )
 
 
+def test_expression_clip_rejects_id_that_exceeds_s3_spiffs_filename_limit(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+
+    with pytest.raises(ValueError, match="1-13 chars"):
+        create_expression_clip(
+            clip_id="pixel-cat-eyes",
+            expression="pixel-cat",
+            source_bytes=_png_sprite_sheet(),
+            filename="pixel-cat.png",
+            fps=10,
+            grid_rows=3,
+            grid_cols=10,
+        )
+
+
 def test_create_expression_clip_supports_precise_two_second_30fps_performance(monkeypatch, tmp_path):
     monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
 
@@ -100,9 +119,66 @@ def test_create_expression_clip_supports_precise_two_second_30fps_performance(mo
 
     assert manifest["duration_ms"] == 2000
     assert manifest["frame_count"] == 60
+    assert manifest["led"]["effect"] == "ecstatic-mouth"
+    assert manifest["default_led_effect_id"] == "ecstatic-mouth"
     assert fps == 30
     assert set(durations) == {33, 34}
     assert sum(durations) == 2000
+
+
+def test_expression_clip_accepts_a_six_second_source_window(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+
+    manifest = create_expression_clip(
+        clip_id="long-eyes",
+        expression="long",
+        source_bytes=_png_sprite_sheet(),
+        filename="long.png",
+        content_type="image/png",
+        fps=10,
+        duration_s=6.0,
+        grid_rows=3,
+        grid_cols=10,
+    )
+
+    assert manifest["duration_ms"] == 6000
+
+
+def test_rebuilding_identical_eye_preserves_sync_state(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    source = _png_sprite_sheet()
+    create_expression_clip(
+        clip_id="stable-eyes",
+        expression="stable",
+        source_bytes=source,
+        filename="stable.png",
+        content_type="image/png",
+        fps=10,
+        grid_rows=3,
+        grid_cols=10,
+        default_led_effect_id="soft-mouth",
+    )
+    update_expression_clip_sync(
+        "stable-eyes",
+        status="synced",
+        device={"c6_confirmed": True},
+    )
+
+    rebuilt = create_expression_clip(
+        clip_id="stable-eyes",
+        expression="stable",
+        source_bytes=source,
+        filename="stable.png",
+        content_type="image/png",
+        fps=10,
+        grid_rows=3,
+        grid_cols=10,
+        default_led_effect_id="soft-mouth",
+    )
+
+    assert rebuilt["sync"]["status"] == "synced"
+    assert rebuilt["sync"]["last_synced_at"] is not None
+    assert rebuilt["sync"]["device"] == {"c6_confirmed": True}
 
 
 def test_expression_clip_api_upload_and_sync(monkeypatch, tmp_path):
@@ -179,3 +255,28 @@ def test_expression_clip_sync_rejects_missing_c6_confirmation(monkeypatch, tmp_p
 
     assert response.status_code == 502
     assert response.json()["error"] == "C6 did not confirm clip sync"
+
+
+def test_expression_clip_sync_surfaces_device_error(monkeypatch, tmp_path):
+    gateway = _make_gateway(monkeypatch, tmp_path)
+    create_expression_clip(
+        clip_id="focused",
+        expression="focused",
+        source_bytes=_png_sprite_sheet(),
+        filename="focused.png",
+        content_type="image/png",
+        fps=10,
+        grid_rows=3,
+        grid_cols=10,
+    )
+
+    async def fake_proxy_post_bytes(*_args, **_kwargs):
+        return 400, {"ok": False, "error": "manifest open failed"}, "application/json"
+
+    monkeypatch.setattr(gateway.server.esp32, "proxy_post_bytes", fake_proxy_post_bytes)
+
+    with TestClient(gateway.app) as client:
+        response = client.post("/api/device/expression-clips/sync", json={"clip_id": "focused"})
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "device sync failed: manifest open failed"

--- a/tests/test_expression_library.py
+++ b/tests/test_expression_library.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import numpy as np
@@ -20,6 +21,8 @@ from lampgo.expression_library import (
 from lampgo.led_effects import LEF_MAGIC
 from lampgo.server import LampgoServer
 from lampgo.web.gateway import WebGateway
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _sprite_sheet(*, rows: int = 3, cols: int = 10) -> bytes:
@@ -64,24 +67,25 @@ def _custom_effect(effect_id: str) -> dict:
     )
 
 
-def _pixel_effect(effect_id: str) -> dict:
+def _pixel_effect(effect_id: str, *, default_playback: str | None = None) -> dict:
     rows = ["." * 51 for _ in range(9)]
     rows[4] = "." * 10 + "1" * 31 + "." * 10
-    return save_led_effect(
-        {
-            "effect_id": effect_id,
-            "label": "彩色嘴巴",
-            "role": "mouth",
-            "program": {
-                "version": 2,
-                "type": "pixel_clip",
-                "fps": 10,
-                "palette": {".": "#000000", "1": "#ff0088"},
-                "roles": {"primary": "1"},
-                "frames": [{"rows": rows, "ticks": 30}],
-            },
+    authored = {
+        "effect_id": effect_id,
+        "label": "彩色嘴巴",
+        "role": "mouth",
+        "program": {
+            "version": 2,
+            "type": "pixel_clip",
+            "fps": 10,
+            "palette": {".": "#000000", "1": "#ff0088"},
+            "roles": {"primary": "1"},
+            "frames": [{"rows": rows, "ticks": 30}],
         }
-    )
+    }
+    if default_playback:
+        authored["default_playback"] = default_playback
+    return save_led_effect(authored)
 
 
 def _gateway(monkeypatch, tmp_path: Path) -> WebGateway:
@@ -99,6 +103,56 @@ def test_eye_default_led_and_explicit_none(monkeypatch, tmp_path):
     eye_only = resolve_expression({"eye_clip_id": "focused_eyes", "led_effect_id": None})
     assert eye_only["led_effect_id"] is None
     assert eye_only["eye_storage_clip_id"] == "focused_eyes"
+
+
+def test_expression_resolution_accepts_a_six_second_eye_only_scene(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    _create_eye("long_eyes")
+
+    resolved = resolve_expression({"eye_clip_id": "long_eyes", "duration_ms": 5667, "playback": "once"})
+
+    assert resolved["duration_ms"] == 5667
+    assert resolved["led_effect_id"] is None
+    with pytest.raises(ExpressionLibraryError, match="1000-6000"):
+        resolve_expression({"eye_clip_id": "long_eyes", "duration_ms": 6001})
+
+
+def test_documented_preset_duration_matches_runtime_contract() -> None:
+    schema = json.loads(
+        (ROOT / "docs/schemas/expression-preset.schema.json").read_text(encoding="utf-8")
+    )
+
+    assert schema["properties"]["duration_ms"] == {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 6000,
+    }
+
+
+def test_expression_play_forwards_a_six_second_eye_only_scene(monkeypatch, tmp_path):
+    gateway = _gateway(monkeypatch, tmp_path)
+    _create_eye("long_eyes")
+    sent: list[tuple[str, dict]] = []
+
+    async def fake_proxy_post(path: str, payload: dict):
+        sent.append((path, payload))
+        return 200, {"ok": True}, "application/json"
+
+    monkeypatch.setattr(gateway.server.esp32, "proxy_post", fake_proxy_post)
+    with TestClient(gateway.app) as client:
+        played = client.post(
+            "/api/expressions/play",
+            json={"eye_clip_id": "long_eyes", "led_effect_id": None, "playback": "once", "duration_ms": 5667},
+        )
+
+    assert played.status_code == 200
+    assert len(sent) == 1
+    path, payload = sent[0]
+    assert path == "/device/expressions/play"
+    assert payload["eye_clip_id"] == "long_eyes"
+    assert payload["led_effect_id"] is None
+    assert payload["playback"] == "once"
+    assert payload["duration_ms"] == 5667
 
 
 def test_many_to_many_presets_reuse_assets(monkeypatch, tmp_path):
@@ -314,6 +368,15 @@ def test_pixel_led_auto_syncs_then_plays_by_id_with_loop_default(monkeypatch, tm
         item["effect_id"] == "color_mouth"
         for item in catalog.json()["result"]["led_effects"]
     )
+
+
+def test_pixel_led_can_default_to_once(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    _pixel_effect("one_shot", default_playback="once")
+
+    resolved = resolve_expression({"led_effect_id": "one_shot"})
+
+    assert resolved["playback"] == "once"
 
 
 def test_preset_name_can_generate_stable_machine_id(monkeypatch, tmp_path):

--- a/tests/test_itachi_eye_clip.py
+++ b/tests/test_itachi_eye_clip.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import importlib.util
+import re
+import struct
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+from lampgo.expression_clips import LCD_HEIGHT, LCD_WIDTH, MAX_LCD_BYTES, load_expression_clip_lcd_payload
+from lampgo.expression_library import expression_schemas, list_eyes, resolve_expression
+
+ROOT = Path(__file__).resolve().parents[1]
+AUTHORING_SCRIPT = ROOT / "tools/author_itachi_eye_clip.py"
+APP_JS = ROOT / "lampgo/web/static/app.js"
+
+
+def _authoring_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("itachi_eye_clip", AUTHORING_SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _reference_sprite() -> bytes:
+    cv2 = pytest.importorskip("cv2")
+    sprite = np.zeros((17 * LCD_HEIGHT, 10 * LCD_WIDTH, 3), dtype=np.uint8)
+    for index in range(170):
+        row, col = divmod(index, 10)
+        x = col * LCD_WIDTH
+        y = row * LCD_HEIGHT
+        sprite[y + 70 : y + 103, x + 80 + index % 40 : x + 166 + index % 40] = (216, 0, 0)
+    ok, encoded = cv2.imencode(".png", cv2.cvtColor(sprite, cv2.COLOR_RGB2BGR))
+    assert ok
+    return bytes(encoded)
+
+
+def test_itachi_authoring_filter_keeps_the_capcut_master_with_c6_safe_transfer() -> None:
+    module = _authoring_module()
+    filter_graph = module.c6_video_filter()
+
+    assert "/Users/" not in AUTHORING_SCRIPT.read_text(encoding="utf-8")
+    assert module.FRAME_COUNT == 170
+    assert module.FPS == 30
+    assert module.DURATION_MS == 5667
+    assert (module.GRID_ROWS, module.GRID_COLS) == (17, 10)
+    assert module.C6_VERTICAL_FLIP is False
+    assert module.C6_CONTENT_FPS == 22
+    assert "vflip" not in filter_graph
+    assert "scale=320:172:flags=lanczos" in filter_graph
+    assert "crop=" not in filter_graph
+    assert "draw" not in filter_graph.lower()
+
+
+def test_itachi_palette_removes_dark_codec_noise_but_keeps_bright_ink() -> None:
+    module = _authoring_module()
+    source = np.array(
+        [
+            [[89, 0, 0], [90, 60, 60], [150, 150, 150]],
+            [[100, 85, 75], [110, 150, 150], [224, 0, 0]],
+        ],
+        dtype=np.uint8,
+    )
+
+    palette = module.c6_palette_transfer(source)
+
+    assert palette.tolist() == [
+        [[0, 0, 0], [224, 0, 0], [224, 224, 224]],
+        [[0, 0, 0], [224, 224, 224], [224, 0, 0]],
+    ]
+    assert {tuple(pixel) for pixel in palette.reshape(-1, 3)} <= {
+        (0, 0, 0),
+        (224, 0, 0),
+        (224, 224, 224),
+    }
+
+
+def test_itachi_temporal_hold_keeps_30fps_envelope_and_both_endpoints() -> None:
+    module = _authoring_module()
+    source_indices = [module.c6_source_frame_index(index) for index in range(module.FRAME_COUNT)]
+
+    assert source_indices[0] == 0
+    assert source_indices[-1] == module.FRAME_COUNT - 1
+    assert source_indices == sorted(source_indices)
+    assert len(set(source_indices)) == 125
+    with pytest.raises(ValueError):
+        module.c6_source_frame_index(module.FRAME_COUNT)
+
+
+def test_eye_schema_matches_the_c6_id_30fps_and_six_second_contract() -> None:
+    schema = expression_schemas()["eye_clip"]["properties"]
+
+    assert re.fullmatch(schema["eye_clip_id"]["pattern"], "itachi-eyes")
+    assert not re.fullmatch(schema["eye_clip_id"]["pattern"], "itachi-sharingan")
+    assert schema["fps"] == {"type": "integer", "minimum": 8, "maximum": 30}
+    assert schema["duration_ms"] == {"type": "integer", "minimum": 1000, "maximum": 6000}
+
+
+def test_expression_preview_uses_the_selected_eye_duration_instead_of_three_seconds() -> None:
+    source = APP_JS.read_text(encoding="utf-8")
+
+    assert "function eyeDurationMs(eyeId)" in source
+    assert "duration_ms: eyeDurationMs(eyeClipId)" in source
+    assert "looping ? elapsed % durationMs : Math.min(elapsed, durationMs - 1)" in source
+    assert "looping ? elapsed % ledDurationMs : Math.min(elapsed, ledDurationMs - 1)" in source
+
+
+def test_itachi_eye_clip_installs_a_direct_video_sprite_and_preview(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    module = _authoring_module()
+    source_video = tmp_path / "preview_2.mov"
+
+    def fake_render_reference_assets(*, video_path: Path, output_dir: Path) -> tuple[Path, Path]:
+        assert video_path == source_video
+        sprite = output_dir / module.SOURCE_FILENAME
+        preview = output_dir / module.PREVIEW_FILENAME
+        sprite.write_bytes(_reference_sprite())
+        preview.write_bytes(b"local preview fixture")
+        return sprite, preview
+
+    monkeypatch.setattr(module, "render_reference_assets", fake_render_reference_assets)
+    manifest = module.create_itachi_eye_clip(video_path=source_video)
+    payload = load_expression_clip_lcd_payload(module.CLIP_ID)
+    width, height, frame_count, fps = struct.unpack_from("<HHHH", payload, 6)
+
+    assert manifest["clip_id"] == module.CLIP_ID
+    assert manifest["default_led_effect_id"] is None
+    assert manifest["source"]["grid_rows"] == 17
+    assert manifest["source"]["grid_cols"] == 10
+    assert manifest["sync"]["status"] == "unsynced"
+    assert (width, height, frame_count, fps) == (LCD_WIDTH, LCD_HEIGHT, 170, 30)
+    assert len(payload) <= MAX_LCD_BYTES
+    preview = tmp_path / "expression_clips" / module.CLIP_ID / module.PREVIEW_FILENAME
+    assert preview.read_bytes() == b"local preview fixture"
+    assert any(eye["eye_clip_id"] == module.CLIP_ID for eye in list_eyes())
+    resolved = resolve_expression({"eye_clip_id": module.CLIP_ID})
+    assert resolved["duration_ms"] == 5667
+    assert resolved["led_effect_id"] is None

--- a/tests/test_itachi_led_effects.py
+++ b/tests/test_itachi_led_effects.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+from lampgo.led_effects import (
+    LED_TICK_COUNT,
+    MAX_LED_EFFECT_BYTES,
+    compile_led_program,
+    inspect_led_package,
+    load_pixel_led_source,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+AUTHORING_SCRIPT = ROOT / "tools/author_itachi_led_effects.py"
+
+
+def _authoring_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("itachi_led_effects", AUTHORING_SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_itachi_led_effects_compile_as_three_second_one_shots() -> None:
+    module = _authoring_module()
+    effects = module.build_effects()
+
+    assert [effect["effect_id"] for effect in effects] == ["itachi-awaken", "itachi-dual", "amaterasu"]
+    for effect in effects:
+        normalized, package = compile_led_program(effect["program"])
+        info = inspect_led_package(package)
+        assert effect["role"] == "accent"
+        assert effect["default_playback"] == "once"
+        assert sum(frame["ticks"] for frame in normalized["frames"]) == LED_TICK_COUNT
+        assert info["frame_count"] == LED_TICK_COUNT
+        assert info["bytes"] <= MAX_LED_EFFECT_BYTES
+
+
+def test_dual_sharingan_effect_has_two_open_eyes_and_a_clear_center_gap() -> None:
+    module = _authoring_module()
+    effect = next(effect for effect in module.build_effects() if effect["effect_id"] == "itachi-dual")
+    final_rows = effect["program"]["frames"][8]["rows"]
+
+    assert len(effect["effect_id"]) <= 13
+    assert any(cell != "." for row in final_rows for cell in row[5:24])
+    assert any(cell != "." for row in final_rows for cell in row[27:46])
+    assert all(row[x] == "." for row in final_rows for x in range(24, 27))
+
+
+def test_itachi_led_effect_install_stays_local_and_editable(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    module = _authoring_module()
+
+    saved = module.install_effects()
+
+    assert [effect["sync"]["status"] for effect in saved] == ["not_synced", "not_synced", "not_synced"]
+    for effect in saved:
+        source = load_pixel_led_source(effect["effect_id"])
+        assert source["label"] == effect["label"]
+        assert source["default_playback"] == "once"
+        assert sum(frame["ticks"] for frame in source["program"]["frames"]) == LED_TICK_COUNT

--- a/tests/test_led_effects.py
+++ b/tests/test_led_effects.py
@@ -97,6 +97,17 @@ def test_pixel_effect_storage_capacity_and_llm_catalog(monkeypatch, tmp_path):
     assert any(item["effect_id"] == "rainbow_smile" for item in catalog["led_effects"])
 
 
+def test_pixel_effect_supports_once_as_default_playback(monkeypatch, tmp_path):
+    monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
+    authored = _effect("one_shot")
+    authored["default_playback"] = "once"
+
+    saved = save_led_effect(authored)
+
+    assert saved["default_playback"] == "once"
+    assert load_pixel_led_source("one_shot")["default_playback"] == "once"
+
+
 def test_custom_effect_limit_is_shared_with_legacy_templates(monkeypatch, tmp_path):
     monkeypatch.setenv("LAMPGO_HOME", str(tmp_path))
     monkeypatch.setattr(expression_library, "MAX_CUSTOM_LED_EFFECTS", 1)

--- a/tests/test_led_effects_frontend.py
+++ b/tests/test_led_effects_frontend.py
@@ -30,7 +30,7 @@ def test_led_effects_are_grouped_with_added_effects_first() -> None:
 def test_led_effect_group_divider_is_a_single_thin_line() -> None:
     assert ".expression-effect-group-title.expression-group-divider" in STYLE_CSS
     assert "border-top: 1px solid #dce3e7;" in STYLE_CSS
-    assert "expression-library-polish-20260803" in INDEX_HTML
+    assert "feature-batch-20260803" in INDEX_HTML
 
 
 def test_led_editor_preserves_one_shot_default_playback() -> None:

--- a/tests/test_led_effects_frontend.py
+++ b/tests/test_led_effects_frontend.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = (ROOT / "lampgo/web/static/app.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "lampgo/web/static/style.css").read_text(encoding="utf-8")
+INDEX_HTML = (ROOT / "lampgo/web/static/index.html").read_text(encoding="utf-8")
+
+
+def test_websocket_prefers_full_led_effect_catalog() -> None:
+    assert "const hasFullLedEffectCatalog = Array.isArray(msg.result.led_effects);" in APP_JS
+    assert "? ledEffectExpressionEntries(msg.result.led_effects)" in APP_JS
+    assert "renderExpressions(ledEffectExpressionEntries(expressionLedEffects));" in APP_JS
+
+
+def test_led_effects_are_grouped_with_added_effects_first() -> None:
+    assert "const groups = { added: [], factory: [] };" in APP_JS
+    assert 'effect && effect.source !== "builtin" ? "added" : "factory"' in APP_JS
+    added = APP_JS.index('{ id: "added", label: "后续新增", names: groups.added }')
+    factory = APP_JS.index('{ id: "factory", label: "出厂默认", names: groups.factory }')
+    assert added < factory
+    assert (
+        'heading.className = `expression-effect-group-title${separated ? " expression-group-divider" : ""}`;'
+        in APP_JS
+    )
+    assert "appendGroupHeading(group, index > 0);" in APP_JS
+    assert 'card.classList.add("expression-effect-card--custom");' in APP_JS
+    assert ".expression-effect-card--custom .expression-card-actions" in STYLE_CSS
+
+
+def test_led_effect_group_divider_is_a_single_thin_line() -> None:
+    assert ".expression-effect-group-title.expression-group-divider" in STYLE_CSS
+    assert "border-top: 1px solid #dce3e7;" in STYLE_CSS
+    assert "expression-library-polish-20260803" in INDEX_HTML
+
+
+def test_led_editor_preserves_one_shot_default_playback() -> None:
+    assert 'const ledEffectDefaultPlayback = document.getElementById("led-effect-default-playback");' in APP_JS
+    assert 'default_playback: (ledEffectDefaultPlayback && ledEffectDefaultPlayback.value) || "loop",' in APP_JS
+    assert 'source.default_playback === "once" ? "once" : "loop"' in APP_JS
+    assert 'playback: (effect && effect.default_playback) || "loop",' in APP_JS
+    assert 'id="led-effect-default-playback"' in INDEX_HTML

--- a/tools/author_itachi_eye_clip.py
+++ b/tools/author_itachi_eye_clip.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Build the Itachi eye clip directly from the supplied reference movie.
+
+This is deliberately a video conversion tool, not an illustration tool.  It
+uses ffmpeg to scale the user-authored CapCut master to the C6's 320x172 LCD,
+then applies a stable low-colour transfer needed by the C6's 256 KiB clip
+cache.  No eye geometry, Sharingan, or blood is redrawn by this script.
+
+The source is retained as a 10x17 PNG sprite for the existing local web
+preview.  A matching MP4 preview is also installed beside the clip.  Neither
+operation contacts or transfers anything to the S3 or C6.
+
+Usage:
+    uv run python tools/author_itachi_eye_clip.py --video /path/to/preview.mov --install
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+import numpy as np
+
+from lampgo.expression_clips import (
+    MAX_LCD_BYTES,
+    create_expression_clip,
+    expression_clip_root,
+)
+from lampgo.expression_library import refresh_llm_expression_catalog
+
+CLIP_ID = "itachi-eyes"
+EXPRESSION_LABEL = "写轮眼·开眼"
+DEFAULT_LED_EFFECT_ID = None
+FPS = 30
+DURATION_MS = 5667
+FRAME_COUNT = 170
+GRID_COLS = 10
+GRID_ROWS = 17
+SOURCE_FILENAME = "itachi_capcut_preview2_10x17_320x172.png"
+PREVIEW_FILENAME = "preview.mp4"
+
+# The CapCut master is 2010x1080, essentially the same aspect ratio as the
+# C6 display (320x172).  We keep the full 320x172 picture so the user's
+# CapCut-adjusted composition is not cropped or repositioned.
+
+# ``preview_2.mov`` is already upright in the C6's landscape coordinate space.
+# A physical C6 check confirmed that a further vertical flip puts the opening
+# shape on the lower half of the panel, so this CapCut master must be packaged
+# without ``vflip``.
+C6_VERTICAL_FLIP = False
+
+# The encoder is delta-RLE rather than video-compressed.  CapCut's H.264 master
+# has faint, rapidly changing colour noise in the black background, so direct
+# posterization reaches ~700 KiB.  A fixed black/bright-red/bright-white
+# palette removes that noise while preserving the deliberately brighter
+# Sharingan opening in a full-size C6 package.
+C6_RED_MIN = 90
+C6_RED_SEPARATION = 30
+C6_WHITE_MIN = 120
+C6_INK = 224
+
+# The panel still receives 30 scheduled frames per second.  Holding a few
+# neighbouring C6 frames at a 22 fps source cadence removes otherwise invisible
+# H.264/RLE churn from the brighter red treatment and leaves safe cache margin.
+C6_CONTENT_FPS = 22
+
+
+def c6_video_filter() -> str:
+    """Return the exact CapCut-master conversion filter used for C6."""
+    orientation = "vflip," if C6_VERTICAL_FLIP else ""
+    return (
+        f"fps={FPS},"
+        f"{orientation}scale=320:172:flags=lanczos,setsar=1"
+    )
+
+
+def c6_palette_transfer(frame_rgb: np.ndarray) -> np.ndarray:
+    """Reduce CapCut pixels to the stable C6 black/red/white ink palette."""
+    if frame_rgb.ndim != 3 or frame_rgb.shape[2] != 3:
+        raise ValueError("C6 palette transfer expects an RGB image")
+
+    source = frame_rgb.astype(np.int16, copy=False)
+    red, green, blue = source[:, :, 0], source[:, :, 1], source[:, :, 2]
+    maximum = source.max(axis=2)
+    output = np.zeros_like(source, dtype=np.uint8)
+
+    red_ink = (
+        (red >= C6_RED_MIN)
+        & (red - green >= C6_RED_SEPARATION)
+        & (red - blue >= C6_RED_SEPARATION)
+    )
+    output[red_ink] = (C6_INK, 0, 0)
+    white_ink = (~red_ink) & (maximum >= C6_WHITE_MIN)
+    output[white_ink] = (C6_INK, C6_INK, C6_INK)
+    return output
+
+
+def apply_c6_palette_to_sprite(sprite_path: Path) -> None:
+    """Replace the rendered sprite with the C6 palette version in place."""
+    try:
+        import cv2
+    except ImportError as exc:  # pragma: no cover - installation error path
+        raise RuntimeError("opencv-python is required to prepare the C6 sprite") from exc
+
+    image_bgr = cv2.imread(str(sprite_path), cv2.IMREAD_COLOR)
+    if image_bgr is None:
+        raise RuntimeError(f"could not read rendered C6 sprite: {sprite_path}")
+    expected_shape = (GRID_ROWS * 172, GRID_COLS * 320, 3)
+    if image_bgr.shape != expected_shape:
+        raise RuntimeError(f"unexpected C6 sprite shape: {image_bgr.shape}, expected {expected_shape}")
+    image_rgb = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
+    palette_bgr = cv2.cvtColor(c6_palette_transfer(image_rgb), cv2.COLOR_RGB2BGR)
+    if not cv2.imwrite(str(sprite_path), palette_bgr):
+        raise RuntimeError(f"could not save C6 palette sprite: {sprite_path}")
+
+
+def c6_source_frame_index(output_index: int) -> int:
+    """Map a 30 fps C6 frame to a nearby 22 fps source frame, including the end."""
+    if not 0 <= output_index < FRAME_COUNT:
+        raise ValueError(f"output frame must be 0-{FRAME_COUNT - 1}")
+    content_index = round(output_index * C6_CONTENT_FPS / FPS)
+    return min(FRAME_COUNT - 1, int(round(content_index * FPS / C6_CONTENT_FPS)))
+
+
+def apply_c6_temporal_hold_to_sprite(sprite_path: Path) -> None:
+    """Keep C6 transport at 30 fps while reducing the source-change cadence."""
+    try:
+        import cv2
+    except ImportError as exc:  # pragma: no cover - installation error path
+        raise RuntimeError("opencv-python is required to prepare the C6 sprite") from exc
+
+    sprite_bgr = cv2.imread(str(sprite_path), cv2.IMREAD_COLOR)
+    if sprite_bgr is None:
+        raise RuntimeError(f"could not read rendered C6 sprite: {sprite_path}")
+    expected_shape = (GRID_ROWS * 172, GRID_COLS * 320, 3)
+    if sprite_bgr.shape != expected_shape:
+        raise RuntimeError(f"unexpected C6 sprite shape: {sprite_bgr.shape}, expected {expected_shape}")
+
+    source = sprite_bgr.copy()
+    for output_index in range(FRAME_COUNT):
+        source_index = c6_source_frame_index(output_index)
+        output_row, output_col = divmod(output_index, GRID_COLS)
+        source_row, source_col = divmod(source_index, GRID_COLS)
+        y0, x0 = output_row * 172, output_col * 320
+        source_y0, source_x0 = source_row * 172, source_col * 320
+        sprite_bgr[y0 : y0 + 172, x0 : x0 + 320] = source[
+            source_y0 : source_y0 + 172,
+            source_x0 : source_x0 + 320,
+        ]
+    if not cv2.imwrite(str(sprite_path), sprite_bgr):
+        raise RuntimeError(f"could not save C6 temporal sprite: {sprite_path}")
+
+
+def _run_ffmpeg(arguments: Sequence[str]) -> None:
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg is required to build the Itachi reference clip")
+    completed = subprocess.run(
+        [ffmpeg, "-hide_banner", "-loglevel", "error", "-y", *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode:
+        detail = (completed.stderr or completed.stdout or "ffmpeg failed").strip()
+        raise RuntimeError(f"ffmpeg conversion failed: {detail}")
+
+
+def render_reference_assets(*, video_path: Path, output_dir: Path) -> tuple[Path, Path]:
+    """Render a C6 sprite plus a locally playable preview from ``video_path``."""
+    if not video_path.is_file():
+        raise FileNotFoundError(f"Itachi reference video not found: {video_path}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    sprite_path = output_dir / SOURCE_FILENAME
+    preview_path = output_dir / PREVIEW_FILENAME
+    filter_graph = c6_video_filter()
+    _run_ffmpeg(
+        [
+            "-i",
+            str(video_path),
+            "-vf",
+            f"{filter_graph},tile={GRID_COLS}x{GRID_ROWS}:padding=0:margin=0",
+            "-frames:v",
+            "1",
+            str(sprite_path),
+        ]
+    )
+    apply_c6_palette_to_sprite(sprite_path)
+    apply_c6_temporal_hold_to_sprite(sprite_path)
+    _run_ffmpeg(
+        [
+            "-framerate",
+            str(FPS),
+            "-loop",
+            "1",
+            "-i",
+            str(sprite_path),
+            "-vf",
+            f"untile={GRID_COLS}x{GRID_ROWS},setpts=N/({FPS}*TB),fps={FPS},setsar=1",
+            "-an",
+            "-c:v",
+            "libx264",
+            "-crf",
+            "15",
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
+            "-frames:v",
+            str(FRAME_COUNT),
+            str(preview_path),
+        ]
+    )
+    return sprite_path, preview_path
+
+
+def create_itachi_eye_clip(*, video_path: Path) -> dict[str, object]:
+    """Replace the local clip with a capacity-checked direct-video conversion."""
+    with tempfile.TemporaryDirectory(prefix="lampgo-itachi-") as temporary:
+        sprite_path, preview_path = render_reference_assets(
+            video_path=video_path,
+            output_dir=Path(temporary),
+        )
+        manifest = create_expression_clip(
+            clip_id=CLIP_ID,
+            expression=EXPRESSION_LABEL,
+            source_bytes=sprite_path.read_bytes(),
+            filename=SOURCE_FILENAME,
+            content_type="image/png",
+            fps=FPS,
+            duration_s=DURATION_MS / 1000,
+            grid_rows=GRID_ROWS,
+            grid_cols=GRID_COLS,
+            default_led_effect_id=DEFAULT_LED_EFFECT_ID,
+        )
+        if int(manifest["frame_count"]) != FRAME_COUNT:
+            raise RuntimeError(
+                f"reference frame count changed: expected {FRAME_COUNT}, got {manifest['frame_count']}"
+            )
+        if int(manifest["lcd"]["bytes"]) > MAX_LCD_BYTES:
+            raise RuntimeError("reference conversion exceeded the C6 cache budget")
+        shutil.copy2(preview_path, expression_clip_root() / CLIP_ID / PREVIEW_FILENAME)
+
+    refresh_llm_expression_catalog()
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--install", action="store_true", help="save the local sprite, preview, and C6 package")
+    parser.add_argument(
+        "--video",
+        type=Path,
+        help="source movie exported from the editor; required together with --install",
+    )
+    args = parser.parse_args()
+    if not args.install:
+        print(
+            f"configured {CLIP_ID}: {FRAME_COUNT} frames, {FPS} fps, {DURATION_MS} ms; "
+            "dry run only"
+        )
+        return 0
+    if args.video is None:
+        parser.error("--video is required together with --install")
+    manifest = create_itachi_eye_clip(video_path=args.video.expanduser().resolve())
+    preview = expression_clip_root() / CLIP_ID / PREVIEW_FILENAME
+    print(
+        f"installed {manifest['clip_id']}: {manifest['lcd']['bytes']} bytes, "
+        f"{manifest['frame_count']} frames, preview={preview}, sync={manifest['sync']['status']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/author_itachi_led_effects.py
+++ b/tools/author_itachi_led_effects.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Author three 3-second Itachi-inspired LED pixel clips.
+
+This is deliberately an authoring utility, not a device-control command.  It
+creates safe LEF1 packages in the local expression library; the user can
+inspect, edit, and explicitly sync either effect from the LampGo console.
+
+Usage:
+    uv run python tools/author_itachi_led_effects.py --install
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable
+from typing import Any
+
+from lampgo.expression_library import save_led_effect
+from lampgo.led_effects import compile_led_program, inspect_led_package
+
+WIDTH = 51
+HEIGHT = 9
+
+Canvas = list[list[str]]
+Point = tuple[int, int]
+
+
+def _blank() -> Canvas:
+    return [["." for _ in range(WIDTH)] for _ in range(HEIGHT)]
+
+
+def _paint(canvas: Canvas, symbol: str, points: Iterable[Point]) -> None:
+    for x, y in points:
+        if 0 <= x < WIDTH and 0 <= y < HEIGHT:
+            canvas[y][x] = symbol
+
+
+def _span(canvas: Canvas, symbol: str, *, y: int, start: int, end: int) -> None:
+    _paint(canvas, symbol, ((x, y) for x in range(start, end + 1)))
+
+
+def _rows(canvas: Canvas) -> list[str]:
+    return ["".join(row) for row in canvas]
+
+
+def _dim(canvas: Canvas) -> Canvas:
+    """Reduce the authored reds for a readable final fade, not a hard cut."""
+    faded = {"5": "3", "4": "4", "3": "2", "2": "1", "1": "1"}
+    return [[faded.get(cell, cell) for cell in row] for row in canvas]
+
+
+def _draw_eye_outline(canvas: Canvas, level: int, *, center_x: int = 25) -> None:
+    """Draw one opening eye around ``center_x`` on the 51-pixel panel."""
+    offset = center_x - 25
+
+    if level <= 0:
+        _span(canvas, "1", y=4, start=21 + offset, end=29 + offset)
+        _span(canvas, "2", y=4, start=23 + offset, end=27 + offset)
+        return
+
+    if level == 1:
+        segments = ((3, 22, 28), (4, 19, 21), (4, 29, 31), (5, 22, 28))
+    elif level == 2:
+        segments = (
+            (2, 22, 28),
+            (3, 19, 21),
+            (3, 29, 31),
+            (4, 17, 18),
+            (4, 32, 33),
+            (5, 19, 21),
+            (5, 29, 31),
+            (6, 22, 28),
+        )
+    else:
+        segments = (
+            (1, 22, 28),
+            (2, 19, 21),
+            (2, 29, 31),
+            (3, 17, 18),
+            (3, 32, 33),
+            (4, 16, 17),
+            (4, 33, 34),
+            (5, 17, 18),
+            (5, 32, 33),
+            (6, 19, 21),
+            (6, 29, 31),
+            (7, 22, 28),
+        )
+    for y, start, end in segments:
+        _span(canvas, "1", y=y, start=start + offset, end=end + offset)
+
+
+_TOMOE_PHASES: tuple[tuple[tuple[Point, tuple[Point, ...]], ...], ...] = (
+    (
+        ((25, 2), ((24, 2), (24, 3))),
+        ((28, 5), ((28, 4), (27, 4))),
+        ((22, 5), ((22, 6), (23, 6))),
+    ),
+    (
+        ((27, 3), ((26, 2), (26, 3))),
+        ((26, 6), ((27, 6), (27, 5))),
+        ((22, 4), ((22, 5), (23, 5))),
+    ),
+    (
+        ((28, 4), ((27, 3), (27, 4))),
+        ((23, 6), ((24, 6), (24, 5))),
+        ((23, 2), ((22, 3), (23, 3))),
+    ),
+)
+
+
+def _draw_iris(canvas: Canvas, phase: int | None, *, center_x: int = 25) -> None:
+    """Draw one Sharingan iris and optionally one tomoe rotation phase."""
+    offset = center_x - 25
+    iris_points = (
+        (24, 2),
+        (25, 2),
+        (26, 2),
+        (23, 3),
+        (27, 3),
+        (22, 4),
+        (28, 4),
+        (23, 5),
+        (27, 5),
+        (24, 6),
+        (25, 6),
+        (26, 6),
+    )
+
+    _paint(
+        canvas,
+        "2",
+        ((x + offset, y) for x, y in iris_points),
+    )
+    _paint(canvas, "4", ((x + offset, y) for x, y in ((25, 3), (24, 4), (25, 4), (26, 4), (25, 5))))
+    _paint(canvas, "5", ((24 + offset, 3),))
+    if phase is None:
+        return
+    for head, tail in _TOMOE_PHASES[phase % len(_TOMOE_PHASES)]:
+        _paint(canvas, "2", ((x + offset, y) for x, y in tail))
+        _paint(canvas, "3", ((head[0] + offset, head[1]),))
+
+
+def _sharingan_canvas(*, level: int, phase: int | None = None, droplets: bool = False) -> Canvas:
+    canvas = _blank()
+    _draw_eye_outline(canvas, level)
+    if level >= 3:
+        _draw_iris(canvas, phase)
+    elif level == 2:
+        _paint(canvas, "2", ((24, 4), (25, 4), (26, 4)))
+    if droplets:
+        _paint(canvas, "2", ((20, 7), (30, 7), (20, 8)))
+        _paint(canvas, "3", ((30, 8),))
+    return canvas
+
+
+_DUAL_EYE_CENTERS = (14, 36)
+
+
+def _dual_sharingan_canvas(*, level: int, phase: int | None = None, droplets: bool = False) -> Canvas:
+    """Draw two synchronized Sharingan eyes with a deliberate centre gap."""
+    canvas = _blank()
+    for center_x in _DUAL_EYE_CENTERS:
+        _draw_eye_outline(canvas, level, center_x=center_x)
+        if level >= 3:
+            _draw_iris(canvas, phase, center_x=center_x)
+        elif level == 2:
+            _paint(canvas, "2", ((center_x - 1, 4), (center_x, 4), (center_x + 1, 4)))
+    if droplets:
+        _paint(canvas, "2", ((9, 7), (19, 7), (9, 8), (41, 7), (31, 7), (41, 8)))
+        _paint(canvas, "3", ((19, 8), (31, 8)))
+    return canvas
+
+
+def _sharingan_effect() -> dict[str, Any]:
+    seed = _blank()
+    _paint(seed, "1", ((24, 4), (26, 4)))
+    _paint(seed, "2", ((25, 4),))
+    final = _sharingan_canvas(level=3, phase=2, droplets=True)
+    return {
+        "effect_id": "itachi-awaken",
+        "label": "写轮眼·同步开眼",
+        "role": "accent",
+        "default_playback": "once",
+        "program": {
+            "version": 2,
+            "type": "pixel_clip",
+            "fps": 10,
+            "palette": {
+                ".": "#000000",
+                "1": "#26000d",
+                "2": "#720019",
+                "3": "#d10c2d",
+                "4": "#2b001f",
+                "5": "#ff6370",
+            },
+            "roles": {"primary": "1", "secondary": "2", "accent": "3"},
+            "frames": [
+                {"rows": _rows(seed), "ticks": 2},
+                {"rows": _rows(_sharingan_canvas(level=0)), "ticks": 2},
+                {"rows": _rows(_sharingan_canvas(level=1)), "ticks": 3},
+                {"rows": _rows(_sharingan_canvas(level=2)), "ticks": 3},
+                {"rows": _rows(_sharingan_canvas(level=3)), "ticks": 3},
+                {"rows": _rows(_sharingan_canvas(level=3, phase=0)), "ticks": 2},
+                {"rows": _rows(_sharingan_canvas(level=3, phase=1)), "ticks": 2},
+                {"rows": _rows(_sharingan_canvas(level=3, phase=2)), "ticks": 2},
+                {"rows": _rows(final), "ticks": 8},
+                {"rows": _rows(_dim(final)), "ticks": 2},
+                {"rows": _rows(_blank()), "ticks": 1},
+            ],
+        },
+    }
+
+
+def _dual_sharingan_effect() -> dict[str, Any]:
+    """Create the compact two-eye counterpart of the existing opening effect."""
+    seed = _blank()
+    for center_x in _DUAL_EYE_CENTERS:
+        _paint(seed, "1", ((center_x - 1, 4), (center_x + 1, 4)))
+        _paint(seed, "2", ((center_x, 4),))
+    final = _dual_sharingan_canvas(level=3, phase=2, droplets=True)
+    return {
+        # 11 ASCII characters keeps the LED asset ID well inside the shared
+        # C6/S3-safe naming convention; the display name can stay descriptive.
+        "effect_id": "itachi-dual",
+        "label": "写轮眼·双眼开眼",
+        "role": "accent",
+        "default_playback": "once",
+        "program": {
+            "version": 2,
+            "type": "pixel_clip",
+            "fps": 10,
+            "palette": {
+                ".": "#000000",
+                "1": "#26000d",
+                "2": "#720019",
+                "3": "#d10c2d",
+                "4": "#2b001f",
+                "5": "#ff6370",
+            },
+            "roles": {"primary": "1", "secondary": "2", "accent": "3"},
+            "frames": [
+                {"rows": _rows(seed), "ticks": 2},
+                {"rows": _rows(_dual_sharingan_canvas(level=0)), "ticks": 2},
+                {"rows": _rows(_dual_sharingan_canvas(level=1)), "ticks": 3},
+                {"rows": _rows(_dual_sharingan_canvas(level=2)), "ticks": 3},
+                {"rows": _rows(_dual_sharingan_canvas(level=3)), "ticks": 3},
+                {"rows": _rows(_dual_sharingan_canvas(level=3, phase=0)), "ticks": 2},
+                {"rows": _rows(_dual_sharingan_canvas(level=3, phase=1)), "ticks": 2},
+                {"rows": _rows(_dual_sharingan_canvas(level=3, phase=2)), "ticks": 2},
+                {"rows": _rows(final), "ticks": 8},
+                {"rows": _rows(_dim(final)), "ticks": 2},
+                {"rows": _rows(_blank()), "ticks": 1},
+            ],
+        },
+    }
+
+
+def _draw_flame(canvas: Canvas, stage: str) -> None:
+    if stage == "ember":
+        _paint(canvas, "1", ((24, 7), (26, 7), (25, 8)))
+        _paint(canvas, "3", ((25, 7),))
+        return
+
+    if stage == "small":
+        for y, start, end in ((8, 22, 28), (7, 23, 27), (6, 24, 26), (5, 25, 25)):
+            _span(canvas, "1", y=y, start=start, end=end)
+        _paint(canvas, "2", ((22, 8), (28, 8), (23, 7), (27, 7), (24, 6), (26, 6), (25, 5)))
+        _paint(canvas, "3", ((25, 7),))
+        return
+
+    if stage == "medium":
+        for y, start, end in ((8, 20, 30), (7, 21, 29), (6, 22, 28), (5, 23, 27), (4, 24, 26)):
+            _span(canvas, "1", y=y, start=start, end=end)
+        _paint(
+            canvas,
+            "2",
+            ((20, 8), (30, 8), (21, 7), (29, 7), (22, 6), (28, 6), (23, 5), (27, 5), (24, 4), (26, 4)),
+        )
+        _paint(canvas, "3", ((24, 7), (26, 7), (25, 6)))
+        _paint(canvas, "4", ((25, 7),))
+        return
+
+    if stage != "full":
+        raise ValueError(f"unknown flame stage: {stage}")
+
+    for y, start, end in ((8, 19, 31), (7, 20, 30), (6, 21, 29), (5, 22, 28)):
+        _span(canvas, "1", y=y, start=start, end=end)
+    _paint(canvas, "1", ((23, 4), (25, 4), (27, 4), (23, 3), (26, 3), (24, 2), (27, 2), (24, 1)))
+    _paint(
+        canvas,
+        "2",
+        (
+            (19, 8),
+            (31, 8),
+            (20, 7),
+            (30, 7),
+            (21, 6),
+            (29, 6),
+            (22, 5),
+            (28, 5),
+            (23, 4),
+            (27, 4),
+            (23, 3),
+            (26, 3),
+            (24, 2),
+            (27, 2),
+            (24, 1),
+        ),
+    )
+    _paint(canvas, "3", ((23, 7), (25, 6), (27, 7)))
+    _paint(canvas, "4", ((25, 7),))
+
+
+_CROW_POSES: dict[str, tuple[Point, ...]] = {
+    "rise": ((-2, 0), (-1, 1), (0, 2), (1, 1), (2, 0)),
+    "down": ((-2, 2), (-1, 1), (0, 0), (1, 1), (2, 2)),
+    "glide": ((-2, 1), (-1, 1), (0, 1), (1, 1), (2, 1), (0, 2)),
+}
+
+
+def _draw_crow(canvas: Canvas, *, x: int, y: int, pose: str, eye: bool = False) -> None:
+    offsets = _CROW_POSES[pose]
+    # Near-black purple wings remain legible against the panel's black void;
+    # the darker core makes them read as black crows rather than pink birds.
+    _paint(canvas, "2", ((x + offset_x, y + offset_y) for offset_x, offset_y in offsets))
+    _paint(canvas, "1", ((x, y + 1),))
+    if eye:
+        _paint(canvas, "3", ((x + 1, y + 1),))
+
+
+def _amaterasu_canvas(*, stage: str | None, crows: tuple[tuple[int, int, str, bool], ...] = ()) -> Canvas:
+    canvas = _blank()
+    if stage:
+        _draw_flame(canvas, stage)
+    for x, y, pose, eye in crows:
+        _draw_crow(canvas, x=x, y=y, pose=pose, eye=eye)
+    return canvas
+
+
+def _amaterasu_effect() -> dict[str, Any]:
+    return {
+        "effect_id": "amaterasu",
+        "label": "天照黑焰",
+        "role": "accent",
+        "default_playback": "once",
+        "program": {
+            "version": 2,
+            "type": "pixel_clip",
+            "fps": 10,
+            "palette": {
+                ".": "#000000",
+                "1": "#1a061e",
+                "2": "#48203f",
+                "3": "#8a1735",
+                "4": "#d74458",
+            },
+            "roles": {"primary": "1", "secondary": "2", "accent": "3"},
+            "frames": [
+                {"rows": _rows(_amaterasu_canvas(stage="ember")), "ticks": 2},
+                {"rows": _rows(_amaterasu_canvas(stage="small")), "ticks": 2},
+                {"rows": _rows(_amaterasu_canvas(stage="medium")), "ticks": 2},
+                {"rows": _rows(_amaterasu_canvas(stage="full")), "ticks": 5},
+                {
+                    "rows": _rows(_amaterasu_canvas(stage="full", crows=((31, 2, "rise", True),))),
+                    "ticks": 2,
+                },
+                {
+                    "rows": _rows(
+                        _amaterasu_canvas(stage="full", crows=((32, 1, "glide", True), (23, 2, "down", False)))
+                    ),
+                    "ticks": 2,
+                },
+                {
+                    "rows": _rows(
+                        _amaterasu_canvas(
+                            stage="full",
+                            crows=((17, 2, "glide", False), (31, 1, "rise", True), (38, 3, "down", False)),
+                        )
+                    ),
+                    "ticks": 4,
+                },
+                {
+                    "rows": _rows(
+                        _amaterasu_canvas(
+                            stage="full",
+                            crows=((14, 1, "down", False), (34, 2, "glide", True), (42, 1, "rise", False)),
+                        )
+                    ),
+                    "ticks": 3,
+                },
+                {
+                    "rows": _rows(
+                        _amaterasu_canvas(stage="medium", crows=((11, 3, "glide", False), (39, 1, "down", True)))
+                    ),
+                    "ticks": 3,
+                },
+                {"rows": _rows(_amaterasu_canvas(stage="small")), "ticks": 2},
+                {"rows": _rows(_amaterasu_canvas(stage="ember")), "ticks": 2},
+                {"rows": _rows(_amaterasu_canvas(stage=None)), "ticks": 1},
+            ],
+        },
+    }
+
+
+def build_effects() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Return all safe LED authoring documents without touching device state."""
+    return _sharingan_effect(), _dual_sharingan_effect(), _amaterasu_effect()
+
+
+def install_effects() -> list[dict[str, Any]]:
+    """Save all effects locally; this never uploads or starts an LED effect."""
+    return [save_led_effect(effect) for effect in build_effects()]
+
+
+def _describe(effect: dict[str, Any]) -> str:
+    _, package = compile_led_program(effect["program"])
+    info = inspect_led_package(package)
+    return f"{effect['effect_id']}: {info['bytes']} bytes, {info['unique_frame_count']} unique frames"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--install",
+        action="store_true",
+        help="save the three effects into the local expression library",
+    )
+    args = parser.parse_args()
+    effects = build_effects()
+    if args.install:
+        for saved in install_effects():
+            print(f"installed {saved['effect_id']}: {saved['package']['bytes']} bytes")
+        return 0
+    for effect in effects:
+        print(_describe(effect))
+    print("Dry run only. Re-run with --install to save locally; it does not sync hardware.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- Extend eye clips to 1–6 seconds at 8–30 fps while enforcing the S3-safe 13-character clip ID.
- Preserve sync state when rebuilding an identical package and surface the device's real sync failure message.
- Add `once` / `loop` defaults for custom LED clips and make previews respect each channel's own duration and final frame.
- Group newly added LED effects separately from factory defaults with a thin divider.
- Add portable Itachi eye-video and LED authoring tools plus regression tests; the source movie remains local and is supplied explicitly with `--video`.
- Align docs and JSON schemas with the runtime contract.

## Why

The 5.667-second opening sequence exposed mismatches between backend validation, S3 playback limits, SPIFFS filename limits, and the three-second preview assumptions. Custom one-shot LED effects also appeared as looping factory effects in parts of the UI.

## Firmware pairing

- Durations above 3500ms require [firmware PR #6](https://github.com/shelly-tang/YareLampGo_esp32/pull/6).
- [firmware PR #7](https://github.com/shelly-tang/YareLampGo_esp32/pull/7) independently fixes installed clips being poisoned by stale upload validation state.

## Checks

- `41 passed` across expression clips/library, LED effects, Itachi authoring, and frontend grouping.
- `node --check lampgo/web/static/app.js`.
- Relevant Python files pass Ruff; `gateway.py` retains only pre-existing repository-wide findings.
- Both authoring tools complete dry runs; generated LED packages remain below the 8 KiB limit.
- `git diff --check`.

## Batch integration

Backend PRs #54 → #55 → #56 → #57 merge cleanly in that order. The combined tree passes `392` tests and `node --check`.
