### PR TITLE
feat(motion): add safe lighting mode

### DIFF
--- a/lampgo/core/motion.py
+++ b/lampgo/core/motion.py
@@ -45,7 +45,7 @@ from enum import Enum, auto
 import structlog
 
 from lampgo.core.config import MotionConfig
-from lampgo.core.hal import HardwareAbstraction
+from lampgo.core.hal import HardwareAbstraction, MotorStartupState
 from lampgo.core.safety import SafetyKernel
 from lampgo.core.spring import SecondOrderDynamics, cap_spring_f
 from lampgo.core.style import get_motion_style, resolve_style_name
@@ -363,8 +363,21 @@ class MotionRuntime:
         return self._hal.recovery_required
 
     @property
+    def recovery_in_progress(self) -> bool:
+        """Whether HAL is inside a recovery session that has not completed."""
+        return self._hal.startup_state is MotorStartupState.RECOVERING
+
+    @property
     def recovery_error(self) -> str | None:
         return self._recovery_failure_reason
+
+    def record_recovery_failure(self, reason: str) -> None:
+        """Persist a recovery failure for status/UI diagnostics while torque is held."""
+        self._recovery_failure_reason = str(reason or "Motor recovery did not complete.")
+
+    def clear_recovery_failure(self) -> None:
+        """Clear a stale diagnostic after a positively completed safe move."""
+        self._recovery_failure_reason = None
 
     # ------------------------------------------------------------------
     # Control thread

--- a/lampgo/lighting_mode.py
+++ b/lampgo/lighting_mode.py
@@ -1,0 +1,362 @@
+"""Persistent conventional desk-lamp operating mode.
+
+The recorded action is treated as a taught pose, not as a trajectory to loop.
+Entering the mode moves once to the stable tail pose and applies steady white
+light.  The server owns interruption/return-safe orchestration so the skill
+executor remains available while the lamp is holding position.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import statistics
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from lampgo.core.hal import MotorStartupState
+from lampgo.core.types import JOINT_NAMES, MotionTarget, SkillResult
+
+logger = structlog.get_logger(__name__)
+
+LIGHTING_RECORDING_NAME = "照明模式"
+LIGHTING_SETTLE_WINDOW_S = 3.0
+LIGHTING_MAX_SETTLE_SPAN_DEG = 0.5
+LIGHTING_MOVE_VELOCITY_DPS = 30.0
+LIGHTING_MOVE_TIMEOUT_S = 30.0
+LIGHTING_POSE_WARNING_TOLERANCE_DEG = 2.0
+# This mode is used as a visual filming pose, not a precision positioning task.
+# Keep a generous acceptance envelope while still rejecting a clearly stalled
+# or unrelated pose.
+LIGHTING_POSE_ACCEPTANCE_TOLERANCE_DEG = 8.0
+
+
+@dataclass(frozen=True)
+class TaughtLightingPose:
+    joints: dict[str, float]
+    source_path: Path
+    source_frames: int
+    settle_frames: int
+    settle_window_s: float
+
+
+def load_taught_lighting_pose(
+    recordings_dir: Path,
+    *,
+    recording_name: str = LIGHTING_RECORDING_NAME,
+    settle_window_s: float = LIGHTING_SETTLE_WINDOW_S,
+    max_settle_span_deg: float = LIGHTING_MAX_SETTLE_SPAN_DEG,
+) -> TaughtLightingPose:
+    """Extract a stable fixed pose from the tail of a teach-recording CSV."""
+    path = Path(recordings_dir) / "user" / f"{recording_name}.csv"
+    if not path.is_file():
+        raise ValueError(f"照明姿态录制不存在：{path}")
+
+    samples: list[tuple[float, dict[str, float]]] = []
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for index, row in enumerate(reader):
+            try:
+                timestamp = float(row.get("timestamp") or index / 30.0)
+                joints = {
+                    joint: float(row.get(f"{joint}.pos", row.get(joint, "")))
+                    for joint in JOINT_NAMES
+                }
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"照明姿态录制第 {index + 2} 行无效") from exc
+            samples.append((timestamp, joints))
+
+    if len(samples) < 2:
+        raise ValueError("照明姿态录制没有足够的有效帧")
+
+    final_timestamp = samples[-1][0]
+    window_start = final_timestamp - max(0.5, float(settle_window_s))
+    settled = [joints for timestamp, joints in samples if timestamp >= window_start]
+    if len(settled) < 10:
+        raise ValueError("照明姿态录制末段稳定帧不足")
+
+    pose: dict[str, float] = {}
+    for joint in JOINT_NAMES:
+        values = [frame[joint] for frame in settled]
+        span = max(values) - min(values)
+        if span > max_settle_span_deg:
+            raise ValueError(
+                f"照明姿态录制末段仍在移动：{joint} 波动 {span:.2f}°，"
+                f"允许值 {max_settle_span_deg:.2f}°"
+            )
+        pose[joint] = float(statistics.median(values))
+
+    return TaughtLightingPose(
+        joints=pose,
+        source_path=path,
+        source_frames=len(samples),
+        settle_frames=len(settled),
+        settle_window_s=max(0.5, float(settle_window_s)),
+    )
+
+
+async def _await_motion(done_event: Any, timeout_s: float) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while not done_event.is_set():
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(0.05)
+    return True
+
+
+class LightingModeController:
+    """Own the long-lived lighting state without occupying SkillExecutor."""
+
+    def __init__(
+        self,
+        *,
+        recordings_dir: Path,
+        motion: Any,
+        led: Any,
+        safety: Any,
+        hal: Any,
+        clock: Any | None,
+        electronic_ocean: Any | None,
+        brightness: Callable[[], int],
+        no_hw: Callable[[], bool],
+    ) -> None:
+        self._recordings_dir = Path(recordings_dir)
+        self._motion = motion
+        self._led = led
+        self._safety = safety
+        self._hal = hal
+        self._clock = clock
+        self._electronic_ocean = electronic_ocean
+        self._brightness = brightness
+        self._no_hw = no_hw
+        self._lock = asyncio.Lock()
+        self._state = "normal"
+        self._target_pose: dict[str, float] = {}
+        self._entered_at: float | None = None
+        self._last_exit_reason = ""
+        self._last_error = ""
+        self._last_return_safe_status = "not_run"
+        self._last_brightness = 0
+        self._last_pose_errors: dict[str, float] = {}
+
+    def bind_runtime(self, motion: Any, hal: Any | None = None) -> None:
+        """Keep the controller aligned with a hot-reloaded/virtual runtime."""
+        self._motion = motion
+        if hal is not None:
+            self._hal = hal
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def is_active(self) -> bool:
+        return self._state == "active"
+
+    @property
+    def is_engaged(self) -> bool:
+        return self._state in {"entering", "active", "exiting"}
+
+    @property
+    def blocks_autonomous_motion(self) -> bool:
+        return self.is_engaged
+
+    @property
+    def blocks_automatic_led(self) -> bool:
+        return self._state in {"entering", "active"}
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "name": "lighting",
+            "label": "台灯常规模式",
+            "state": self._state,
+            "active": self.is_active,
+            "engaged": self.is_engaged,
+            "source_recording": LIGHTING_RECORDING_NAME,
+            "target_pose": dict(self._target_pose),
+            "brightness": self._last_brightness,
+            "entered_at": self._entered_at,
+            "last_exit_reason": self._last_exit_reason,
+            "last_error": self._last_error,
+            "pose_errors": dict(self._last_pose_errors),
+            "return_safe_status": self._last_return_safe_status,
+        }
+
+    def _preflight_error(self) -> str:
+        if self._no_hw() or bool(getattr(self._motion, "is_virtual", False)):
+            return "台灯常规模式需要真实机械臂硬件"
+        if not bool(getattr(self._hal, "is_connected", False)):
+            return "机械臂硬件未连接"
+        startup_state = getattr(self._hal, "startup_state", MotorStartupState.READY)
+        startup_value = getattr(startup_state, "value", str(startup_state))
+        if startup_value == MotorStartupState.RECOVERY_REQUIRED.value:
+            return str(getattr(self._hal, "recovery_reason", "") or "机械臂需要先完成安全恢复")
+        if startup_value == MotorStartupState.RECOVERING.value:
+            recovery_error = str(getattr(self._motion, "recovery_error", "") or "").strip()
+            return recovery_error or "上一次 return_safe 安全恢复未完成，机械臂当前仍在恢复保护状态"
+        if startup_value != MotorStartupState.READY.value:
+            return f"机械臂启动状态异常：{startup_value}"
+        if bool(self._safety.is_estopped()):
+            return "安全急停处于激活状态"
+        if not bool(getattr(self._led, "is_connected", False)):
+            return "ESP32-S3 LED 未连接"
+        return ""
+
+    def _ensure_motion_runtime(self) -> None:
+        """Repair a stopped runtime only after HAL has positively reported READY."""
+        if bool(getattr(self._motion, "is_running", False)):
+            return
+        self._motion.start()
+        if not bool(getattr(self._motion, "is_running", False)):
+            raise RuntimeError("机械臂硬件已就绪，但运动运行时启动失败")
+
+    def _deactivate_background_led(self) -> None:
+        if self._clock is not None:
+            self._clock.deactivate()
+        if self._electronic_ocean is not None:
+            self._electronic_ocean.deactivate()
+
+    async def enter(self) -> SkillResult:
+        async with self._lock:
+            if self._state == "active":
+                return SkillResult(status="ok", data={**self.snapshot(), "already_active": True})
+            if self._state in {"entering", "exiting"}:
+                return SkillResult(status="error", message=f"照明模式当前正在{self._state}")
+
+            preflight_error = self._preflight_error()
+            if preflight_error:
+                self._last_error = preflight_error
+                return SkillResult(status="error", message=preflight_error, data=self.snapshot())
+
+            self._state = "entering"
+            self._last_error = ""
+            self._last_pose_errors = {}
+            self._last_return_safe_status = "not_run"
+            try:
+                self._ensure_motion_runtime()
+                taught = load_taught_lighting_pose(self._recordings_dir)
+                self._target_pose = dict(taught.joints)
+                self._deactivate_background_led()
+
+                done = self._motion.move_to(
+                    MotionTarget(
+                        joints=dict(taught.joints),
+                        max_velocity=LIGHTING_MOVE_VELOCITY_DPS,
+                        anticipation=False,
+                    )
+                )
+                if not await _await_motion(done, LIGHTING_MOVE_TIMEOUT_S):
+                    raise RuntimeError("移动到照明姿态超时")
+
+                actual = dict(getattr(self._motion.current_state, "positions", {}) or {})
+                pose_errors = {
+                    joint: round(actual.get(joint, target) - target, 2)
+                    for joint, target in taught.joints.items()
+                    if abs(actual.get(joint, target) - target)
+                    > LIGHTING_POSE_WARNING_TOLERANCE_DEG
+                }
+                self._last_pose_errors = pose_errors
+                blocking_errors = {
+                    joint: error
+                    for joint, error in pose_errors.items()
+                    if abs(error) > LIGHTING_POSE_ACCEPTANCE_TOLERANCE_DEG
+                }
+                if blocking_errors:
+                    raise RuntimeError(f"明显偏离照明姿态，关节误差：{blocking_errors}")
+                if pose_errors:
+                    logger.warning(
+                        "lighting_mode.pose_within_video_tolerance",
+                        errors=pose_errors,
+                        acceptance_tolerance_deg=LIGHTING_POSE_ACCEPTANCE_TOLERANCE_DEG,
+                    )
+
+                brightness = max(1, min(96, int(self._brightness())))
+                if not self._led.set_brightness(brightness):
+                    raise RuntimeError("照明姿态已到达，但 LED 亮度设置失败")
+                if not self._led.set_mode("white"):
+                    raise RuntimeError("照明姿态已到达，但白色灯光设置失败")
+
+                self._last_brightness = brightness
+                self._entered_at = time.time()
+                self._state = "active"
+                logger.info(
+                    "lighting_mode.entered",
+                    target=taught.joints,
+                    brightness=brightness,
+                    source=str(taught.source_path),
+                )
+                return SkillResult(
+                    status="ok",
+                    data={
+                        **self.snapshot(),
+                        "actual_pose": actual,
+                        "pose_warning": pose_errors,
+                        "source_frames": taught.source_frames,
+                        "settle_frames": taught.settle_frames,
+                    },
+                )
+            except asyncio.CancelledError:
+                self._state = "normal"
+                self._entered_at = None
+                self._last_exit_reason = "enter_cancelled"
+                raise
+            except Exception as exc:
+                self._state = "normal"
+                self._entered_at = None
+                self._last_error = str(exc)
+                logger.warning("lighting_mode.enter_failed", error=str(exc))
+                return SkillResult(status="error", message=str(exc), data=self.snapshot())
+
+    async def cancel_enter(self) -> None:
+        if self._state != "entering":
+            return
+        self._motion.stop_immediate()
+        self._led.off()
+        self._state = "normal"
+        self._entered_at = None
+        self._last_exit_reason = "enter_cancelled"
+
+    async def begin_exit(self, *, reason: str, force: bool = False) -> bool:
+        async with self._lock:
+            if not force and not self.is_engaged:
+                return False
+            self._state = "exiting"
+            self._last_exit_reason = str(reason or "user")
+            self._last_return_safe_status = "running"
+            self._deactivate_background_led()
+            if not self._led.off():
+                logger.warning("lighting_mode.led_off_failed", reason=reason)
+            logger.info("lighting_mode.exiting", reason=reason)
+            return True
+
+    async def finish_exit(self, *, return_safe_status: str, error: str = "") -> None:
+        async with self._lock:
+            self._state = "normal"
+            self._entered_at = None
+            self._last_return_safe_status = return_safe_status
+            self._last_error = str(error or "")
+            logger.info(
+                "lighting_mode.exited",
+                reason=self._last_exit_reason,
+                return_safe_status=return_safe_status,
+                error=error,
+            )
+
+    async def force_exit(self, *, reason: str, turn_off_led: bool = True) -> None:
+        """Leave mode without motion; used only for estop/shutdown/fault paths."""
+        async with self._lock:
+            if not self.is_engaged:
+                return
+            self._state = "normal"
+            self._entered_at = None
+            self._last_exit_reason = reason
+            self._last_return_safe_status = "skipped"
+            self._deactivate_background_led()
+            if turn_off_led:
+                self._led.off()
+            logger.info("lighting_mode.force_exited", reason=reason)

--- a/lampgo/server.py
+++ b/lampgo/server.py
@@ -41,10 +41,12 @@ from lampgo.core.hal import HardwareAbstraction, MotorStartupState
 from lampgo.core.led import LEDController
 from lampgo.core.motion import MotionRuntime
 from lampgo.core.safety import SafetyKernel
+from lampgo.core.types import InvokeResult
 from lampgo.core.virtual_motion import VirtualMotionRuntime
 from lampgo.device import Esp32DeviceManager
 from lampgo.electronic_ocean import ElectronicOceanController
 from lampgo.ipc import IPCServer
+from lampgo.lighting_mode import LightingModeController
 from lampgo.perception.cat_teaser import CatTeaserFrameSource, is_supported_local_camera_port
 from lampgo.perception.router import IntentRouter, IntentType
 from lampgo.recordings import (
@@ -60,6 +62,10 @@ from lampgo.skills.builtin.expression_skills import (
     ShowClockSkill,
     StartElectronicOceanSkill,
     StopElectronicOceanSkill,
+)
+from lampgo.skills.builtin.lighting_mode_skills import (
+    EnterLightingModeSkill,
+    ExitLightingModeSkill,
 )
 from lampgo.skills.builtin.motion_skills import EStopSkill, MoveToSkill, ReturnSafeSkill
 from lampgo.skills.builtin.music_skills import DanceToMusicSkill
@@ -123,11 +129,24 @@ class LampgoServer:
         self.fsm = StateMachine()
         self.registry = SkillRegistry()
         self.executor = SkillExecutor(self.registry, self.events)
+        self.lighting_mode = LightingModeController(
+            recordings_dir=Path(config.recordings_dir),
+            motion=self.motion,
+            led=self.led,
+            safety=self.safety,
+            hal=self.hal,
+            clock=self.clock,
+            electronic_ocean=self.electronic_ocean,
+            brightness=lambda: self.config.device_esp32.led_brightness,
+            no_hw=lambda: bool(self.config.no_hw),
+        )
+        self._lighting_entry_lock = asyncio.Lock()
+        self._lighting_exit_lock = asyncio.Lock()
         self.agent = AgentManager(
             self.events,
             api_base=f"http://127.0.0.1:{config.web.port}",
         )
-        self._agent_indicator = AgentLedIndicator(self.events, self.led.set_mode)
+        self._agent_indicator = AgentLedIndicator(self.events, self._set_agent_indicator_led)
         self.router = IntentRouter()
         self._stt: VolcengineASR = build_stt(config)
         self._ipc = IPCServer(self.handle_request, socket_path=config.socket_path)
@@ -170,6 +189,7 @@ class LampgoServer:
             self.motion.stop()
         self.motion = VirtualMotionRuntime(self.config.motion)
         self.motion.start()
+        self.lighting_mode.bind_runtime(self.motion, self.hal)
 
     def _resume_motion_after_recording(self) -> None:
         if self.config.no_hw or not self.hal.is_connected:
@@ -183,6 +203,8 @@ class LampgoServer:
         self.registry.register(ReturnSafeSkill())
         self.registry.register(EStopSkill())
         self.registry.register(PlayRecordingSkill(recordings_dir))
+        self.registry.register(EnterLightingModeSkill(self.lighting_mode))
+        self.registry.register(ExitLightingModeSkill(self.lighting_mode))
         self.registry.register(SetExpressionSkill())
         self.registry.register(ShowClockSkill())
         self.registry.register(StartElectronicOceanSkill())
@@ -270,6 +292,140 @@ class LampgoServer:
             electronic_ocean=self.electronic_ocean,
         )
 
+    def _set_agent_indicator_led(self, mode: str) -> bool:
+        if self.lighting_mode.blocks_automatic_led:
+            logger.info("lighting_mode.agent_led_suppressed", requested_mode=mode)
+            return True
+        return self.led.set_mode(mode)
+
+    async def _exit_lighting_mode_with_return_safe(self, *, reason: str) -> InvokeResult:
+        """Exit mode and invoke the registered return_safe skill exactly once."""
+        async with self._lighting_exit_lock:
+            was_engaged = self.lighting_mode.is_engaged
+            if not was_engaged:
+                return InvokeResult(
+                    invocation_id=uuid.uuid4().hex[:12],
+                    status="ok",
+                    result={
+                        "lighting_mode": self.lighting_mode.snapshot(),
+                        "already_inactive": True,
+                        "return_safe_invoked": False,
+                    },
+                )
+
+            # An in-progress enter may own the executor. Cancel it before
+            # beginning the standalone return_safe invocation.
+            await self.executor.cancel_current()
+            started = await self.lighting_mode.begin_exit(reason=reason, force=was_engaged)
+            if not started:
+                return InvokeResult(
+                    invocation_id=uuid.uuid4().hex[:12],
+                    status="ok",
+                    result={
+                        "lighting_mode": self.lighting_mode.snapshot(),
+                        "already_inactive": True,
+                        "return_safe_invoked": False,
+                    },
+                )
+
+            return_safe = await self.executor.invoke(
+                "return_safe",
+                self.make_context(),
+                velocity=60.0,
+            )
+            await self.lighting_mode.finish_exit(
+                return_safe_status=return_safe.status,
+                error=(return_safe.error_detail or "") if return_safe.status != "ok" else "",
+            )
+            return InvokeResult(
+                invocation_id=return_safe.invocation_id,
+                status=return_safe.status,
+                error_code=return_safe.error_code,
+                error_detail=return_safe.error_detail,
+                result={
+                    "lighting_mode": self.lighting_mode.snapshot(),
+                    "return_safe_invoked": True,
+                    "return_safe_invocation_id": return_safe.invocation_id,
+                    "return_safe": return_safe.result,
+                },
+            )
+
+    def _motor_recovery_detail(self) -> str:
+        recovery_error = str(getattr(self.motion, "recovery_error", "") or "").strip()
+        if recovery_error:
+            return recovery_error
+        recovery_reason = str(getattr(self.hal, "recovery_reason", "") or "").strip()
+        if recovery_reason:
+            return recovery_reason
+        return "上一次 return_safe 安全恢复未完成，机械臂当前仍在恢复保护状态"
+
+    async def _prepare_lighting_mode_entry(self) -> InvokeResult | None:
+        """Make an explicit lighting request cross the normal recovery gate safely."""
+        startup_state = getattr(self.hal, "startup_state", MotorStartupState.DISCONNECTED)
+        if startup_state is MotorStartupState.READY:
+            return None
+        if startup_state is MotorStartupState.RECOVERY_REQUIRED:
+            recovery = await self.executor.invoke(
+                "return_safe",
+                self.make_context(),
+                velocity=30.0,
+            )
+            if recovery.status == "ok":
+                return None
+            return InvokeResult(
+                invocation_id=recovery.invocation_id,
+                status=recovery.status,
+                error_code=recovery.error_code or "lighting_recovery_failed",
+                error_detail=recovery.error_detail or "进入照明模式前的 return_safe 失败",
+                result={
+                    "lighting_mode": self.lighting_mode.snapshot(),
+                    "recovery_before_lighting": recovery.result,
+                },
+            )
+        if startup_state is MotorStartupState.RECOVERING:
+            return InvokeResult(
+                invocation_id=uuid.uuid4().hex[:12],
+                status="rejected",
+                error_code="motor_recovery_incomplete",
+                error_detail=self._motor_recovery_detail(),
+                result={"lighting_mode": self.lighting_mode.snapshot()},
+            )
+        return InvokeResult(
+            invocation_id=uuid.uuid4().hex[:12],
+            status="rejected",
+            error_code="motor_not_ready",
+            error_detail=f"机械臂启动状态异常：{startup_state.value}",
+            result={"lighting_mode": self.lighting_mode.snapshot()},
+        )
+
+    async def _invoke_lampgo_skill(
+        self,
+        skill_id: str,
+        ctx: SkillContext,
+        *,
+        reason: str,
+        **params: Any,
+    ) -> InvokeResult:
+        if skill_id == "exit_lighting_mode":
+            return await self._exit_lighting_mode_with_return_safe(reason=reason)
+        if skill_id == "enter_lighting_mode":
+            # Keep recovery + pose entry atomic.  LLM retries or a double UI
+            # click must wait for the first request instead of cancelling its
+            # return_safe / lighting move halfway through.
+            async with self._lighting_entry_lock:
+                recovery = await self._prepare_lighting_mode_entry()
+                if recovery is not None:
+                    return recovery
+                return await self.executor.invoke(skill_id, ctx, **params)
+        if skill_id == "estop":
+            await self.lighting_mode.force_exit(reason="estop", turn_off_led=True)
+            return await self.executor.invoke(skill_id, ctx, **params)
+        if skill_id != "enter_lighting_mode" and self.lighting_mode.is_engaged:
+            exited = await self._exit_lighting_mode_with_return_safe(reason=reason)
+            if exited.status != "ok" or skill_id == "return_safe":
+                return exited
+        return await self.executor.invoke(skill_id, ctx, **params)
+
     async def _on_skill_started(self, event: SkillStarted) -> None:
         if event.skill_id == "idle_sway" and self._auto_idle_sway_invoking:
             return
@@ -316,6 +472,9 @@ class LampgoServer:
                 self._next_idle_sway_at = 0.0
                 continue
             if not self.motion.is_running or self.safety.is_estopped() or self._record_recorder is not None:
+                self._mark_foreground_activity()
+                continue
+            if self.lighting_mode.blocks_autonomous_motion:
                 self._mark_foreground_activity()
                 continue
             if self.executor.current_skill_id:
@@ -394,6 +553,8 @@ class LampgoServer:
         if cmd == "estop":
             self.safety.estop("IPC estop command")
             self.motion.stop_immediate()
+            await self.executor.cancel_current()
+            await self.lighting_mode.force_exit(reason="estop", turn_off_led=True)
             return {"ok": True, "result": {"status": "estopped"}}
 
         if cmd == "start_conversation":
@@ -516,7 +677,12 @@ class LampgoServer:
         ctx = self.make_context()
 
         if wait:
-            result = await self.executor.invoke(skill_id, ctx, **params)
+            result = await self._invoke_lampgo_skill(
+                skill_id,
+                ctx,
+                reason=f"invoke:{skill_id}",
+                **params,
+            )
             return {
                 "ok": result.status in ("ok", "cancelled"),
                 "result": {
@@ -528,7 +694,12 @@ class LampgoServer:
             }
 
         async def _bg():
-            await self.executor.invoke(skill_id, ctx, **params)
+            await self._invoke_lampgo_skill(
+                skill_id,
+                ctx,
+                reason=f"invoke:{skill_id}",
+                **params,
+            )
 
         asyncio.ensure_future(_bg())
         return {"ok": True, "result": {"status": "accepted", "skill_id": skill_id}}
@@ -539,6 +710,13 @@ class LampgoServer:
         The session samples HAL joint positions at a fixed FPS and buffers frames
         in memory until the caller stops + saves (or discards).
         """
+        if self.lighting_mode.is_engaged:
+            exited = await self._exit_lighting_mode_with_return_safe(reason="recording_start")
+            if exited.status != "ok":
+                return {
+                    "ok": False,
+                    "error": exited.error_detail or "退出照明模式并回到安全位失败",
+                }
         async with self._record_lock:
             if self.config.no_hw or not self.hal.is_connected:
                 return {"ok": False, "error": "hardware not connected"}
@@ -767,15 +945,27 @@ class LampgoServer:
             active_task.cancel()
             cancelled_llm = 1
         cancelled_tts = self.cancel_pending_tts()
-        await self.executor.cancel_current()
+        lighting_return_safe = 0
+        if self.lighting_mode.is_engaged:
+            lighting_exit = await self._exit_lighting_mode_with_return_safe(reason="cancel")
+            lighting_return_safe = int(
+                bool((lighting_exit.result or {}).get("return_safe_invoked"))
+            )
+        else:
+            await self.executor.cancel_current()
         logger.info(
             "server.stop_all_interactions",
             request_id=request_id,
             active_request_id=active_request_id,
             cancelled_llm=cancelled_llm,
             cancelled_tts=cancelled_tts,
+            lighting_return_safe=lighting_return_safe,
         )
-        return {"llm": cancelled_llm, "tts": cancelled_tts}
+        return {
+            "llm": cancelled_llm,
+            "tts": cancelled_tts,
+            "lighting_return_safe": lighting_return_safe,
+        }
 
     async def _handle_text(self, data: dict) -> dict:
         """Route free text through the IntentRouter, then invoke or reply."""
@@ -834,7 +1024,12 @@ class LampgoServer:
         alias = self._resolve_recording_alias(text)
         if alias:
             ctx = self.make_context()
-            result = await self.executor.invoke("play_recording", ctx, name=alias)
+            result = await self._invoke_lampgo_skill(
+                "play_recording",
+                ctx,
+                reason="voice_or_text_recording",
+                name=alias,
+            )
             return {
                 "ok": result.status in ("ok", "cancelled"),
                 "result": {
@@ -1012,7 +1207,12 @@ class LampgoServer:
         if intent.intent_type == IntentType.SKILL and intent.skill_id:
             ctx = self.make_context()
             params = intent.params or {}
-            result = await self.executor.invoke(intent.skill_id, ctx, **params)
+            result = await self._invoke_lampgo_skill(
+                intent.skill_id,
+                ctx,
+                reason=f"voice_or_text:{intent.skill_id}",
+                **params,
+            )
             return {
                 "ok": result.status in ("ok", "cancelled"),
                 "result": {
@@ -1178,7 +1378,12 @@ class LampgoServer:
             tool_name=tool_name,
             params=params,
         )
-        result = await self.executor.invoke(tool_name, self.make_context(), **params)
+        result = await self._invoke_lampgo_skill(
+            tool_name,
+            self.make_context(),
+            reason=f"agent_tool:{tool_name}",
+            **params,
+        )
         tool_payload = {
             "ok": result.status in ("ok", "cancelled"),
             "status": result.status,
@@ -1488,10 +1693,17 @@ class LampgoServer:
         health = "ok" if not self.safety.is_estopped() else "degraded"
         virtual = bool(getattr(self.motion, "is_virtual", False))
         motor_startup_state = self.hal.startup_state.value
-        recovery_error = self.hal.recovery_reason if self.hal.recovery_required else None
+        recovery_error = None
+        if self.hal.startup_state is MotorStartupState.RECOVERY_REQUIRED:
+            recovery_error = self.hal.recovery_reason or "Motor recovery is required."
+        elif self.hal.startup_state is MotorStartupState.RECOVERING:
+            recovery_error = self._motor_recovery_detail()
         if not self.hal.is_connected and not virtual:
             health = "disconnected"
-        if self._hal_startup_error or recovery_error:
+        if (
+            not virtual
+            and self.hal.startup_state is not MotorStartupState.READY
+        ) or self._hal_startup_error or recovery_error:
             health = "degraded"
         cat_teaser_camera = self._cat_teaser_camera_status()
         camera_ready = self._cat_teaser_camera_ready(cat_teaser_camera)
@@ -1511,6 +1723,7 @@ class LampgoServer:
                 "motor_startup_state": motor_startup_state,
                 "hardware_error": self._hal_startup_error or recovery_error,
                 "led_ready": bool(self.led.is_connected),
+                "lighting_mode": self.lighting_mode.snapshot(),
                 "camera_ready": camera_ready,
                 "cat_teaser_camera": cat_teaser_camera,
                 "conversation_state": self._wake_loop.conversation_state.value if self._wake_loop else None,
@@ -2086,6 +2299,7 @@ class LampgoServer:
             self.hal = new_hal
             self._hal_startup_error = None
             self.motion = MotionRuntime(self.hal, self.safety, self.config.motion)
+            self.lighting_mode.bind_runtime(self.motion, self.hal)
             self.config.no_hw = False
             if self.hal.recovery_required:
                 self.executor.set_motion_block_reason(
@@ -2214,6 +2428,7 @@ class LampgoServer:
         self._web_serve_task = None
         self._uvicorn_server = None
         await self._stop_idle_sway_scheduler()
+        await self.lighting_mode.force_exit(reason="shutdown", turn_off_led=True)
         async with self._record_lock:
             if self._record_recorder is not None and self._record_recorder.is_recording:
                 self._record_recorder.stop()

--- a/lampgo/skills/builtin/lighting_mode_skills.py
+++ b/lampgo/skills/builtin/lighting_mode_skills.py
@@ -1,0 +1,77 @@
+"""Factory skills for the persistent conventional desk-lamp mode."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lampgo.core.types import SkillResult
+from lampgo.lighting_mode import LightingModeController
+from lampgo.skills.base import Skill, SkillContext
+from lampgo.skills.builtin.motion_skills import ReturnSafeSkill
+
+
+class EnterLightingModeSkill(Skill):
+    skill_id = "enter_lighting_mode"
+    label = "启动照明模式"
+    description = (
+        "当用户明确要求启动或进入照明模式时调用。机械臂只移动一次到录制的照明姿态，"
+        "随后保持不动，并让 S3 LED 白色常亮。"
+    )
+    parameters = {}
+
+    def __init__(self, controller: LightingModeController) -> None:
+        self._controller = controller
+
+    async def execute(self, ctx: SkillContext, **params: Any) -> SkillResult:
+        del ctx, params
+        return await self._controller.enter()
+
+    async def cancel(self) -> None:
+        await self._controller.cancel_enter()
+
+
+class ExitLightingModeSkill(Skill):
+    """Fallback direct execution path.
+
+    Normal server invocations orchestrate this as two executor-visible steps:
+    leave mode, then invoke the registered ``return_safe`` skill exactly once.
+    This fallback keeps composed/direct skill execution safe as well.
+    """
+
+    skill_id = "exit_lighting_mode"
+    label = "退出照明模式"
+    description = (
+        "当用户明确要求退出或关闭照明模式时调用。服务端会关闭白色常亮，"
+        "并单独执行且只执行一次 return_safe。"
+    )
+    parameters = {}
+
+    def __init__(self, controller: LightingModeController) -> None:
+        self._controller = controller
+        self._return_safe = ReturnSafeSkill()
+
+    async def execute(self, ctx: SkillContext, **params: Any) -> SkillResult:
+        del params
+        started = await self._controller.begin_exit(reason="direct_skill")
+        if not started:
+            return SkillResult(
+                status="ok",
+                data={**self._controller.snapshot(), "already_inactive": True, "return_safe_invoked": False},
+            )
+        result = await self._return_safe.execute(ctx, velocity=60.0)
+        await self._controller.finish_exit(
+            return_safe_status=result.status,
+            error=result.message if result.status != "ok" else "",
+        )
+        return SkillResult(
+            status=result.status,
+            message=result.message,
+            data={
+                **self._controller.snapshot(),
+                "return_safe_invoked": True,
+                "return_safe": result.data,
+            },
+        )
+
+    async def cancel(self) -> None:
+        await self._return_safe.cancel()

--- a/lampgo/skills/builtin/motion_skills.py
+++ b/lampgo/skills/builtin/motion_skills.py
@@ -113,6 +113,17 @@ class ReturnSafeSkill(Skill):
         velocity = float(params.get("velocity", 60.0))
         safe = get_safe_position()
 
+        # ``recovery_required`` is false once HAL has transitioned from
+        # RECOVERY_REQUIRED to RECOVERING.  Treating that state as an ordinary
+        # move used to produce a false-positive ``ok`` for a duplicate
+        # return_safe while the original recovery was still active.
+        if bool(getattr(ctx.motion, "recovery_in_progress", False)):
+            detail = str(getattr(ctx.motion, "recovery_error", "") or "").strip()
+            return SkillResult(
+                status="error",
+                message=detail or "return_safe 安全恢复仍在执行，不能重复启动",
+            )
+
         if bool(getattr(ctx.motion, "recovery_required", False)):
             self._recovery_active = True
             logger.info(
@@ -160,6 +171,8 @@ class ReturnSafeSkill(Skill):
                 # releasing torque. The motor bus already enforces its torque
                 # limit, and ordinary software observations (lag, clipping or
                 # a completion mismatch) must not make a raised arm fall.
+                if hasattr(ctx.motion, "record_recovery_failure"):
+                    ctx.motion.record_recovery_failure(str(exc))
                 logger.warning(
                     "return_safe.recovery_failed_holding_torque",
                     error=str(exc),
@@ -190,6 +203,8 @@ class ReturnSafeSkill(Skill):
         if not await _await_done(done_event, timeout=60.0):
             logger.warning("return_safe.timeout")
             return SkillResult(status="error", message="Homing did not complete within timeout")
+        if hasattr(ctx.motion, "clear_recovery_failure"):
+            ctx.motion.clear_recovery_failure()
         logger.info("return_safe.done")
         return SkillResult(status="ok")
 
@@ -200,6 +215,8 @@ class ReturnSafeSkill(Skill):
             # Cancellation/pre-emption is not an emergency stop. Keep the
             # active servo goals and torque so the structure cannot fall.
             self._motion.stop_immediate()
+            if hasattr(self._motion, "record_recovery_failure"):
+                self._motion.record_recovery_failure("return_safe 安全恢复被新的动作中断")
             self._recovery_active = False
             return
         self._motion.stop_immediate()

--- a/lampgo/skills/executor.py
+++ b/lampgo/skills/executor.py
@@ -1,6 +1,7 @@
 """SkillExecutor — runs skills with cancel/timeout, enforces scheduling rules.
 
-M1 scheduling: simple last-writer-wins with estop/return_safe as highest priority.
+Normal skills use last-writer-wins scheduling.  Positive-priority safety skills
+cannot be pre-empted by a skill with equal or lower priority.
 """
 
 from __future__ import annotations
@@ -36,7 +37,7 @@ _LED_SKILLS = {
 
 
 class SkillExecutor:
-    """Runs one skill at a time. New invocations cancel the current skill."""
+    """Run one skill at a time while preserving safety-skill priority."""
 
     def __init__(self, registry: SkillRegistry, events: EventBus) -> None:
         self._registry = registry
@@ -115,10 +116,33 @@ class SkillExecutor:
                 ctx.electronic_ocean.deactivate()
 
         async with self._lock:
-            # Cancel current skill if running. This gives rapid UI clicks
-            # last-writer-wins semantics without leaving old skill coroutines
-            # around to run their own cleanup motions later.
+            # Normal skills keep rapid-click last-writer-wins semantics.  A
+            # positive-priority safety skill, however, must finish unless the
+            # replacement has strictly higher priority (estop may interrupt
+            # return_safe; idle_sway, duplicate return_safe, and ordinary LLM
+            # tools may not).
             if self._current_task is not None and not self._current_task.done():
+                current_skill = self._current_skill
+                current_priority = int(getattr(current_skill, "priority", 0) or 0)
+                incoming_priority = int(getattr(skill, "priority", 0) or 0)
+                if current_priority > 0 and incoming_priority <= current_priority:
+                    current_skill_id = current_skill.skill_id if current_skill is not None else "unknown"
+                    logger.warning(
+                        "executor.preemption_rejected",
+                        current_skill_id=current_skill_id,
+                        current_priority=current_priority,
+                        incoming_skill_id=skill_id,
+                        incoming_priority=incoming_priority,
+                    )
+                    return InvokeResult(
+                        invocation_id=invocation_id,
+                        status="rejected",
+                        error_code="priority_skill_running",
+                        error_detail=(
+                            f"{current_skill_id} 安全动作正在执行，"
+                            f"{skill_id} 不能中断它"
+                        ),
+                    )
                 await self._cancel_current_locked()
 
             self._current_skill = skill

--- a/lampgo/web/gateway.py
+++ b/lampgo/web/gateway.py
@@ -675,6 +675,21 @@ class WebGateway:
                 result["error"] = nested_error
         return JSONResponse(result)
 
+    async def _preempt_lighting_mode(self, reason: str) -> JSONResponse | None:
+        if not self.server.lighting_mode.is_engaged:
+            return None
+        result = await self.server._exit_lighting_mode_with_return_safe(reason=reason)
+        if result.status == "ok":
+            return None
+        return JSONResponse(
+            {
+                "ok": False,
+                "error": result.error_detail or "退出照明模式并回到安全位失败",
+                "result": result.result,
+            },
+            status_code=503,
+        )
+
     async def api_status(self, request: Request) -> JSONResponse:
         result = self.server._handle_status()
         return JSONResponse(result)
@@ -1175,6 +1190,9 @@ class WebGateway:
         return status, response
 
     async def api_expression_play(self, request: Request) -> JSONResponse:
+        blocked = await self._preempt_lighting_mode("expression_play")
+        if blocked is not None:
+            return blocked
         try:
             body = await request.json()
             composition = resolve_expression(body)
@@ -1200,6 +1218,9 @@ class WebGateway:
         return JSONResponse({"ok": True, "result": self.server.clock.snapshot()})
 
     async def api_clock_show(self, request: Request) -> JSONResponse:
+        blocked = await self._preempt_lighting_mode("clock_show")
+        if blocked is not None:
+            return blocked
         try:
             body = await request.json()
         except Exception:
@@ -1225,6 +1246,9 @@ class WebGateway:
         return JSONResponse({"ok": True, "result": self.server.electronic_ocean.snapshot()})
 
     async def api_electronic_ocean_start(self, request: Request) -> JSONResponse:
+        blocked = await self._preempt_lighting_mode("electronic_ocean_start")
+        if blocked is not None:
+            return blocked
         try:
             body = await request.json()
         except Exception:
@@ -2814,6 +2838,10 @@ class WebGateway:
                 except Exception:
                     body = {"ok": False, "error": "non_json_response"}
             return JSONResponse(self._with_expression_catalog(body), status_code=status)
+
+        blocked = await self._preempt_lighting_mode("device_led")
+        if blocked is not None:
+            return blocked
 
         try:
             patch = await request.json()

--- a/lampgo/web/static/app.js
+++ b/lampgo/web/static/app.js
@@ -121,6 +121,8 @@
   const btnMic = document.getElementById("btn-mic");
   const btnVoiceCancel = document.getElementById("btn-voice-cancel");
   const btnStop = document.getElementById("btn-stop");
+  const btnLightingMode = document.getElementById("btn-lighting-mode");
+  const lightingModeLabel = document.getElementById("lighting-mode-label");
   const btnMusicMode = document.getElementById("btn-music-mode");
   const musicStyleSelect = document.getElementById("music-style-select");
   const musicModeLabel = document.getElementById("music-mode-label");
@@ -244,6 +246,8 @@
     cat_teaser: { title: "逗猫棒互动", description: "识别逗猫棒彩色标记，根据猫咪互动状态实时摆动。" },
     move_to: { title: "移动到目标", description: "以平滑的梯形插值移动到目标关节位置。" },
     return_safe: { title: "回到安全位", description: "平滑回到固定的待机安全姿态。" },
+    enter_lighting_mode: { title: "启动照明模式", description: "移动到录制的照明姿态并保持白色灯光。" },
+    exit_lighting_mode: { title: "退出照明模式", description: "退出照明并单独回到安全位一次。" },
     presence_react: { title: "人来反应", description: "检测到人时转向并展示问候表情。" },
     face_follow: { title: "人脸跟随", description: "持续调整偏航与俯仰，跟踪人脸。" },
     teleop_mouse: { title: "鼠标遥操作", description: "用手臂当作鼠标控制光标。" },
@@ -803,6 +807,7 @@
   let recordTimerTask = null;
   let recordingFps = 30;
   let recordingFrames = 0;
+  let lightingModeRequestId = null;
   let musicModeRequestId = null;
 
   let sessions = [];
@@ -2424,7 +2429,9 @@
   function send(obj) {
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify(obj));
+      return true;
     }
+    return false;
   }
 
   function handleMessage(msg) {
@@ -3083,6 +3090,7 @@
     if (catTeaserDialog && catTeaserDialog.open) renderCatTeaserHardwareNotice();
 
     if (isJointPopoverOpen()) renderJointPopoverContent();
+    setLightingModeState(data.lighting_mode || {});
     if (data.running_skill === "dance_to_music") {
       setMusicModeActive(true);
     } else if (!data.is_busy && musicModeRequestId) {
@@ -5141,6 +5149,54 @@
     send({ type: "invoke", skill_id: skillId, params: params || {}, wait: true, request_id: requestId });
   }
 
+  function setLightingModeState(mode = {}) {
+    const state = String(mode.state || "normal");
+    const active = state === "active";
+    const transitioning = state === "entering" || state === "exiting" || Boolean(lightingModeRequestId);
+    if (!btnLightingMode) return;
+    btnLightingMode.classList.toggle("is-active", active);
+    btnLightingMode.classList.toggle("is-pending", transitioning);
+    btnLightingMode.setAttribute("aria-pressed", active ? "true" : "false");
+    btnLightingMode.disabled = transitioning;
+    btnLightingMode.title = active
+      ? "退出照明模式；退出后会单独回到安全位一次"
+      : state === "entering"
+        ? "正在移动到照明姿态"
+        : state === "exiting"
+          ? "正在退出并回到安全位"
+          : "移动到录制的照明姿态并保持白色灯光";
+    if (lightingModeLabel) {
+      lightingModeLabel.textContent = state === "entering"
+        ? "正在进入…"
+        : state === "exiting"
+          ? "正在退出…"
+          : active
+            ? "退出照明"
+            : "照明模式";
+    }
+  }
+
+  function toggleLightingMode() {
+    if (!btnLightingMode || lightingModeRequestId) return;
+    const mode = (latestStatusData && latestStatusData.lighting_mode) || {};
+    const exiting = mode.active || mode.engaged || btnLightingMode.classList.contains("is-active");
+    const skillId = exiting ? "exit_lighting_mode" : "enter_lighting_mode";
+    const requestId = nextId();
+    const bubble = addAssistantBubble(requestId);
+    lightingModeRequestId = requestId;
+    setLightingModeState({ state: exiting ? "exiting" : "entering" });
+    addStep(
+      getPreludeArea(ensureActivityLog(bubble)),
+      exiting ? "退出照明模式并回到安全位" : "进入台灯常规模式",
+      "active",
+    );
+    if (!send({ type: "invoke", skill_id: skillId, params: {}, wait: true, request_id: requestId })) {
+      lightingModeRequestId = null;
+      setLightingModeState(mode);
+      finishPending({ ok: false, error: "后端连接未就绪", request_id: requestId });
+    }
+  }
+
   function setMusicModeActive(active, requestId = null) {
     const isActive = !!active;
     if (isActive && requestId) musicModeRequestId = requestId;
@@ -5660,6 +5716,17 @@
     }
     if (msg.request_id === musicModeRequestId) {
       setMusicModeActive(false);
+    }
+    if (msg.request_id === lightingModeRequestId) {
+      lightingModeRequestId = null;
+      const data = (msg.result && msg.result.data) || {};
+      const mode = data.lighting_mode || (data.name === "lighting" ? data : null);
+      if (mode) setLightingModeState(mode);
+      else setLightingModeState((latestStatusData && latestStatusData.lighting_mode) || {});
+      if (msg.ok && msg.result && msg.result.status === "ok") {
+        addSystemMessage(data.return_safe_invoked ? "已退出照明模式并回到安全位" : "已进入照明模式");
+      }
+      send({ type: "status", request_id: `lighting_status_${Date.now()}` });
     }
 
     const isPreempted = !!(result.preempted);
@@ -6308,6 +6375,10 @@
 
   if (btnMusicMode) {
     btnMusicMode.addEventListener("click", toggleMusicMode);
+  }
+
+  if (btnLightingMode) {
+    btnLightingMode.addEventListener("click", toggleLightingMode);
   }
 
   btnEstop.addEventListener("click", () => {

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>YareLampGo 控制台</title>
   <link rel="icon" href="/%E5%8F%B0%E7%81%AF%E8%99%BE%E5%A4%B4%E5%83%8F.jpeg">
-  <link rel="stylesheet" href="/style.css?v=clock-prominent-20260721">
+  <link rel="stylesheet" href="/style.css?v=lighting-mode-safety-20260803">
   <link rel="stylesheet" href="/setup.css?v=secret-inputs-20260602">
 </head>
 <body>
@@ -139,6 +139,12 @@
         </div>
 
         <div class="topbar-right">
+          <button id="btn-lighting-mode" class="ghost-button lighting-mode-button" type="button" aria-pressed="false" title="移动到录制的照明姿态并保持白色灯光">
+            <span class="lighting-mode-icon" aria-hidden="true">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7V17h8v-2.3A7 7 0 0 0 12 2z"/></svg>
+            </span>
+            <span id="lighting-mode-label">照明模式</span>
+          </button>
           <label class="music-style-control" title="选择音乐律动风格">
             <span class="music-style-label">风格</span>
             <select id="music-style-select" class="music-style-select" aria-label="音乐律动风格">
@@ -1523,7 +1529,7 @@
     </div>
   </dialog>
 
-  <script src="/app.js?v=electronic-ocean-impact-20260721"></script>
+  <script src="/app.js?v=lighting-mode-safety-20260803"></script>
   <script type="module" src="/pet.js?v=19"></script>
   <script src="/setup.js?v=secret-inputs-20260602"></script>
 </body>

--- a/lampgo/web/static/index.html
+++ b/lampgo/web/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>YareLampGo 控制台</title>
   <link rel="icon" href="/%E5%8F%B0%E7%81%AF%E8%99%BE%E5%A4%B4%E5%83%8F.jpeg">
-  <link rel="stylesheet" href="/style.css?v=lighting-mode-safety-20260803">
+  <link rel="stylesheet" href="/style.css?v=feature-batch-20260803">
   <link rel="stylesheet" href="/setup.css?v=secret-inputs-20260602">
 </head>
 <body>
@@ -1529,7 +1529,7 @@
     </div>
   </dialog>
 
-  <script src="/app.js?v=lighting-mode-safety-20260803"></script>
+  <script src="/app.js?v=feature-batch-20260803"></script>
   <script type="module" src="/pet.js?v=19"></script>
   <script src="/setup.js?v=secret-inputs-20260602"></script>
 </body>

--- a/lampgo/web/static/style.css
+++ b/lampgo/web/static/style.css
@@ -840,6 +840,29 @@ button {
   color: #6b5f4a;
 }
 
+.lighting-mode-button {
+  gap: 7px;
+  padding: 0 12px;
+  color: #5f594c;
+  transition: color 160ms ease, background 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.lighting-mode-icon {
+  display: inline-flex;
+}
+
+.lighting-mode-button.is-active {
+  color: #7a5115;
+  background: #fff7d8;
+  border-color: rgba(217, 157, 49, 0.5);
+  box-shadow: 0 0 0 3px rgba(246, 194, 83, 0.17), 0 0 18px rgba(255, 203, 83, 0.2);
+}
+
+.lighting-mode-button.is-pending {
+  cursor: progress;
+  opacity: 0.72;
+}
+
 .music-mode-icon {
   display: inline-flex;
 }
@@ -4063,9 +4086,14 @@ button.device-chip.is-active {
     padding: 8px 12px;
   }
 
+  .lighting-mode-button,
   .music-mode-button {
     width: 34px;
     padding: 0;
+  }
+
+  #lighting-mode-label {
+    display: none;
   }
 
   .music-style-control {

--- a/tests/test_lighting_mode.py
+++ b/tests/test_lighting_mode.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+import asyncio
+import csv
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from lampgo.core.hal import MotorStartupState
+from lampgo.core.types import JOINT_NAMES, InvokeResult, JointState
+from lampgo.lighting_mode import LightingModeController, load_taught_lighting_pose
+from lampgo.server import LampgoServer
+from lampgo.skills.builtin.lighting_mode_skills import (
+    EnterLightingModeSkill,
+    ExitLightingModeSkill,
+)
+
+TARGET_POSE = {
+    "base_yaw": 1.1,
+    "base_pitch": -2.24,
+    "elbow_pitch": 10.55,
+    "wrist_roll": 55.91,
+    "wrist_pitch": 2.42,
+}
+
+
+def _write_recording(path: Path, *, unstable_tail: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = ["timestamp", *(f"{joint}.pos" for joint in JOINT_NAMES)]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for index in range(120):
+            settled = index >= 80
+            row = {"timestamp": index / 10.0}
+            for joint_index, joint in enumerate(JOINT_NAMES):
+                if settled:
+                    value = TARGET_POSE[joint]
+                    if unstable_tail and joint == "wrist_roll":
+                        value += (index - 80) * 0.1
+                else:
+                    value = TARGET_POSE[joint] + 8.0 - index * 0.1 + joint_index
+                row[f"{joint}.pos"] = value
+            writer.writerow(row)
+
+
+def test_taught_pose_uses_stable_tail_instead_of_replaying_trajectory(tmp_path: Path) -> None:
+    source = tmp_path / "user" / "照明模式.csv"
+    _write_recording(source)
+
+    taught = load_taught_lighting_pose(tmp_path)
+
+    assert taught.source_path == source
+    assert taught.source_frames == 120
+    assert taught.settle_frames >= 30
+    assert taught.joints == pytest.approx(TARGET_POSE)
+
+
+def test_taught_pose_rejects_a_recording_that_is_still_moving(tmp_path: Path) -> None:
+    _write_recording(tmp_path / "user" / "照明模式.csv", unstable_tail=True)
+
+    with pytest.raises(ValueError, match="末段仍在移动.*wrist_roll"):
+        load_taught_lighting_pose(tmp_path)
+
+
+class _Motion:
+    is_virtual = False
+
+    def __init__(
+        self,
+        *,
+        running: bool = True,
+        position_offsets: dict[str, float] | None = None,
+    ) -> None:
+        self.is_running = running
+        self.targets = []
+        self.current_state = JointState({joint: 0.0 for joint in JOINT_NAMES})
+        self.stopped = False
+        self.start_calls = 0
+        self.recovery_error = None
+        self.position_offsets = dict(position_offsets or {})
+
+    def start(self) -> None:
+        self.start_calls += 1
+        self.is_running = True
+
+    def move_to(self, target):
+        self.targets.append(target)
+        self.current_state = JointState(
+            {
+                joint: value + self.position_offsets.get(joint, 0.0)
+                for joint, value in target.joints.items()
+            }
+        )
+        done = threading.Event()
+        done.set()
+        return done
+
+    def stop_immediate(self) -> None:
+        self.stopped = True
+
+
+class _Led:
+    is_connected = True
+
+    def __init__(self) -> None:
+        self.brightness = []
+        self.modes = []
+        self.off_calls = 0
+
+    def set_brightness(self, level: int) -> bool:
+        self.brightness.append(level)
+        return True
+
+    def set_mode(self, mode: str) -> bool:
+        self.modes.append(mode)
+        return True
+
+    def off(self) -> bool:
+        self.off_calls += 1
+        return True
+
+
+class _Safety:
+    @staticmethod
+    def is_estopped() -> bool:
+        return False
+
+
+class _Hal:
+    is_connected = True
+    recovery_required = False
+    recovery_reason = None
+    startup_state = MotorStartupState.READY
+
+
+class _BackgroundEffect:
+    def __init__(self) -> None:
+        self.deactivate_calls = 0
+
+    def deactivate(self) -> None:
+        self.deactivate_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_enter_moves_once_then_holds_white_light(tmp_path: Path) -> None:
+    _write_recording(tmp_path / "user" / "照明模式.csv")
+    motion = _Motion()
+    led = _Led()
+    clock = _BackgroundEffect()
+    ocean = _BackgroundEffect()
+    controller = LightingModeController(
+        recordings_dir=tmp_path,
+        motion=motion,
+        led=led,
+        safety=_Safety(),
+        hal=_Hal(),
+        clock=clock,
+        electronic_ocean=ocean,
+        brightness=lambda: 120,
+        no_hw=lambda: False,
+    )
+
+    result = await controller.enter()
+    repeated = await controller.enter()
+
+    assert result.status == "ok"
+    assert repeated.status == "ok"
+    assert repeated.data["already_active"] is True
+    assert controller.is_active is True
+    assert len(motion.targets) == 1
+    assert motion.targets[0].joints == pytest.approx(TARGET_POSE)
+    assert motion.targets[0].max_velocity == 30.0
+    assert motion.targets[0].anticipation is False
+    assert led.brightness == [96]
+    assert led.modes == ["white"]
+    assert clock.deactivate_calls == 1
+    assert ocean.deactivate_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_video_pose_accepts_a_four_degree_loaded_elbow_residual(tmp_path: Path) -> None:
+    _write_recording(tmp_path / "user" / "照明模式.csv")
+    motion = _Motion(position_offsets={"elbow_pitch": 4.13})
+    led = _Led()
+    controller = LightingModeController(
+        recordings_dir=tmp_path,
+        motion=motion,
+        led=led,
+        safety=_Safety(),
+        hal=_Hal(),
+        clock=None,
+        electronic_ocean=None,
+        brightness=lambda: 32,
+        no_hw=lambda: False,
+    )
+
+    result = await controller.enter()
+
+    assert result.status == "ok"
+    assert result.data["pose_warning"] == {"elbow_pitch": 4.13}
+    assert controller.is_active is True
+    assert led.modes == ["white"]
+
+
+@pytest.mark.asyncio
+async def test_video_pose_still_rejects_a_clearly_wrong_pose(tmp_path: Path) -> None:
+    _write_recording(tmp_path / "user" / "照明模式.csv")
+    motion = _Motion(position_offsets={"elbow_pitch": 8.01})
+    controller = LightingModeController(
+        recordings_dir=tmp_path,
+        motion=motion,
+        led=_Led(),
+        safety=_Safety(),
+        hal=_Hal(),
+        clock=None,
+        electronic_ocean=None,
+        brightness=lambda: 32,
+        no_hw=lambda: False,
+    )
+
+    result = await controller.enter()
+
+    assert result.status == "error"
+    assert "明显偏离照明姿态" in result.message
+    assert result.data["pose_errors"] == {"elbow_pitch": 8.01}
+
+
+@pytest.mark.asyncio
+async def test_enter_repairs_a_stopped_runtime_when_hal_is_ready(tmp_path: Path) -> None:
+    _write_recording(tmp_path / "user" / "照明模式.csv")
+    motion = _Motion(running=False)
+    controller = LightingModeController(
+        recordings_dir=tmp_path,
+        motion=motion,
+        led=_Led(),
+        safety=_Safety(),
+        hal=_Hal(),
+        clock=None,
+        electronic_ocean=None,
+        brightness=lambda: 32,
+        no_hw=lambda: False,
+    )
+
+    result = await controller.enter()
+
+    assert result.status == "ok"
+    assert motion.start_calls == 1
+    assert len(motion.targets) == 1
+
+
+@pytest.mark.asyncio
+async def test_enter_does_not_bypass_an_incomplete_recovery(tmp_path: Path) -> None:
+    _write_recording(tmp_path / "user" / "照明模式.csv")
+    motion = _Motion(running=False)
+    motion.recovery_error = "elbow_pitch recovery stalled"
+    hal = _Hal()
+    hal.startup_state = MotorStartupState.RECOVERING
+    controller = LightingModeController(
+        recordings_dir=tmp_path,
+        motion=motion,
+        led=_Led(),
+        safety=_Safety(),
+        hal=hal,
+        clock=None,
+        electronic_ocean=None,
+        brightness=lambda: 32,
+        no_hw=lambda: False,
+    )
+
+    result = await controller.enter()
+
+    assert result.status == "error"
+    assert result.message == "elbow_pitch recovery stalled"
+    assert motion.start_calls == 0
+    assert motion.targets == []
+
+
+class _LightingState:
+    def __init__(self) -> None:
+        self.state = "active"
+        self.begin_exit_calls = 0
+        self.finish_exit_calls = 0
+
+    @property
+    def is_engaged(self) -> bool:
+        return self.state in {"entering", "active", "exiting"}
+
+    async def begin_exit(self, *, reason: str, force: bool = False) -> bool:
+        del reason, force
+        if not self.is_engaged:
+            return False
+        self.begin_exit_calls += 1
+        self.state = "exiting"
+        return True
+
+    async def finish_exit(self, *, return_safe_status: str, error: str = "") -> None:
+        del return_safe_status, error
+        self.finish_exit_calls += 1
+        self.state = "normal"
+
+    def snapshot(self) -> dict:
+        return {"state": self.state, "active": self.state == "active"}
+
+
+class _Executor:
+    def __init__(self) -> None:
+        self.invocations = []
+        self.cancel_calls = 0
+
+    async def cancel_current(self) -> None:
+        self.cancel_calls += 1
+
+    async def invoke(self, skill_id: str, _ctx, **params) -> InvokeResult:
+        self.invocations.append((skill_id, params))
+        await asyncio.sleep(0)
+        return InvokeResult(
+            invocation_id=f"inv-{len(self.invocations)}",
+            status="ok",
+            result={"skill_id": skill_id},
+        )
+
+
+def _server_shell() -> LampgoServer:
+    server = object.__new__(LampgoServer)
+    server._lighting_entry_lock = asyncio.Lock()
+    server._lighting_exit_lock = asyncio.Lock()
+    server.lighting_mode = _LightingState()
+    server.executor = _Executor()
+    server.hal = SimpleNamespace(
+        startup_state=MotorStartupState.READY,
+        recovery_reason=None,
+    )
+    server.motion = SimpleNamespace(recovery_error=None)
+    server.make_context = lambda: object()
+    return server
+
+
+@pytest.mark.asyncio
+async def test_explicit_exit_runs_standalone_return_safe_exactly_once() -> None:
+    server = _server_shell()
+
+    first, second = await asyncio.gather(
+        server._exit_lighting_mode_with_return_safe(reason="llm_exit"),
+        server._exit_lighting_mode_with_return_safe(reason="duplicate_exit"),
+    )
+
+    assert [skill_id for skill_id, _params in server.executor.invocations] == ["return_safe"]
+    assert server.executor.invocations[0][1] == {"velocity": 60.0}
+    assert server.lighting_mode.begin_exit_calls == 1
+    assert server.lighting_mode.finish_exit_calls == 1
+    assert first.result["return_safe_invoked"] is True
+    assert second.result["return_safe_invoked"] is False
+
+
+@pytest.mark.asyncio
+async def test_llm_tool_operation_preempts_mode_before_running_requested_skill() -> None:
+    server = _server_shell()
+
+    result = await server._invoke_lampgo_skill(
+        "nod",
+        object(),
+        reason="agent_tool:nod",
+    )
+
+    assert result.status == "ok"
+    assert [skill_id for skill_id, _params in server.executor.invocations] == [
+        "return_safe",
+        "nod",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_lighting_entry_runs_recovery_first_when_required() -> None:
+    server = _server_shell()
+    server.hal.startup_state = MotorStartupState.RECOVERY_REQUIRED
+
+    result = await server._invoke_lampgo_skill(
+        "enter_lighting_mode",
+        object(),
+        reason="agent_tool:enter_lighting_mode",
+    )
+
+    assert result.status == "ok"
+    assert [skill_id for skill_id, _params in server.executor.invocations] == [
+        "return_safe",
+        "enter_lighting_mode",
+    ]
+    assert server.executor.invocations[0][1] == {"velocity": 30.0}
+
+
+@pytest.mark.asyncio
+async def test_lighting_entry_reports_incomplete_recovery_instead_of_runtime_error() -> None:
+    server = _server_shell()
+    server.hal.startup_state = MotorStartupState.RECOVERING
+    server.motion.recovery_error = "base_pitch recovery stalled"
+
+    result = await server._invoke_lampgo_skill(
+        "enter_lighting_mode",
+        object(),
+        reason="agent_tool:enter_lighting_mode",
+    )
+
+    assert result.status == "rejected"
+    assert result.error_code == "motor_recovery_incomplete"
+    assert result.error_detail == "base_pitch recovery stalled"
+    assert server.executor.invocations == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_lighting_entries_are_serialized() -> None:
+    class BlockingEntryExecutor(_Executor):
+        def __init__(self) -> None:
+            super().__init__()
+            self.active_entries = 0
+            self.max_active_entries = 0
+
+        async def invoke(self, skill_id: str, _ctx, **params) -> InvokeResult:
+            self.invocations.append((skill_id, params))
+            if skill_id == "enter_lighting_mode":
+                self.active_entries += 1
+                self.max_active_entries = max(self.max_active_entries, self.active_entries)
+                await asyncio.sleep(0.01)
+                self.active_entries -= 1
+            return InvokeResult(
+                invocation_id=f"inv-{len(self.invocations)}",
+                status="ok",
+                result={"skill_id": skill_id},
+            )
+
+    server = _server_shell()
+    server.executor = BlockingEntryExecutor()
+
+    first, second = await asyncio.gather(
+        server._invoke_lampgo_skill(
+            "enter_lighting_mode",
+            object(),
+            reason="first_enter",
+        ),
+        server._invoke_lampgo_skill(
+            "enter_lighting_mode",
+            object(),
+            reason="duplicate_enter",
+        ),
+    )
+
+    assert first.status == "ok"
+    assert second.status == "ok"
+    assert server.executor.max_active_entries == 1
+    assert [skill_id for skill_id, _params in server.executor.invocations] == [
+        "enter_lighting_mode",
+        "enter_lighting_mode",
+    ]
+
+
+def test_lighting_tools_tell_the_llm_when_to_enter_and_exit() -> None:
+    assert "用户明确要求启动或进入照明模式" in EnterLightingModeSkill.description
+    assert "用户明确要求退出或关闭照明模式" in ExitLightingModeSkill.description
+    assert "只执行一次 return_safe" in ExitLightingModeSkill.description

--- a/tests/test_lighting_mode_frontend.py
+++ b/tests/test_lighting_mode_frontend.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_JS = (ROOT / "lampgo/web/static/app.js").read_text(encoding="utf-8")
+INDEX_HTML = (ROOT / "lampgo/web/static/index.html").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "lampgo/web/static/style.css").read_text(encoding="utf-8")
+
+
+def test_frontend_has_a_single_lighting_mode_toggle() -> None:
+    assert 'id="btn-lighting-mode"' in INDEX_HTML
+    assert 'id="lighting-mode-label"' in INDEX_HTML
+    assert 'aria-pressed="false"' in INDEX_HTML
+    assert 'skillId = exiting ? "exit_lighting_mode" : "enter_lighting_mode";' in APP_JS
+    assert 'btnLightingMode.addEventListener("click", toggleLightingMode);' in APP_JS
+
+
+def test_frontend_reflects_backend_mode_state_and_return_safe_completion() -> None:
+    assert "setLightingModeState(data.lighting_mode || {});" in APP_JS
+    assert 'data.return_safe_invoked ? "已退出照明模式并回到安全位"' in APP_JS
+    assert ".lighting-mode-button.is-active" in STYLE_CSS
+    assert ".lighting-mode-button.is-pending" in STYLE_CSS
+
+
+def test_frontend_detects_when_the_lighting_request_cannot_be_sent() -> None:
+    assert "ws.send(JSON.stringify(obj));\n      return true;" in APP_JS
+    assert "return false;\n  }\n\n  function handleMessage" in APP_JS
+    assert 'if (!send({ type: "invoke", skill_id: skillId' in APP_JS

--- a/tests/test_motion_skills.py
+++ b/tests/test_motion_skills.py
@@ -190,6 +190,7 @@ def test_return_safe_recovery_error_keeps_torque_enabled():
             self.recovery_error = "Recovery feedback watchdog stopped motion: base_pitch stalled"
             self.current_state = SimpleNamespace(positions=get_safe_position())
             self.aborted = False
+            self.recorded_failure = None
 
         def prepare_recovery(self, target, *, max_velocity, fps):
             del max_velocity, fps
@@ -209,6 +210,9 @@ def test_return_safe_recovery_error_keeps_torque_enabled():
         def stop_immediate(self):
             pass
 
+        def record_recovery_failure(self, reason):
+            self.recorded_failure = reason
+
     async def run() -> None:
         motion = FailedRecoveryMotion()
         result = await ReturnSafeSkill().execute(SimpleNamespace(motion=motion), velocity=60.0)
@@ -216,6 +220,7 @@ def test_return_safe_recovery_error_keeps_torque_enabled():
         assert result.status == "error"
         assert "feedback watchdog" in result.message
         assert motion.aborted is False
+        assert motion.recorded_failure == result.message
 
     asyncio.run(run())
 
@@ -268,6 +273,82 @@ def test_executor_preempts_running_skill():
         assert second.status == "ok"
         assert second.result == {"ran": True}
         assert executor.is_busy is False
+
+    asyncio.run(run())
+
+
+def test_return_safe_cannot_be_preempted_by_idle_or_duplicate_recovery():
+    class BlockingReturnSafe(Skill):
+        skill_id = "return_safe"
+        priority = 90
+
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+            self.cancelled = False
+
+        async def execute(self, ctx, **params):
+            del ctx, params
+            self.started.set()
+            await self.release.wait()
+            return SkillResult(status="ok", data={"recovered": True})
+
+        async def cancel(self) -> None:
+            self.cancelled = True
+
+    class FakeIdleSway(Skill):
+        skill_id = "idle_sway"
+
+        async def execute(self, ctx, **params):
+            del ctx, params
+            raise AssertionError("idle sway must not run during return_safe")
+
+    async def run() -> None:
+        return_safe = BlockingReturnSafe()
+        registry = SkillRegistry()
+        registry.register(return_safe)
+        registry.register(FakeIdleSway())
+        executor = SkillExecutor(registry, EventBus())
+        ctx = SimpleNamespace(
+            motion=SimpleNamespace(is_running=True, recovery_required=False),
+            led=SimpleNamespace(is_connected=True),
+            clock=None,
+            electronic_ocean=None,
+        )
+
+        active = asyncio.create_task(executor.invoke("return_safe", ctx))
+        await return_safe.started.wait()
+
+        idle = await executor.invoke("idle_sway", ctx)
+        duplicate = await executor.invoke("return_safe", ctx)
+
+        assert idle.status == "rejected"
+        assert idle.error_code == "priority_skill_running"
+        assert duplicate.status == "rejected"
+        assert duplicate.error_code == "priority_skill_running"
+        assert return_safe.cancelled is False
+
+        return_safe.release.set()
+        result = await active
+        assert result.status == "ok"
+
+    asyncio.run(run())
+
+
+def test_return_safe_rejects_an_already_in_progress_recovery():
+    async def run() -> None:
+        motion = SimpleNamespace(
+            recovery_in_progress=True,
+            recovery_required=False,
+            recovery_error="return_safe 安全恢复被新的动作中断",
+        )
+
+        result = await ReturnSafeSkill().execute(SimpleNamespace(motion=motion))
+
+        assert result.status == "error"
+        assert result.message == "return_safe 安全恢复被新的动作中断"
+
+    from lampgo.skills.builtin.motion_skills import ReturnSafeSkill
 
     asyncio.run(run())
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -52,3 +52,10 @@ def test_dj_music_keyword_normalizes_case():
     assert intent.intent_type is IntentType.SKILL
     assert intent.skill_id == "dance_to_music"
     assert intent.params == {"style": "dj"}
+
+
+def test_lighting_mode_phrase_is_left_for_the_llm_to_decide():
+    intent = IntentRouter().route("启动照明模式")
+
+    assert intent.intent_type is IntentType.COMPLEX
+    assert intent.skill_id is None


### PR DESCRIPTION
## What changed

- Add a lighting-mode controller that enters a recorded fixed pose, holds a white LED state, and exposes a single toggle in the web console.
- Gate entry on motor recovery, serialize duplicate entry/exit requests, and run `return_safe` exactly once when leaving the mode.
- Prevent ordinary skills and idle motion from pre-empting a positive-priority safety recovery; preserve recovery failure diagnostics while torque remains held.
- Exit lighting mode safely before expressions, clock/ocean effects, direct LED commands, recordings, other skills, cancel, estop, shutdown, or runtime hardware replacement.
- Suppress autonomous LED/motion updates while the mode owns the lamp.

## Why

A persistent lighting pose needs an explicit ownership and recovery boundary. Treating it as an ordinary last-writer-wins motion could cancel `return_safe`, allow idle sway to take over, or report success while recovery was still in progress.

## Checks

- Full backend suite: `359 passed` (`1` existing Starlette deprecation warning).
- Focused lighting/motion/router suite: `39 passed`.
- `node --check lampgo/web/static/app.js`.
- `git diff --check`.

## Review note

The PR stays draft until the lighting pose and physical return-to-safe behavior are reviewed on the target lamp.

## Batch integration

Backend PRs #54 → #55 → #56 → #57 merge cleanly in that order. The combined tree passes `392` tests and `node --check`.
